### PR TITLE
xcalcc: add options and type hint for the driver

### DIFF
--- a/osprey/driver/xcalc++
+++ b/osprey/driver/xcalc++
@@ -43,6 +43,7 @@ PIC       = True
 DEBUG     = False
 LOG       = False
 EMIT_LLVM = False
+AST_DUMP  = False
 STD       = ""
 
 class Formatter(logging.Formatter):
@@ -71,7 +72,6 @@ class Formatter(logging.Formatter):
 def report_err(logger: logging.Logger, cond: bool, msg: str):
     if cond == False:
         logger.error(msg)
-        sys.exit(1)
     return cond
 
 
@@ -125,6 +125,7 @@ def collect_options(argv: List[str]) -> Tuple[List[str], List[str], str]:
     global LOG
     global STD
     global EMIT_LLVM
+    global AST_DUMP
     opts = []
     output = ""
     files = []
@@ -159,6 +160,8 @@ def collect_options(argv: List[str]) -> Tuple[List[str], List[str], str]:
                     STATIC = False
                 elif argv[i] == '-emit-llvm':
                     EMIT_LLVM = True
+                elif argv[i] == '-ast-dump':
+                    AST_DUMP = True
                 else:
                     opts.append(argv[i])
             else:
@@ -282,12 +285,18 @@ def mapclang(logger: logging.Logger, opts: List[str], f: str) -> bool:
     opts = list(filter(lambda x: not x.startswith("-l"), opts))
     cmd = MAPCLANG_OPTS.split() + opts + [dot_ii, "-o", dot_B]
 
+    if AST_DUMP == True:
+        cmd.append("-ast-dump")
+
     if LOG:
         info = MAPCLANG + " " + " ".join(i for i in cmd)
         logger.info(info)
 
     process = subprocess.Popen([MAPCLANG] + cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = process.communicate()
+
+    if AST_DUMP == True:
+        print(out.decode().strip())
 
     # the return code 16 means inlining is required
     if (process.returncode != 0) and (process.returncode != 16):
@@ -375,6 +384,9 @@ def front_end(logger: logging.Logger, opts: List[str], files: List[str]) -> List
             ret = mapclang(logger, opts, f)
             if report_err(logger, ret, msg) == False:
                 continue
+            # exit if ast dump is enabled
+            if AST_DUMP == True:
+                sys.exit(0)
 
         ret = inline(logger, f)
         if report_err(logger, ret, msg) == False:

--- a/osprey/driver/xcalc++
+++ b/osprey/driver/xcalc++
@@ -6,6 +6,7 @@ import logging
 import platform
 import subprocess
 from shutil import which
+from typing import List, Tuple
 
 XCALCC        = "xcalcc"
 W2LL          = "w2ll"
@@ -33,13 +34,16 @@ LD_LIBRARY_PATH = ""
 
 DEFAULT_OPTS = ["-PHASE:c=off", "-WOPT:divrem=0", "-LNO:simd=0", "-WOPT:cfo_main=0, -fno-exceptions"]
 
+# options
 OPT_LEVEL = 2
 ASM_MODE  = False
-NEED_LINK = True 
+NEED_LINK = True
 STATIC    = False
 PIC       = True
 DEBUG     = False
-LOG       = False 
+LOG       = False
+EMIT_LLVM = False
+STD       = ""
 
 class Formatter(logging.Formatter):
 
@@ -64,7 +68,7 @@ class Formatter(logging.Formatter):
         return formatter.format(record)
 
 
-def report_err(logger, cond, msg):
+def report_err(logger: logging.Logger, cond: bool, msg: str):
     if cond == False:
         logger.error(msg)
         sys.exit(1)
@@ -99,7 +103,7 @@ def set_env():
     INLINE   = os.path.join(LD_LIBRARY_PATH, INLINE)
     BE   = os.path.join(LD_LIBRARY_PATH, BE)
 
-def has_cmd(cmd):
+def has_cmd(cmd: str):
     return which(cmd) is not None
 
 
@@ -109,15 +113,18 @@ def check_exec():
             raise AssertionError("xcalcc is missing")
     except AssertionError as e:
         print(e)
+        sys.exit(1)
 
 
-def collect_options(argv):
+def collect_options(argv: List[str]) -> Tuple[List[str], List[str], str]:
     global OPT_LEVEL
     global ASM_MODE
     global NEED_LINK
     global STATIC
     global DEBUG
     global LOG
+    global STD
+    global EMIT_LLVM
     opts = []
     output = ""
     files = []
@@ -145,25 +152,33 @@ def collect_options(argv):
                     DEBUG = True
                 elif argv[i] == "-v":
                     LOG = True 
+                elif argv[i].startswith("-std="):
+                    STD = argv[i]
+                elif argv[i] == '-fPIC':
+                    PIC = True
+                    STATIC = False
+                elif argv[i] == '-emit-llvm':
+                    EMIT_LLVM = True
                 else:
                     opts.append(argv[i])
             else:
                 files.append(argv[i])
         except AssertionError as e:
             print(e)
+            sys.exit(1)
         
         i = i + 1
     return opts, files, output
 
 
-def gen_opts(opts):
+def gen_opts(opts: List[str]) -> str:
     res = " "
     for i in opts:
         res = res + i + " "
     return res
 
 
-def rm_suffix(f):
+def rm_suffix(f: str) -> str:
     if '.' in f:
         while f[-1] != '.':
             f = f[: len(f) - 1]
@@ -171,11 +186,11 @@ def rm_suffix(f):
     return f
 
 
-def is_obj(f):
+def is_obj(f: str) -> bool:
     return f.endswith(".o")
 
 
-def is_src(f):
+def is_src(f: str) -> bool:
     src = [".c", ".cxx", ".cpp", ".c++", 
            ".cc", ".C", ".h", ".hpp", 
            ".hh", ".hxx", ".H", ".h++",
@@ -186,9 +201,20 @@ def is_src(f):
              return True
     return False
 
-def preprocess(logger, opts, f):
+
+def is_ii(f: str) -> bool:
+    if f.endswith(".ii"):
+        return True
+    return False
+
+
+def preprocess(logger: logging.Logger, opts: List[str], f: str) -> bool:
+    if is_ii(f):
+        return True
+
     dot_ii = rm_suffix(f.split('/')[-1]) + ".ii" 
-    cmd = opts + PP_OPTS.split() + ["-fno-exceptions", "-E", f, "-o", dot_ii]
+    # cmd = opts + PP_OPTS.split() + ["-fno-exceptions", "-E", f, "-o", dot_ii]
+    cmd = opts + PP_OPTS.split() + ["-E", f, "-o", dot_ii]
 
     if LOG:
         info = "preprocessing: " + GCC + " " + " ".join(i for i in cmd)
@@ -204,11 +230,14 @@ def preprocess(logger, opts, f):
         return True 
     
 
-def cc1plus(logger, f):
+def cc1plus(logger: logging.Logger, f: str) -> bool:
     dot_ii = rm_suffix(f.split('/')[-1]) + ".ii" 
     spin = rm_suffix(f.split('/')[-1]) + ".spin" 
 
     opts = CC1PLUS_OPTS.split()
+    if STD != "":
+        opts = [STD] + opts
+
     if DEBUG == True:
         opts = ["-g2"] + opts
     cmd = opts + [f, dot_ii, "-spinfile", spin]
@@ -227,7 +256,7 @@ def cc1plus(logger, f):
         return True 
 
 
-def wgen(logger, f):
+def wgen(logger: logging.Logger, f: str) -> bool:
     spin = rm_suffix(f.split('/')[-1]) + ".spin" 
     dot_B = rm_suffix(f.split('/')[-1]) + ".B" 
     cmd = ["-fS," + spin, "-fB," + dot_B]
@@ -247,7 +276,7 @@ def wgen(logger, f):
         return True 
 
 
-def mapclang(logger, opts, f):
+def mapclang(logger: logging.Logger, opts: List[str], f: str) -> bool:
     dot_B  = rm_suffix(f.split('/')[-1]) + ".B" 
     dot_ii = rm_suffix(f.split('/')[-1]) + ".ii" 
     opts = list(filter(lambda x: not x.startswith("-l"), opts))
@@ -268,7 +297,7 @@ def mapclang(logger, opts, f):
         return True
 
 
-def inline(logger, f):
+def inline(logger: logging.Logger, f: str) -> bool:
     dot_B = rm_suffix(f.split('/')[-1]) + ".B" 
     dot_I = rm_suffix(f.split('/')[-1]) + ".I" 
     cmd = INLINE_OPTS.split()
@@ -290,7 +319,7 @@ def inline(logger, f):
         return True 
 
 
-def be(logger, f):
+def be(logger: logging.Logger, f: str) -> bool:
    #  -fB,a.I -s -fs,a.s /media/psf/Home/code/xc5/mastiff_build/a.c
     dot_I = rm_suffix(f.split('/')[-1]) + ".I" 
     dot_s = rm_suffix(f.split('/')[-1]) + ".s" 
@@ -313,7 +342,7 @@ def be(logger, f):
         return True 
 
 
-def front_end(logger, opts, files):
+def front_end(logger: logging.Logger, opts: List[str], files: List[str]) -> List[str]:
     res = []
 
     # option for using GCC front end
@@ -360,7 +389,7 @@ def front_end(logger, opts, files):
     return res
 
 
-def whirl2llvm(logger, opts, files):
+def whirl2llvm(logger: logging.Logger, opts: List[str], files: List[str], out_file: str) -> List[str]:
     res = []
     opts = []
     suffix = ""
@@ -375,6 +404,10 @@ def whirl2llvm(logger, opts, files):
         suffix = ".B"
         opts = opts + W2LL_OPTS.split()
 
+    if out_file != "":
+        opts.append("-o")
+        opts.append(out_file)
+
     for f in files:
         cmd = [f + suffix] + opts
 
@@ -385,6 +418,9 @@ def whirl2llvm(logger, opts, files):
         process = subprocess.Popen([W2LL] + cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = process.communicate()
 
+        if EMIT_LLVM and out_file == '-':
+            print(out.decode().strip())
+
         if process.returncode != 0:
             logger.error(err.decode().strip())
             sys.exit(process.returncode)
@@ -394,7 +430,7 @@ def whirl2llvm(logger, opts, files):
     return res
 
 
-def llc(logger, opts, files, outfile):
+def llc(logger: logging.Logger, opts: List[str], files: List[str], outfile: str) -> List[str]:
     res = []
     opts = ["-O" + str(OPT_LEVEL)] + LLC_OPTS.split()
     suffix = ""
@@ -428,6 +464,9 @@ def llc(logger, opts, files, outfile):
         process = subprocess.Popen([LLC] + cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = process.communicate()
 
+        if ASM_MODE and outfile == "-":
+            print(out.decode().strip())
+
         if process.returncode != 0:
             logger.error(err.decode().strip())
             sys.exit(process.returncode)
@@ -437,7 +476,7 @@ def llc(logger, opts, files, outfile):
     return res
 
 
-def link(logger, opts, files, outfile):
+def link(logger: logging.Logger, opts: List[str], files: List[str], outfile: str):
     cmd = []
     if STATIC == True:
         cmd.append("-static")
@@ -465,7 +504,7 @@ def link(logger, opts, files, outfile):
         sys.exit(process.returncode)
 
 
-def compile(opts, files, output):
+def compile(opts: List[str], files: List[str], output: str):
     logger = logging.getLogger("xcalc++")
     logger.setLevel(logging.DEBUG)
 
@@ -485,10 +524,12 @@ def compile(opts, files, output):
         sys.exit(1)
 
     res = front_end(logger, opts, src)
-    res = whirl2llvm(logger, opts, res)
-    res = llc(logger, opts, res, output)
-    if NEED_LINK:
-        link(logger, opts, res + obj, output)
+    res = whirl2llvm(logger, opts, res, output)
+
+    if EMIT_LLVM == False:
+        res = llc(logger, opts, res, output)
+        if NEED_LINK:
+            link(logger, opts, res + obj, output)
 
 
 def main():

--- a/osprey/driver/xcalc++
+++ b/osprey/driver/xcalc++
@@ -45,6 +45,8 @@ LOG       = False
 EMIT_LLVM = False
 AST_DUMP  = False
 STD       = ""
+VERIFY    = ""
+
 
 class Formatter(logging.Formatter):
 
@@ -126,6 +128,7 @@ def collect_options(argv: List[str]) -> Tuple[List[str], List[str], str]:
     global STD
     global EMIT_LLVM
     global AST_DUMP
+    global VERIFY
     opts = []
     output = ""
     files = []
@@ -162,6 +165,8 @@ def collect_options(argv: List[str]) -> Tuple[List[str], List[str], str]:
                     EMIT_LLVM = True
                 elif argv[i] == '-ast-dump':
                     AST_DUMP = True
+                elif argv[i].startswith('-verify'):
+                    VERIFY = argv[i]
                 else:
                     opts.append(argv[i])
             else:
@@ -287,6 +292,9 @@ def mapclang(logger: logging.Logger, opts: List[str], f: str) -> bool:
 
     if AST_DUMP == True:
         cmd.append("-ast-dump")
+
+    if VERIFY != "":
+        cmd.append(VERIFY)
 
     if LOG:
         info = MAPCLANG + " " + " ".join(i for i in cmd)

--- a/osprey/driver/xcalc++
+++ b/osprey/driver/xcalc++
@@ -424,7 +424,7 @@ def whirl2llvm(logger: logging.Logger, opts: List[str], files: List[str], out_fi
         suffix = ".B"
         opts = opts + W2LL_OPTS.split()
 
-    if out_file != "":
+    if EMIT_LLVM and out_file != "":
         opts.append("-o")
         opts.append(out_file)
 

--- a/osprey/driver/xcalcc
+++ b/osprey/driver/xcalcc
@@ -6,6 +6,7 @@ import logging
 import platform
 import subprocess
 from shutil import which
+from typing import List, Tuple
 
 XCALCC        = "xcalcc"
 W2LL          = "w2ll"
@@ -34,13 +35,15 @@ LD_LIBRARY_PATH = ""
 
 DEFAULT_OPTS = ["-PHASE:c=off", "-WOPT:divrem=0", "-LNO:simd=0", "-WOPT:cfo_main=0"]
 
+# options
 OPT_LEVEL = 2
 ASM_MODE  = False
-NEED_LINK = True 
+NEED_LINK = True
 STATIC    = False
 PIC       = True
 DEBUG     = False
 LOG       = False 
+EMIT_LLVM = False
 STD       = ""
 
 
@@ -67,7 +70,7 @@ class Formatter(logging.Formatter):
         return formatter.format(record)
 
 
-def report_err(logger, cond, msg):
+def report_err(logger: logging.Logger, cond: bool, msg: str):
     if cond == False:
         logger.error(msg)
         sys.exit(1)
@@ -75,7 +78,7 @@ def report_err(logger, cond, msg):
 
 
 def set_env():
-    global GCC 
+    global GCC
     global W2LL
     global LLC
     global MAPCLANG
@@ -84,8 +87,8 @@ def set_env():
     global INLINE
     global BE
     global MACHINE
-    global XCALCC_HOME 
-    global LD_LIBRARY_PATH 
+    global XCALCC_HOME
+    global LD_LIBRARY_PATH
 
     check_exec()
 
@@ -105,7 +108,7 @@ def set_env():
     INLINE = os.path.join(LD_LIBRARY_PATH, INLINE)
     BE = os.path.join(LD_LIBRARY_PATH, BE)
 
-def has_cmd(cmd):
+def has_cmd(cmd: str):
     return which(cmd) is not None
 
 
@@ -115,9 +118,10 @@ def check_exec():
             raise AssertionError("xcalcc is missing")
     except AssertionError as e:
         print(e)
+        sys.exit(1)
 
 
-def collect_options(argv):
+def collect_options(argv: List[str]) -> Tuple[List[str], List[str], str]:
     global OPT_LEVEL
     global ASM_MODE
     global NEED_LINK
@@ -125,6 +129,7 @@ def collect_options(argv):
     global DEBUG
     global LOG
     global STD
+    global EMIT_LLVM
     opts = []
     output = ""
     files = []
@@ -133,7 +138,7 @@ def collect_options(argv):
     while i < len(argv):
         try:
             if argv[i] == "-o":
-                if i+1 >= len(argv):
+                if i + 1 >= len(argv):
                     raise AssertionError("Output file is required!")
                 output = argv[i + 1]
                 i = i + 1   # eat the next argument
@@ -154,25 +159,31 @@ def collect_options(argv):
                     LOG = True
                 elif argv[i].startswith("-std="):
                     STD = argv[i]
+                elif argv[i] == '-fPIC':
+                    PIC = True
+                    STATIC = False
+                elif argv[i] == '-emit-llvm':
+                    EMIT_LLVM = True
                 else:
                     opts.append(argv[i])
             else:
                 files.append(argv[i])
         except AssertionError as e:
             print(e)
+            sys.exit(1)
         
         i = i + 1
     return opts, files, output
 
 
-def gen_opts(opts):
+def gen_opts(opts: List[str]) -> str:
     res = " "
     for i in opts:
         res = res + i + " "
     return res
 
 
-def rm_suffix(f):
+def rm_suffix(f: str) -> str:
     if '.' in f:
         while f[-1] != '.':
             f = f[: len(f) - 1]
@@ -180,11 +191,11 @@ def rm_suffix(f):
     return f
 
 
-def is_obj(f):
+def is_obj(f: str) -> bool:
     return f.endswith(".o")
 
 
-def is_src(f):
+def is_src(f: str) -> bool:
     src = [".c", ".cxx", ".cpp", ".c++", 
            ".cc", ".C", ".h", ".hpp", 
            ".hh", ".hxx", ".H", ".h++",
@@ -195,7 +206,7 @@ def is_src(f):
              return True
     return False
 
-def preprocess(logger, opts, f):
+def preprocess(logger: logging.Logger, opts: List[str], f: str) -> bool:
     dot_i = rm_suffix(f.split('/')[-1]) + ".i" 
     cmd = opts + PP_OPTS.split() + ["-E", f, "-o", dot_i]
 
@@ -213,7 +224,7 @@ def preprocess(logger, opts, f):
         return True 
     
 
-def cc1(logger, f):
+def cc1(logger: logging.Logger, f: str) -> bool:
     dot_i = rm_suffix(f.split('/')[-1]) + ".i" 
     spin = rm_suffix(f.split('/')[-1]) + ".spin" 
 
@@ -239,7 +250,7 @@ def cc1(logger, f):
         return True 
 
 
-def wgen(logger, f):
+def wgen(logger: logging.Logger, f: str) -> bool:
     spin = rm_suffix(f.split('/')[-1]) + ".spin" 
     dot_B = rm_suffix(f.split('/')[-1]) + ".B" 
     cmd = ["-fS," + spin, "-fB," + dot_B]
@@ -259,7 +270,7 @@ def wgen(logger, f):
         return True 
 
 
-def mapclang(logger, opts, f):
+def mapclang(logger: logging.Logger, opts: List[str], f: str) -> bool:
     dot_B  = rm_suffix(f.split('/')[-1]) + ".B"
     dot_i = rm_suffix(f.split('/')[-1]) + ".i"
     opts = list(filter(lambda x: not x.startswith("-l"), opts))
@@ -280,7 +291,7 @@ def mapclang(logger, opts, f):
         return True
 
 
-def inline(logger, f):
+def inline(logger: logging.Logger, f: str) -> bool:
     dot_B = rm_suffix(f.split('/')[-1]) + ".B" 
     dot_I = rm_suffix(f.split('/')[-1]) + ".I" 
     cmd = INLINE_OPTS.split()
@@ -302,7 +313,7 @@ def inline(logger, f):
         return True 
 
 
-def be(logger, f):
+def be(logger: logging.Logger, f: str) -> bool:
    #  -fB,a.I -s -fs,a.s /media/psf/Home/code/xc5/mastiff_build/a.c
     dot_I = rm_suffix(f.split('/')[-1]) + ".I" 
     dot_s = rm_suffix(f.split('/')[-1]) + ".s" 
@@ -325,7 +336,7 @@ def be(logger, f):
         return True 
 
 
-def front_end(logger, opts, files):
+def front_end(logger: logging.Logger, opts: List[str], files: List[str]) -> List[str]:
     res = []
 
     # option for using GCC front end
@@ -372,7 +383,7 @@ def front_end(logger, opts, files):
     return res
 
 
-def whirl2llvm(logger, opts, files):
+def whirl2llvm(logger: logging.Logger, opts: List[str], files: List[str], out_file: str) -> List[str]:
     res = []
     opts = []
     suffix = ""
@@ -387,6 +398,10 @@ def whirl2llvm(logger, opts, files):
         suffix = ".B"
         opts = opts + W2LL_OPTS.split()
 
+    if out_file != "":
+        opts.append("-o")
+        opts.append(out_file)
+
     for f in files:
         cmd = [f + suffix] + opts
 
@@ -397,6 +412,9 @@ def whirl2llvm(logger, opts, files):
         process = subprocess.Popen([W2LL] + cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = process.communicate()
 
+        if EMIT_LLVM and out_file == '-':
+            print(out.decode().strip())
+
         if process.returncode != 0:
             logger.error(err.decode().strip())
             sys.exit(process.returncode)
@@ -406,7 +424,7 @@ def whirl2llvm(logger, opts, files):
     return res
 
 
-def llc(logger, opts, files, outfile):
+def llc(logger: logging.Logger, opts: List[str], files: List[str], outfile: str) -> List[str]:
     res = []
     opts = ["-O" + str(OPT_LEVEL)] + LLC_OPTS.split()
     suffix = ""
@@ -440,6 +458,9 @@ def llc(logger, opts, files, outfile):
         process = subprocess.Popen([LLC] + cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out, err = process.communicate()
 
+        if ASM_MODE and outfile == "-":
+            print(out.decode().strip())
+
         if process.returncode != 0:
             logger.error(err.decode().strip())
             sys.exit(process.returncode)
@@ -449,7 +470,7 @@ def llc(logger, opts, files, outfile):
     return res
 
 
-def link(logger, opts, files, outfile):
+def link(logger: logging.Logger, opts: List[str], files: List[str], outfile: str):
     cmd = []
     if STATIC == True:
         cmd.append("-static")
@@ -477,7 +498,7 @@ def link(logger, opts, files, outfile):
         sys.exit(process.returncode)
 
 
-def compile(opts, files, output):
+def compile(opts: List[str], files: List[str], output: str):
     logger = logging.getLogger("xcalcc")
     logger.setLevel(logging.DEBUG)
 
@@ -497,10 +518,12 @@ def compile(opts, files, output):
         sys.exit(1)
 
     res = front_end(logger, opts, src)
-    res = whirl2llvm(logger, opts, res)
-    res = llc(logger, opts, res, output)
-    if NEED_LINK:
-        link(logger, opts, res + obj, output)
+    res = whirl2llvm(logger, opts, res, output)
+
+    if EMIT_LLVM == False:
+        res = llc(logger, opts, res, output)
+        if NEED_LINK:
+            link(logger, opts, res + obj, output)
 
 
 def main():

--- a/osprey/driver/xcalcc
+++ b/osprey/driver/xcalcc
@@ -417,7 +417,7 @@ def whirl2llvm(logger: logging.Logger, opts: List[str], files: List[str], out_fi
         suffix = ".B"
         opts = opts + W2LL_OPTS.split()
 
-    if out_file != "":
+    if EMIT_LLVM and out_file != "":
         opts.append("-o")
         opts.append(out_file)
 

--- a/osprey/driver/xcalcc
+++ b/osprey/driver/xcalcc
@@ -46,6 +46,7 @@ LOG       = False
 EMIT_LLVM = False
 AST_DUMP  = False
 STD       = ""
+VERIFY    = ""
 
 
 class Formatter(logging.Formatter):
@@ -131,6 +132,7 @@ def collect_options(argv: List[str]) -> Tuple[List[str], List[str], str]:
     global STD
     global EMIT_LLVM
     global AST_DUMP
+    global VERIFY
     opts = []
     output = ""
     files = []
@@ -167,6 +169,8 @@ def collect_options(argv: List[str]) -> Tuple[List[str], List[str], str]:
                     EMIT_LLVM = True
                 elif argv[i] == '-ast-dump':
                     AST_DUMP = True
+                elif argv[i].startswith('-verify'):
+                    VERIFY = argv[i]
                 else:
                     opts.append(argv[i])
             else:
@@ -281,6 +285,9 @@ def mapclang(logger: logging.Logger, opts: List[str], f: str) -> bool:
 
     if AST_DUMP == True:
         cmd.append("-ast-dump")
+    
+    if VERIFY != "":
+        cmd.append(VERIFY)
 
     if LOG:
         info = MAPCLANG + " " + " ".join(i for i in cmd)

--- a/osprey/driver/xcalcc
+++ b/osprey/driver/xcalcc
@@ -44,6 +44,7 @@ PIC       = True
 DEBUG     = False
 LOG       = False 
 EMIT_LLVM = False
+AST_DUMP  = False
 STD       = ""
 
 
@@ -73,7 +74,6 @@ class Formatter(logging.Formatter):
 def report_err(logger: logging.Logger, cond: bool, msg: str):
     if cond == False:
         logger.error(msg)
-        sys.exit(1)
     return cond
 
 
@@ -130,6 +130,7 @@ def collect_options(argv: List[str]) -> Tuple[List[str], List[str], str]:
     global LOG
     global STD
     global EMIT_LLVM
+    global AST_DUMP
     opts = []
     output = ""
     files = []
@@ -164,6 +165,8 @@ def collect_options(argv: List[str]) -> Tuple[List[str], List[str], str]:
                     STATIC = False
                 elif argv[i] == '-emit-llvm':
                     EMIT_LLVM = True
+                elif argv[i] == '-ast-dump':
+                    AST_DUMP = True
                 else:
                     opts.append(argv[i])
             else:
@@ -276,12 +279,18 @@ def mapclang(logger: logging.Logger, opts: List[str], f: str) -> bool:
     opts = list(filter(lambda x: not x.startswith("-l"), opts))
     cmd = MAPCLANG_OPTS.split() + opts + [dot_i, "-o", dot_B]
 
+    if AST_DUMP == True:
+        cmd.append("-ast-dump")
+
     if LOG:
         info = MAPCLANG + " " + " ".join(i for i in cmd)
         logger.info(info)
 
     process = subprocess.Popen([MAPCLANG] + cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = process.communicate()
+
+    if AST_DUMP == True:
+        print(out.decode().strip())
 
     # the return code 16 means inlining is required
     if (process.returncode != 0) and (process.returncode != 16):
@@ -369,6 +378,9 @@ def front_end(logger: logging.Logger, opts: List[str], files: List[str]) -> List
             ret = mapclang(logger, opts, f)
             if report_err(logger, ret, msg) == False:
                 continue
+            # exit if ast dump is enabled
+            if AST_DUMP == True:
+                sys.exit(0)
 
         ret = inline(logger, f)
         if report_err(logger, ret, msg) == False:


### PR DESCRIPTION
xcalcc:
1 .add type hint for driver
2. add option '-o' to set the output file
3. add the option '-ast-dump' for xcalcc/xcalc++
4. add the option '-verify' for xcalcc/xcalc++