### PR TITLE
Fix clang2whirl build with LLVM 11

### DIFF
--- a/osprey/clang2whirl/Makefile.gbase
+++ b/osprey/clang2whirl/Makefile.gbase
@@ -293,7 +293,10 @@ COMUTIL_OBJS = $(TARG_COMUTIL_DIR)/libcomutil.a
 #----------------------------------------------------------------------
 CLANG_LIBS = -lclangFrontendTool -lclangEdit -lclangSerialization -lclangRewrite -lclangRewriteFrontend \
              -lclangFrontend -lclangDriver -lclangSerialization -lclangParse -lclangSema \
-             -lclangAnalysis -lclangTooling -lclangAST -lclangLex -lclangBasic
+             -lclangAnalysis -lclangTooling -lclangAST -lclangLex -lclangBasic \
+             -lclangARCMigrate -lclangStaticAnalyzerFrontend -lclangStaticAnalyzerCheckers \
+             -lclangStaticAnalyzerCore -lclangCrossTU -lclangIndex -lclangASTMatchers \
+             -lclangToolingCore
 
 LLVM_LIBS = -lLLVMProfileData -lLLVMBitReader -lLLVMMC -lLLVMMCParser \
             -lLLVMBinaryFormat -lLLVMCore -lLLVMOption -lLLVMSupport
@@ -327,7 +330,7 @@ ifneq ($(BUILD_OS),DARWIN)
 LLDOPTS = -Wl,--export-dynamic
 endif
 LLDLIBS = -Wl,--start-group $(CLANG_LIBS) $(LLVM_LIBS) -Wl,--end-group $(COMUTIL_OBJS) $(LIBIBERTY_OBJS)
-LLDLIBS += -lm $(CMPLRS_OBJS) -ldl
+LLDLIBS += -lm $(CMPLRS_OBJS) -ldl -lz -ltinfo
 LDIRT += $(TARGETS) build_version.h
 
 # .PHONY: default first last install build_version.h

--- a/osprey/clang2whirl/c2w_builtin.cxx
+++ b/osprey/clang2whirl/c2w_builtin.cxx
@@ -822,7 +822,9 @@ WhirlExprBuilder::ConvertBuiltinExpr(const CallExpr *expr, const FunctionDecl *d
   case Builtin::BIindex ... Builtin::BIstrncasecmp: // POSIX strings.h
   case Builtin::BI_exit ...  Builtin::BIvfork:      // POSIX unistd.h
   case Builtin::BI_setjmp ... Builtin::BIsiglongjmp:// POSIX setjmp.h
+#if LLVM_VERSION_MAJOR >= 14
   case Builtin::BIstrlcpy ... Builtin::BIstrlcat:   // non-std
+#endif
     return Result::nwNone();
 
   // ignore ObjC builtins


### PR DESCRIPTION
## Summary

- Add missing clang/LLVM static libraries to the clang2whirl link step (`clangARCMigrate`, `clangStaticAnalyzerFrontend`, `clangStaticAnalyzerCheckers`, `clangStaticAnalyzerCore`, `clangCrossTU`, `clangIndex`, `clangASTMatchers`, `clangToolingCore`) plus system libraries `-lz` (zlib) and `-ltinfo` (terminfo) that LLVM depends on
- Guard `BIstrlcpy`/`BIstrlcat` builtin case range in `c2w_builtin.cxx` with `#if LLVM_VERSION_MAJOR >= 14`, since these builtins were added in Clang 14 and do not exist in LLVM 11

## Motivation

Building with LLVM 11 (the version available on Ubuntu 20.04) produces undefined reference link errors in clang2whirl, and a compile error for the missing `BIstrlcpy`/`BIstrlcat` identifiers. These are straightforward compatibility fixes.

## Test plan

- [ ] Build clang2whirl with LLVM 11 on Ubuntu 20.04 — link succeeds
- [ ] Build clang2whirl with LLVM 14/15 — existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)