### PR TITLE
Add --disable-jfe configure flag to make JFE optional

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -76,6 +76,7 @@ BUILD_TARGET        = @BUILD_TARGET@
 BUILD_MULTILIB      = @BUILD_MULTILIB@
 BUILD_GNU3          = @BUILD_GNU3@
 BUILD_FORTRAN       = @BUILD_FORTRAN@
+BUILD_JFE           = @BUILD_JFE@
 BUILD_TYPE          = @BUILD_TYPE@
 BUILD_SKIP_IPA      = @BUILD_SKIP_IPA@
 BUILD_PRODUCT       = @BUILD_PRODUCT@
@@ -138,11 +139,15 @@ endif
 
 GNU4_FE_COMPONENTS = \
                 $(NATIVE_BUILD_DIR)/wgen/wgen42 \
-                $(NATIVE_BUILD_DIR)/jfe/jfe \
                 $(NATIVE_BUILD_DIR)/clang2whirl/clangfe \
-                $(NATIVE_BUILD_DIR)/js2mplref/js2mpl \
                 $(GNUFE_BUILD_SUBDIR)/gcc/cc1 \
                 $(GNUFE_BUILD_SUBDIR)/gcc/cc1plus
+
+ifeq ($(BUILD_JFE), YES)
+GNU4_FE_COMPONENTS += \
+                $(NATIVE_BUILD_DIR)/jfe/jfe \
+                $(NATIVE_BUILD_DIR)/js2mplref/js2mpl
+endif
 
 GNU3_FE_COMPONENTS = \
                 $(NATIVE_BUILD_DIR)/gccfe/gfec \
@@ -528,9 +533,11 @@ clobber: clean
 clean: $(CLEAN_LIB)
 	$(MAKE) -C $(NATIVE_BUILD_DIR)/driver clobber 
 	$(MAKE) -C $(NATIVE_BUILD_DIR)/wgen clobber
-	$(MAKE) -C $(NATIVE_BUILD_DIR)/jfe clobber
 	$(MAKE) -C $(NATIVE_BUILD_DIR)/clang2whirl clobber
+ifeq ($(BUILD_JFE), YES)
+	$(MAKE) -C $(NATIVE_BUILD_DIR)/jfe clobber
 	$(MAKE) -C $(NATIVE_BUILD_DIR)/js2mplref clobber
+endif
 ifeq ($(BUILD_GNU3), YES)
 	$(MAKE) -C $(NATIVE_BUILD_DIR)/gccfe clobber 
 	$(MAKE) -C $(NATIVE_BUILD_DIR)/g++fe clobber

--- a/configure
+++ b/configure
@@ -594,6 +594,7 @@ BUILD_TYPE
 BUILD_SKIP_IPA
 WHIRL_HAS_ID_FIELD
 BUILD_FORTRAN
+BUILD_JFE
 BUILD_GNU3
 TARG_INFO_NAME
 COMPILER_TARG_DIR
@@ -681,6 +682,7 @@ with_build_ffe_optimize
 with_build_lib_optimize
 enable_gnu3
 enable_fortran
+enable_jfe
 enable_whirl_id
 enable_ipa
 enable_multilib
@@ -1318,6 +1320,8 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-gnu3           Enable GNU3-based C/C++ frontend
   --disable-fortran       Disable Fortran language support
+  --disable-jfe           Disable Java Frontend (JFE) and js2mpl
+                          (requires gradle, openjdk-8, cmake)
   --enable-whirl-id       Enable debugging ID in WHIRL node
   --disable-ipa           Disable IPA compilation support (EXPERIMENTAL)
   --disable-multilib      Disable multilib support for IA32/x86-64
@@ -2049,6 +2053,19 @@ fi
 if test "x$enable_fortran" != "xno"; then :
 
   BUILD_FORTRAN=YES
+
+fi
+
+# Set whether to build the Java Frontend (JFE) and js2mpl
+# Check whether --enable-jfe was given.
+if test "${enable_jfe+set}" = set; then :
+  enableval=$enable_jfe;
+fi
+
+
+if test "x$enable_jfe" != "xno"; then :
+
+  BUILD_JFE=YES
 
 fi
 
@@ -3846,8 +3863,10 @@ fi
 
 
 #
-# Starting JFE Checks
+# Starting JFE Checks (only when --enable-jfe or default)
 #
+
+if [ "x$enable_jfe" != "xno" ]; then
 
 ISRUNNABLE_JFE=1
 printf "checking whether gradle works "
@@ -3920,6 +3939,10 @@ echo "            JAVA_HOME = $JAVA_HOME"
 if [ $ISRUNNABLE_JFE = 0 ]
 then
 	exit 1
+fi
+
+else
+echo "JFE build disabled (use --enable-jfe to enable)"
 fi
 
 printf "checking CLANG_HOME is set ..."

--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,14 @@ AS_IF([test "x$enable_fortran" != "xno"], [
   BUILD_FORTRAN=YES
 ])
 
+# Set whether to build the Java Frontend (JFE) and js2mpl
+AC_ARG_ENABLE([jfe],
+  AS_HELP_STRING([--disable-jfe], [Disable Java Frontend (JFE) and js2mpl (requires gradle, openjdk-8, cmake)]))
+
+AS_IF([test "x$enable_jfe" != "xno"], [
+  BUILD_JFE=YES
+])
+
 # Set whether WHIRL a node contains a debugging ID
 AC_ARG_ENABLE([whirl_id],
   AS_HELP_STRING([--enable-whirl-id], [Enable debugging ID in WHIRL node]))
@@ -463,6 +471,7 @@ AC_SUBST([COMPILER_TARG_DIR])
 AC_SUBST([TARG_INFO_NAME])
 AC_SUBST([BUILD_GNU3])
 AC_SUBST([BUILD_FORTRAN])
+AC_SUBST([BUILD_JFE])
 AC_SUBST([WHIRL_HAS_ID_FIELD])
 AC_SUBST([BUILD_SKIP_IPA])
 AC_SUBST([BUILD_TYPE])
@@ -632,8 +641,10 @@ AC_CONFIG_SUBDIRS(binutils)
 AC_OUTPUT
 
 #
-# Starting JFE Checks
+# Starting JFE Checks (only when --enable-jfe or default)
 #
+
+if @<:@ "x$enable_jfe" != "xno" @:>@; then
 
 ISRUNNABLE_JFE=1
 printf "checking whether gradle works "
@@ -706,6 +717,10 @@ echo "            JAVA_HOME = $JAVA_HOME"
 if @<:@ $ISRUNNABLE_JFE = 0 @:>@
 then
 	exit 1
+fi
+
+else
+echo "JFE build disabled (use --enable-jfe to enable)"
 fi
 
 printf "checking CLANG_HOME is set ..."


### PR DESCRIPTION
## Summary

- Add `--disable-jfe` configure flag following the existing `--disable-fortran` pattern
- Gate JFE/js2mpl in `GNU4_FE_COMPONENTS` and clean targets behind `ifeq ($(BUILD_JFE), YES)`
- Wrap JFE dependency checks (gradle, java, cmake, JAVA_HOME) so they only run when JFE is enabled

## Motivation

The Java Frontend requires gradle, openjdk-8, cmake, and a correctly configured JAVA_HOME. Currently, `configure` exits with an error if any of these are missing, blocking the entire compiler build even for users who only need C/C++ support.

This change makes JFE opt-out while preserving full backward compatibility: without `--disable-jfe`, the existing checks still run and JFE is built as before.

## Changes

- `configure.ac`: `AC_ARG_ENABLE([jfe])`, `AC_SUBST([BUILD_JFE])`, guard JFE checks
- `configure`: Mirror configure.ac changes in the pre-generated script
- `Makefile.in`: `BUILD_JFE = @BUILD_JFE@`, conditional jfe/js2mpl build and clean targets

## Test plan

- [ ] `./configure --disable-jfe` — skips JFE checks, builds without jfe/js2mpl
- [ ] `./configure` (no flag) — existing behavior, JFE checks run, jfe/js2mpl built
- [ ] `make clean` with and without JFE — only cleans jfe/js2mpl dirs when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)