### PR TITLE
Guard Open64-specific flags in libm for BUILD_COMPILER=GNU

### DIFF
--- a/osprey/libm/Makefile.gbase
+++ b/osprey/libm/Makefile.gbase
@@ -73,13 +73,17 @@ endif
 ifeq ($(BUILD_VARIANT), LIBMV)
 LCDEFS += -D_SW_PIPELINE
  ifeq ($(BUILD_ABI), I64BIT)
+  ifneq ($(BUILD_COMPILER), GNU)
 CFLAGS += -OPT:alias=restrict:alias=unnamed -TENV:X=2
 CFLAGS += -WOPT:cse_fcmp=off
-CCFVSQRT = $(CCF)
 CCFVLOG = $(CCN) $(CFLAGS) -WOPT:cse_fcmp=on
+  else
+CCFVLOG = $(CCN) $(CFLAGS)
+  endif
+CCFVSQRT = $(CCF)
  else
 CCFVSQRT = $(CCF)
-CCFVLOG = $(CCF) 
+CCFVLOG = $(CCF)
  endif
 endif
 


### PR DESCRIPTION
## Summary

- Guard `-OPT:alias=restrict:alias=unnamed`, `-TENV:X=2`, and `-WOPT:cse_fcmp` flags behind `ifneq ($(BUILD_COMPILER), GNU)` in `osprey/libm/Makefile.gbase`

## Motivation

When building libm with `BUILD_COMPILER=GNU` (for bootstrapping or when the Open64 compiler is not yet available), these Open64-specific flags cause GCC to fail:

```
gcc: error: unrecognized command line option '-WOPT:cse_fcmp=off'
gcc: error: unrecognized command line option '-OPT:alias=restrict:alias=unnamed'
```

The fix only affects the `BUILD_COMPILER=GNU` path; the Open64 (`SELF`/`OSP`/`PSC`) build path is unchanged.

## Test plan

- [ ] Build libm with `BUILD_COMPILER=GNU` — no unrecognized option errors
- [ ] Build libm with `BUILD_COMPILER=OSP` — flags still applied as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)