### PR TITLE
Add PREGENERATED_TARG_INFO for cross-compilation

### DIFF
--- a/osprey/common/targ_info/Makefile.gbase
+++ b/osprey/common/targ_info/Makefile.gbase
@@ -203,6 +203,12 @@ LLDLIBS =
 #  This is useful when cross-compiling the compiler.
 #----------------------------------------------------------------------
 
+# If PREGENERATED_TARG_INFO is set, use pre-generated files instead of running generators.
+# This is needed when cross-compiling (e.g., building x86_64 on ARM64 via Rosetta/QEMU)
+# where the host-tool generators may segfault under emulation.
+ifdef PREGENERATED_TARG_INFO
+COPYSOURCEDIR = $(PREGENERATED_TARG_INFO)
+else
 ifeq ($(BUILD_ARCH), MIPS64)
 ifeq ($(BUILD_HOST), IA32)
 ifeq ($(BUILD_TARGET), SL)
@@ -215,6 +221,7 @@ COPYSOURCEDIR = FALSE
 endif
 else
 COPYSOURCEDIR = FALSE
+endif
 endif
 
 .PHONY: default first last install


### PR DESCRIPTION
## Summary

- Add `PREGENERATED_TARG_INFO` variable to `osprey/common/targ_info/Makefile.gbase` that overrides `COPYSOURCEDIR` to use pre-generated header/source files instead of running the targ_info generators

## Motivation

The targ_info build runs host-tool generators (`isa_gen`, `targ_si_gen`, etc.) that produce architecture-specific `.h` and `.c` files. When cross-compiling — for example, building an x86_64 compiler on ARM64 via Rosetta or QEMU — these generators may crash under emulation.

This reuses the existing `COPYSOURCEDIR` mechanism (already used for MIPS64-on-IA32 cross-compilation) and exposes it as a user-settable variable:

```
make PREGENERATED_TARG_INFO=/path/to/generated/files
```

The pre-generated files can be produced by running the targ_info build natively on the target architecture, then copying the output `.h` and `.c` files.

## Test plan

- [ ] Normal build (no flag) — behavior unchanged, generators run as before
- [ ] Build with `PREGENERATED_TARG_INFO=/path` — copies files from directory, skips generators

🤖 Generated with [Claude Code](https://claude.com/claude-code)