### PR TITLE
Add hash specializations for 64-bit integer types in hash_map

### DIFF
--- a/osprey/be/com/whirl_file_mgr.h
+++ b/osprey/be/com/whirl_file_mgr.h
@@ -36,6 +36,7 @@
 #include "phase.h"
 #include "whirl_file_ctx.h"
 #include <ext/hash_map>
+#include "hash_compat.h"
 
 using __gnu_cxx::hash_map;
 

--- a/osprey/clang2whirl/c2w_map.h
+++ b/osprey/clang2whirl/c2w_map.h
@@ -46,6 +46,8 @@
 
 #undef _GLIBCXX_PERMIT_BACKWARD_HASH
 
+#include "hash_compat.h"
+
 namespace wgen {
 
 using __gnu_cxx::hash_map;

--- a/osprey/common/com/hash_compat.h
+++ b/osprey/common/com/hash_compat.h
@@ -1,0 +1,32 @@
+/*
+ * hash_compat.h — GCC hash_map compatibility for 64-bit integer types
+ *
+ * GCC's <ext/hash_map> does not provide __gnu_cxx::hash specializations
+ * for 'long long' or 'unsigned long long'. This header adds them.
+ *
+ * Include this header AFTER <ext/hash_map> and BEFORE any hash_map
+ * instantiation with 64-bit integer keys.
+ */
+
+#ifndef HASH_COMPAT_H
+#define HASH_COMPAT_H
+
+#ifdef __cplusplus
+
+#include <ext/hash_map>
+
+namespace __gnu_cxx {
+  template<> struct hash<unsigned long long> {
+    size_t operator()(unsigned long long __x) const {
+      return static_cast<size_t>(__x);
+    }
+  };
+  template<> struct hash<long long> {
+    size_t operator()(long long __x) const {
+      return static_cast<size_t>(__x);
+    }
+  };
+}
+
+#endif /* __cplusplus */
+#endif /* HASH_COMPAT_H */

--- a/osprey/common/com/strtab.h
+++ b/osprey/common/com/strtab.h
@@ -69,14 +69,16 @@
 
 // New hash function to accommodate unsigned long long, STL hash does
 // not have one.
+#ifdef __cplusplus
 namespace __new_hash
 {
 template <class _Key> struct hash { };
 
   template<> struct hash<unsigned long long> {
     size_t operator()(unsigned long long __x) const { return __x; }
-  }; 
+  };
 }
+#endif
 
 // From a user point of view, the string table is a collection of unique
 // strings, each of which can be indentified by STR_IDX.  The actual


### PR DESCRIPTION
## Summary

- Add `osprey/common/com/hash_compat.h` with `__gnu_cxx::hash` specializations for `long long` and `unsigned long long`
- Include `hash_compat.h` in `whirl_file_mgr.h` and `c2w_map.h` where 64-bit hash_map keys are used
- Add missing `#ifdef __cplusplus` guard around the `__new_hash` namespace in `strtab.h`

## Motivation

When building Open64 as a 64-bit compiler (`BUILD_ARCH=X8664`), several components use `__gnu_cxx::hash_map` with 64-bit integer keys (e.g. `uint64_t`, `TCON_IDX`). GCC's `<ext/hash_map>` does not provide hash specializations for `long long` or `unsigned long long`, causing compilation errors:

```
error: no match for call to '(__gnu_cxx::hash<unsigned long long>) (const unsigned long long&)'
```

The `strtab.h` fix is also needed because `__new_hash` uses C++ syntax but the header can be included from C translation units.

## Test plan

- [ ] Build Open64 with `BUILD_ARCH=X8664` on Ubuntu 20.04 — no hash_map compilation errors
- [ ] Verify `whirl_file_mgr.h` and `c2w_map.h` consumers compile cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)