### PR TITLE
Fix build failures with modern glibc (2.28+) and kernel headers

### DIFF
--- a/osprey-gcc-4.2.0/gcc/config/i386/linux-unwind.h
+++ b/osprey-gcc-4.2.0/gcc/config/i386/linux-unwind.h
@@ -144,15 +144,15 @@ x86_fallback_frame_state (struct _Unwind_Context *context,
 #ifdef __have_siginfo_t
 	siginfo_t *pinfo;
 #else
-	struct siginfo *pinfo;
+	siginfo_t *pinfo;
 #endif
 	void *puc;
 #ifdef __have_siginfo_t
 	siginfo_t info;
 #else
-	struct siginfo info;
+	siginfo_t info;
 #endif
-	struct ucontext uc;
+	ucontext_t uc;
       } *rt_ = context->cfa;
       /* The void * cast is necessary to avoid an aliasing warning.
          The aliasing warning is correct, but should not be a problem

--- a/osprey/libf/fio/flush.c
+++ b/osprey/libf/fio/flush.c
@@ -196,14 +196,12 @@ flush_(
 		case FS_TEXT:
 #ifdef KEY
 			{
-# if defined(BUILD_OS_DARWIN)
-			int writeable = cup->ufp.std->_flags & (__SWR | __SRW);
-# else /* defined(BUILD_OS_DARWIN) */
-			int writeable = !(cup->ufp.std->_flags & _IO_NO_WRITES);
-# endif /* defined(BUILD_OS_DARWIN) */
-			if (writeable)
-				if (fflush(cup->ufp.std) == EOF)
-					FLUSH_ERROR(errno);
+			/* Always call fflush — checking _IO_NO_WRITES was
+			   an optimization using glibc internals removed in
+			   glibc 2.28+.  fflush on a read-only stream is
+			   safe (returns 0 per POSIX). */
+			if (fflush(cup->ufp.std) == EOF)
+				FLUSH_ERROR(errno);
 			}
 			break;
 #endif


### PR DESCRIPTION
## Summary

- Replace removed `_IO_NO_WRITES` glibc internal macro in `osprey/libf/fio/flush.c` with an unconditional `fflush()` call (safe per POSIX — returns 0 on read-only streams)
- Replace deprecated `struct siginfo` and `struct ucontext` types in `osprey-gcc-4.2.0/gcc/config/i386/linux-unwind.h` with the POSIX-standard typedefs `siginfo_t` and `ucontext_t`

## Motivation

These two issues prevent building on any Linux distribution shipping glibc >= 2.28 (Ubuntu 18.10+, Debian 10+, Fedora 29+, etc.):

1. `_IO_NO_WRITES` was a glibc-internal macro exposed through `<stdio.h>` internals, removed in glibc 2.28 (2018). The code used it to check stream writability before calling `fflush()`, but `fflush()` on a read-only stream is a no-op per POSIX, making the check unnecessary.

2. `struct siginfo` and `struct ucontext` were deprecated in favor of `siginfo_t` and `ucontext_t` (the POSIX typedefs) and removed from kernel UAPI headers. GCC upstream fixed this in 2018 but Open64's bundled GCC 4.2.0 still uses the old types.

## Test plan

- [ ] Build on Ubuntu 20.04 (glibc 2.31) — both files compile without errors
- [ ] Build on Ubuntu 22.04 (glibc 2.35) — both files compile without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)