### PR TITLE
Fix whirl2f.so hardcoded maccom.so dependency

### DIFF
--- a/osprey/be/whirl2f/Makefile.gbase
+++ b/osprey/be/whirl2f/Makefile.gbase
@@ -206,9 +206,9 @@ WHIRL2F_C_OBJS = $(WHIRL2F_C_SRCS:.cxx=.o)
 WHIRL2F_DRIVER_OBJS = $(WHIRL2F_DRIVER_SRCS:.cxx=.o)
 WHIRL2F_MAIN_OBJS = $(WHIRL2F_MAIN_SRCS:.cxx=.o)
 ifeq ($(BUILD_OS), LINUX)
-WHIRL2F_DSOS = maccom.so
+WHIRL2F_DSOS = $(BE_SO)
 else
-WHIRL2F_DSOS = $(TARGDIR)/be/maccom.so
+WHIRL2F_DSOS = $(TARGDIR)/be/$(BE_SO)
 endif
 
 VPATH    =  $(SRC_DIRS)
@@ -264,7 +264,7 @@ TARGETS = libwhirl2f.a whirl2f
 endif
 
 # extra files to be removed with make clobber
-LDIRT += be maccom.so $(TARGETS)
+LDIRT += be $(BE_SO) $(TARGETS)
 
 
 #----------------------------------------------------------------------
@@ -334,8 +334,8 @@ ifeq ($(BUILD_TYPE), SHARED)
 whirl2f: whirl2f.so whirl2f_be $(WHIRL2F_MAIN_OBJS)
 	$(link.c++f) -o whirl2f $(WHIRL2F_MAIN_OBJS) $(LDFLAGS)
 
-maccom.so:
-	if ! test -e maccom.so; then ln -sf $(TARGDIR)/be/maccom.so .; fi
+$(BE_SO):
+	if ! test -e $(BE_SO); then ln -sf $(TARGDIR)/be/$(BE_SO) .; fi
 
 be:
 	if ! test -e be; then ln -sf $(TARGDIR)/be/be .; fi


### PR DESCRIPTION
## Summary

- Replace hardcoded `maccom.so` references in `osprey/be/whirl2f/Makefile.gbase` with `$(BE_SO)`

## Motivation

The xcalscan merge (commit 12cc654b) replaced `be.so` with hardcoded `maccom.so` in whirl2f's Makefile. `maccom.so` is only the correct backend DSO name when `BUILD_PRODUCT=MASTIFF`. For the standard open-source build (`BUILD_PRODUCT=OPEN64`), the backend is `be.so`.

This causes whirl2f.so to link against a `maccom.so` symlink pointing to a nonexistent file, since only `be.so` gets built. `whirl2c` in the same directory already correctly uses `$(BE_SO)`.

## Changes

- `osprey/be/whirl2f/Makefile.gbase`: Replace all `maccom.so` references with `$(BE_SO)`, matching the pattern used by `whirl2c`

## Test plan

- [ ] `make build` with default `BUILD_PRODUCT=OPEN64` — whirl2f.so links against `be.so`
- [ ] whirl2f symlink points to the correct backend DSO

🤖 Generated with [Claude Code](https://claude.com/claude-code)