### PR TITLE
Fix libjson parallel build race condition

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -252,7 +252,7 @@ arith:
 	$(MAKE) -C $(NATIVE_BUILD_DIR)/arith
 
 libjson:
-	$(MAKE) -C $(NATIVE_BUILD_DIR)/libjson
+	+$(MAKE) -j1 -C $(NATIVE_BUILD_DIR)/libjson
 
 $(NATIVE_BUILD_DIR)/driver/driver driver: include
 	$(MAKE) -C $(NATIVE_BUILD_DIR)/driver


### PR DESCRIPTION
## Summary

- Force serial build (`-j1`) for the libjson CMake sub-build and add `+` prefix for jobserver propagation

## Motivation

The libjson target invokes CMake internally, which has race conditions with GNU Make's jobserver under parallel builds (`make -j8`). This causes intermittent link failures during the libjson build step.

Forcing `-j1` for this small sub-build eliminates the race with negligible impact on overall build time. The `+` prefix ensures proper jobserver propagation to the recursive make call.

## Changes

- `Makefile.in`: Change `$(MAKE) -C $(NATIVE_BUILD_DIR)/libjson` to `+$(MAKE) -j1 -C $(NATIVE_BUILD_DIR)/libjson`

## Test plan

- [ ] `make -j8 build` completes without intermittent libjson failures
- [ ] `make -j1 build` still works (no regression for serial builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)