### PR TITLE
Remove stale x86_64 to i686 downgrade in configure

### DIFF
--- a/configure
+++ b/configure
@@ -1904,20 +1904,6 @@ test -n "$target_alias" &&
 #AC_PROG_CXX
 #AC_PROG_RANLIB
 
-# There are known bugs when building the compiler in 64 bit mode on x86 so,
-# unless the user specifies otherwise, we default to 32 bit mode as the
-# default on x86 64 bit platforms.
-
-if test "$build_alias" = "" && test "$host_alias" = "" && test "$host_cpu" = "x86_64"; then
-  host_cpu=i686
-  host=$host_cpu-$host_vendor-$host_os
-fi
-
-if test "$build_alias" = "" && test "$target_alias" = "" && test "$target_cpu" = "x86_64"; then
-  target_cpu=i686
-  target=$target_cpu-$target_vendor-$target_os
-fi
-
 
 # Check whether --with-build-compiler was given.
 if test "${with_build_compiler+set}" = set; then :

--- a/configure.ac
+++ b/configure.ac
@@ -44,20 +44,6 @@ AC_CANONICAL_TARGET
 #AC_PROG_CXX
 #AC_PROG_RANLIB
 
-# There are known bugs when building the compiler in 64 bit mode on x86 so,
-# unless the user specifies otherwise, we default to 32 bit mode as the
-# default on x86 64 bit platforms.
-
-if test "$build_alias" = "" && test "$host_alias" = "" && test "$host_cpu" = "x86_64"; then
-  host_cpu=i686
-  host=$host_cpu-$host_vendor-$host_os
-fi
-
-if test "$build_alias" = "" && test "$target_alias" = "" && test "$target_cpu" = "x86_64"; then
-  target_cpu=i686
-  target=$target_cpu-$target_vendor-$target_os
-fi
-
 AC_ARG_WITH(build-compiler,
 [  --with-build-compiler=GNU|OSP	Use GNU or OSP compilers in build],
 BUILD_COMPILER="$with_build_compiler",


### PR DESCRIPTION
## Summary

- Remove the workaround in `configure.ac` (and generated `configure`) that silently rewrote `host_cpu` and `target_cpu` from `x86_64` to `i686` when `--host`/`--target` were not explicitly passed
- This caused `./configure` on a 64-bit host to silently build a 32-bit compiler

## Context

The removed code had the comment:

> "There are known bugs when building the compiler in 64 bit mode on x86 so, unless the user specifies otherwise, we default to 32 bit mode"

These bugs have long been fixed. The compiler builds and runs correctly as a native 64-bit binary (verified with full end-to-end build + runtime library compilation on x86_64).

Without this workaround, `./configure` on an x86_64 host correctly detects the platform and builds a 64-bit compiler. Users who need a 32-bit compiler can still pass `--host=i686-linux-gnu --target=i686-linux-gnu`.

## Test plan

- [ ] Run `./configure && make build` on x86_64 Linux without `--host`/`--target` flags
- [ ] Verify the resulting compiler is 64-bit: `file osprey/targdir/driver/driver`
- [ ] Verify `./configure --host=i686-linux-gnu --target=i686-linux-gnu` still produces a 32-bit build


🤖 Generated with [Claude Code](https://claude.com/claude-code)