### PR TITLE
Add WHIRL DSL IR infrastructure and tests

### DIFF
--- a/README
+++ b/README
@@ -67,7 +67,39 @@ in the repository:
     ./build-open64-docker.sh
 
   The script handles all necessary workarounds (targ_info pre-generation
-on ARM64, runtime library build flags, dependency installation, etc.).
+  on ARM64, runtime library build flags, dependency installation, etc.) and
+  produces a reusable linux/amd64 Docker image tagged as
+  open64:x86_64-apple-silicon by default. The compiler itself is built as
+  x86_64 and continues to generate x86_64 binaries.
+  The Docker build directory and Open64 installation are bind-mounted on
+  the macOS host under:
+
+    ~/work/open64/build
+    ~/work/open64/opt/open64
+    ~/work/open64/bin
+
+  To use a different host location:
+
+    OPEN64_HOST_WORK_ROOT=~/my-open64-work ./build-open64-docker.sh
+
+  To use a different image tag:
+
+    OPEN64_DOCKER_IMAGE=my-open64:latest ./build-open64-docker.sh
+
+  After the build completes, run the x86_64 Linux compiler through
+  Docker/Rosetta with the host installation mounted back into /opt/open64:
+
+    docker run --rm --platform linux/amd64 \
+      -v "$HOME/work/open64/opt/open64:/opt/open64:ro" \
+      -v "$PWD:/work" \
+      open64:x86_64-apple-silicon opencc -v
+
+  The script also creates wrapper commands that run the same Docker/Rosetta
+  command from the current macOS directory:
+
+    ~/work/open64/bin/opencc -v
+    ~/work/open64/bin/openCC -v
+    ~/work/open64/bin/openf90 -v
 
   Requirements: Docker Desktop for Mac with Rosetta emulation enabled.
 

--- a/build-open64-docker.sh
+++ b/build-open64-docker.sh
@@ -17,6 +17,10 @@
 #   ./build-open64-docker.sh [path-to-open64-source]
 #
 # If no path is given, defaults to the directory containing this script.
+# The final compiler image is linux/amd64 so Open64 continues to generate
+# x86_64 binaries. Set OPEN64_DOCKER_IMAGE to override the output image tag.
+# The build and install trees are bind-mounted under ~/work/open64 by default.
+# Set OPEN64_HOST_WORK_ROOT to override that host location.
 #
 
 set -euo pipefail
@@ -35,15 +39,25 @@ BUILD_RAM_GB=$(( TOTAL_RAM_GB * 3 / 4 ))
 [[ $BUILD_CORES -lt 2 ]] && BUILD_CORES=2
 [[ $BUILD_RAM_GB -lt 4 ]] && BUILD_RAM_GB=4
 
-OPEN64_SRC="${1:-$(cd "$(dirname "$0")" && pwd)/open64}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPEN64_SRC="${1:-$SCRIPT_DIR}"
 CONTAINER_NAME="open64-build"
 ARM_CONTAINER_NAME="open64-arm-gen"
 PREGENERATED_HOST_DIR="/tmp/open64-generated"
+IMAGE_NAME="${OPEN64_DOCKER_IMAGE:-open64:x86_64-apple-silicon}"
+HOST_WORK_ROOT="${OPEN64_HOST_WORK_ROOT:-$HOME/work/open64}"
+HOST_BUILD_DIR="$HOST_WORK_ROOT/build"
+HOST_INSTALL_DIR="$HOST_WORK_ROOT/opt/open64"
+HOST_BIN_DIR="$HOST_WORK_ROOT/bin"
 
 echo "============================================="
 echo "  Open64 Docker Build Script"
 echo "============================================="
 echo "  Source:     $OPEN64_SRC"
+echo "  Image:      $IMAGE_NAME"
+echo "  Build dir:  $HOST_BUILD_DIR"
+echo "  Install:    $HOST_INSTALL_DIR"
+echo "  Wrappers:   $HOST_BIN_DIR"
 echo "  Cores:      $BUILD_CORES / $TOTAL_CORES"
 echo "  RAM:        ${BUILD_RAM_GB}GB / ${TOTAL_RAM_GB}GB"
 echo "  Container:  $CONTAINER_NAME"
@@ -55,6 +69,8 @@ if [[ ! -d "$OPEN64_SRC/osprey" ]]; then
     echo "Usage: $0 [path-to-open64-source]"
     exit 1
 fi
+
+mkdir -p "$HOST_BUILD_DIR" "$HOST_INSTALL_DIR" "$HOST_BIN_DIR"
 
 # ─── Step 1: Pre-generate targ_info files natively on ARM64 ─────────────────
 #
@@ -307,6 +323,8 @@ docker run -d \
     --cpus="$BUILD_CORES" \
     --memory="${BUILD_RAM_GB}g" \
     -v "$OPEN64_SRC:/open64" \
+    -v "$HOST_BUILD_DIR:/build" \
+    -v "$HOST_INSTALL_DIR:/opt/open64" \
     -v "$PREGENERATED_HOST_DIR:/pregenerated_targ_info:ro" \
     ubuntu:20.04 \
     sleep infinity
@@ -420,6 +438,61 @@ echo ""
 echo "    Runtime libraries built."
 '
 
+# ─── Step 7: Install and package a reusable Docker runner image ──────────────
+
+echo ""
+echo ">>> Step 7: Installing Open64 and creating Docker runner image"
+
+docker exec "$CONTAINER_NAME" bash -c '
+set -e
+set -o pipefail
+export CLANG_HOME=/usr/lib/llvm-11
+cd /build
+
+make install
+rm -rf /var/lib/apt/lists/* /tmp/*
+
+echo ""
+echo "    Open64 installed to /opt/open64."
+'
+
+docker commit \
+    --change 'ENV PATH=/opt/open64/bin:$PATH' \
+    --change 'WORKDIR /work' \
+    --change 'CMD ["opencc", "-v"]' \
+    "$CONTAINER_NAME" \
+    "$IMAGE_NAME" >/dev/null
+
+echo "    Docker runner image created: $IMAGE_NAME (linux/amd64)"
+
+cat > "$HOST_BIN_DIR/open64-docker" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="$IMAGE_NAME"
+OPEN64_INSTALL="$HOST_INSTALL_DIR"
+
+cmd="\$(basename "\$0")"
+if [[ "\$cmd" == "open64-docker" ]]; then
+    cmd="\${1:-opencc}"
+    if [[ \$# -gt 0 ]]; then
+        shift
+    fi
+fi
+
+docker run --rm --platform linux/amd64 \\
+    -v "\$OPEN64_INSTALL:/opt/open64:ro" \\
+    -v "\$PWD:/work" \\
+    "\$IMAGE_NAME" "\$cmd" "\$@"
+EOF
+
+chmod +x "$HOST_BIN_DIR/open64-docker"
+ln -sf open64-docker "$HOST_BIN_DIR/opencc"
+ln -sf open64-docker "$HOST_BIN_DIR/openCC"
+ln -sf open64-docker "$HOST_BIN_DIR/openf90"
+
+echo "    Host wrapper commands created in $HOST_BIN_DIR"
+
 # ─── Done ────────────────────────────────────────────────────────────────────
 
 echo ""
@@ -427,12 +500,27 @@ echo "============================================="
 echo "  BUILD COMPLETE"
 echo "============================================="
 echo ""
-echo "  The compiler is inside the Docker container:"
+echo "  Docker image:"
+echo "    $IMAGE_NAME"
+echo ""
+echo "  Host build directory:"
+echo "    $HOST_BUILD_DIR"
+echo ""
+echo "  Host install directory:"
+echo "    $HOST_INSTALL_DIR"
+echo ""
+echo "  Host wrapper commands:"
+echo "    $HOST_BIN_DIR/opencc"
+echo "    $HOST_BIN_DIR/openCC"
+echo "    $HOST_BIN_DIR/openf90"
+echo ""
+echo "  Run the x86_64 compiler from macOS through Docker/Rosetta:"
+echo "    docker run --rm --platform linux/amd64 -v \"$HOST_INSTALL_DIR:/opt/open64:ro\" -v \"\$PWD:/work\" $IMAGE_NAME opencc -v"
+echo "    $HOST_BIN_DIR/opencc -v"
+echo ""
+echo "  The build container is still available:"
 echo "    docker exec -it $CONTAINER_NAME bash"
 echo "    ls /build/osprey/targdir/driver/opencc"
-echo ""
-echo "  To install to /opt/open64:"
-echo "    docker exec $CONTAINER_NAME make -C /build install"
 echo ""
 echo "  To stop the container:"
 echo "    docker stop $CONTAINER_NAME"

--- a/osprey/common/com/ir_bcom.cxx
+++ b/osprey/common/com/ir_bcom.cxx
@@ -696,6 +696,28 @@ ir_b_write_global_symtab (off_t base_offset, Output_File *fl)
 			      Scope_tab[idx].st_attr_tab->Size () * sizeof(ST_ATTR),
 			      sizeof(ST_ATTR), __ALIGNOF(ST_ATTR), SHDR_ST_ATTR);
 
+    cur_offset = write_table (Ty_tensor_extensions, symtab_offset, fl);
+    gsymtab.header[i++].Init (cur_offset,
+			      Ty_tensor_extensions.Size () *
+				sizeof(TY_TENSOR_EXTENSION_STORE),
+			      sizeof(TY_TENSOR_EXTENSION_STORE),
+			      __ALIGNOF(TY_TENSOR_EXTENSION_STORE),
+			      SHDR_TY_TENSOR_EXT);
+
+    cur_offset = write_table (St_tensor_metadata, symtab_offset, fl);
+    gsymtab.header[i++].Init (cur_offset,
+			      St_tensor_metadata.Size () *
+				sizeof(ST_TENSOR_METADATA_STORE),
+			      sizeof(ST_TENSOR_METADATA_STORE),
+			      __ALIGNOF(ST_TENSOR_METADATA_STORE),
+			      SHDR_ST_TENSOR_METADATA);
+
+    cur_offset = write_table (Tensor_dsl_kv_table, symtab_offset, fl);
+    gsymtab.header[i++].Init (cur_offset,
+			      Tensor_dsl_kv_table.Size () * sizeof(TY_DSL_KV),
+			      sizeof(TY_DSL_KV), __ALIGNOF(TY_DSL_KV),
+			      SHDR_TENSOR_DSL_KV);
+
     save_buf_at_offset (&gsymtab, sizeof(gsymtab), symtab_offset, fl);
 
     return symtab_offset - base_offset;
@@ -866,4 +888,3 @@ IPA_irb_write_mod_ref_info(Output_File *fl)
     header_addr->entsize = sizeof(pu_mod_ref_info);
 }
 #endif
-

--- a/osprey/common/com/ir_bread.cxx
+++ b/osprey/common/com/ir_bread.cxx
@@ -240,16 +240,18 @@ WN_get_global_symtab (void *handle)
 
     UINT64 size = shdr.size;
 
-    if (gsymtab->size < sizeof(gsymtab) ||
-	gsymtab->entries < GLOBAL_SYMTAB_TABLES || gsymtab->size > size)
+    if (gsymtab->entries < GLOBAL_SYMTAB_TABLES_LEGACY ||
+	gsymtab->entries > GLOBAL_SYMTAB_TABLES ||
+	gsymtab->size < SYMTAB_HEADER_TABLE_SIZE(gsymtab->entries) ||
+	gsymtab->size > size)
 	return ERROR_RETURN;
 
     UINT i;
-    for (i = 0; i < GLOBAL_SYMTAB_TABLES; ++i)
+    for (i = 0; i < gsymtab->entries; ++i)
 	if (gsymtab->header[i].offset + gsymtab->header[i].size > size)
 	    return ERROR_RETURN;
 
-    for (i = 0; i < GLOBAL_SYMTAB_TABLES; ++i) {
+    for (i = 0; i < gsymtab->entries; ++i) {
 	const SYMTAB_HEADER& hdr = gsymtab->header[i];
 	const char *addr = base + hdr.offset;
 
@@ -309,6 +311,21 @@ WN_get_global_symtab (void *handle)
 	    Scope_tab[GLOBAL_SYMTAB].st_attr_tab->
 		Transfer ((ST_ATTR *) addr, hdr.size / hdr.entsize);
 	   break;
+
+	case SHDR_TY_TENSOR_EXT:
+	    Ty_tensor_extensions.Transfer ((TY_TENSOR_EXTENSION_STORE *) addr,
+					   hdr.size / hdr.entsize);
+	    break;
+
+	case SHDR_ST_TENSOR_METADATA:
+	    St_tensor_metadata.Transfer ((ST_TENSOR_METADATA_STORE *) addr,
+					 hdr.size / hdr.entsize);
+	    break;
+
+	case SHDR_TENSOR_DSL_KV:
+	    Tensor_dsl_kv_table.Transfer ((TY_DSL_KV *) addr,
+					  hdr.size / hdr.entsize);
+	    break;
 	}
     }
 
@@ -1746,4 +1763,3 @@ Set_Local_Info(char* file, void* handle) {
 }
 
 #endif	/* OWN_ERROR_PACKAGE */
-

--- a/osprey/common/com/symtab.cxx
+++ b/osprey/common/com/symtab.cxx
@@ -55,11 +55,13 @@
 #endif /* USE_PCH */
 #pragma hdrstop
 #include <stdio.h>
+#include <string.h>
 #include <alloca.h>
 
 #include <ext/hash_map>			// stl hash table
 #include <ext/algorithm>
 #include <ostream>
+#include <vector>
 
 #include "defs.h"
 #include "config.h"
@@ -102,6 +104,326 @@ ST_ATTR_TABLE	St_Attr_Table;
 
 SYMTAB_IDX Current_scope;		// index to current scope
 PU *Current_pu;				// ptr to current PU
+
+TY_TENSOR_EXTENSION_TABLE Ty_tensor_extensions;
+ST_TENSOR_METADATA_TABLE St_tensor_metadata;
+TY_DSL_KV_TABLE Tensor_dsl_kv_table;
+
+static TY_TENSOR_EXTENSION_STORE *
+Find_Tensor_Extension (TY_IDX ty)
+{
+    for (UINT32 i = 0; i < Ty_tensor_extensions.Size(); ++i) {
+	TY_TENSOR_EXTENSION_STORE &ext = Ty_tensor_extensions[i];
+	if (ext.ty == ty)
+	    return &ext;
+    }
+    return NULL;
+}
+
+static TY_TENSOR_EXTENSION_STORE &
+Ensure_Tensor_Extension (TY_IDX ty, TY_IDX element_ty, INT32 rank)
+{
+    TY_TENSOR_EXTENSION_STORE *existing = Find_Tensor_Extension (ty);
+    if (existing != NULL) {
+	existing->element_ty = element_ty;
+	existing->rank = rank;
+	return *existing;
+    }
+
+    TY_TENSOR_EXTENSION_STORE ext_record;
+    UINT32 ext_index = Ty_tensor_extensions.Insert(ext_record);
+    TY_TENSOR_EXTENSION_STORE &ext = Ty_tensor_extensions[ext_index];
+    ext.ty = ty;
+    ext.element_ty = element_ty;
+    ext.rank = rank;
+    return ext;
+}
+
+static ST_TENSOR_METADATA_STORE *
+Find_Tensor_Metadata (ST_IDX st)
+{
+    for (UINT32 i = 0; i < St_tensor_metadata.Size(); ++i) {
+	ST_TENSOR_METADATA_STORE &metadata = St_tensor_metadata[i];
+	if (metadata.st == st)
+	    return &metadata;
+    }
+    return NULL;
+}
+
+static ST_TENSOR_METADATA_STORE &
+Ensure_Tensor_Metadata (ST_IDX st)
+{
+    ST_TENSOR_METADATA_STORE *existing = Find_Tensor_Metadata (st);
+    if (existing != NULL)
+	return *existing;
+
+    ST_TENSOR_METADATA_STORE metadata_record;
+    UINT32 metadata_index = St_tensor_metadata.Insert(metadata_record);
+    ST_TENSOR_METADATA_STORE &metadata = St_tensor_metadata[metadata_index];
+    metadata.st = st;
+    return metadata;
+}
+
+static TY_DSL_KV *
+Find_Tensor_KV (UINT32 head, const char *key)
+{
+    for (UINT32 handle = head; handle != 0;
+	 handle = Tensor_dsl_kv_table[handle - 1].next) {
+	TY_DSL_KV &entry = Tensor_dsl_kv_table[handle - 1];
+	if (strcmp(&Str_Table[entry.key], key ? key : "") == 0)
+	    return &entry;
+    }
+    return NULL;
+}
+
+static const TY_DSL_KV *
+Find_Tensor_KV_Const (UINT32 head, const char *key)
+{
+    for (UINT32 handle = head; handle != 0;
+	 handle = Tensor_dsl_kv_table[handle - 1].next) {
+	const TY_DSL_KV &entry = Tensor_dsl_kv_table[handle - 1];
+	if (strcmp(&Str_Table[entry.key], key ? key : "") == 0)
+	    return &entry;
+    }
+    return NULL;
+}
+
+static STR_IDX
+Tensor_Ext_Key (const char *key)
+{
+    return Str_To_Index(Save_Str(key ? key : ""), Current_Strtab);
+}
+
+static STR_IDX
+Tensor_Ext_Value (const char *value)
+{
+    return Str_To_Index(Save_Str(value ? value : ""), Current_Strtab);
+}
+
+static void
+Declare_Tensor_KV (UINT32 &head, UINT32 &count, const char *key)
+{
+    STR_IDX key_idx = Tensor_Ext_Key (key);
+    TY_DSL_KV *entry = Find_Tensor_KV (head, key);
+    if (entry != NULL)
+	return;
+
+    TY_DSL_KV new_entry;
+    new_entry.key = key_idx;
+    new_entry.value = 0;
+    new_entry.state = TY_DSL_BIND_PENDING;
+    new_entry.next = head;
+    head = Tensor_dsl_kv_table.Insert(new_entry) + 1;
+    ++count;
+}
+
+static void
+Bind_Tensor_KV (UINT32 &head, UINT32 &count, const char *key,
+		const char *value)
+{
+    TY_DSL_KV *entry = Find_Tensor_KV (head, key);
+    if (entry == NULL) {
+	Declare_Tensor_KV (head, count, key);
+	entry = Find_Tensor_KV (head, key);
+    }
+    Is_True(entry != NULL, ("failed to create tensor extension binding"));
+    entry->value = Tensor_Ext_Value (value);
+    entry->state = TY_DSL_BIND_BOUND;
+}
+
+static BOOL
+Tensor_KV_Is_Bound (UINT32 head, const char *key)
+{
+    const TY_DSL_KV *entry = Find_Tensor_KV_Const (head, key);
+    return entry != NULL && entry->state == TY_DSL_BIND_BOUND;
+}
+
+static const char *
+Tensor_KV_Value (UINT32 head, const char *key)
+{
+    const TY_DSL_KV *entry = Find_Tensor_KV_Const (head, key);
+    if (entry == NULL || entry->state != TY_DSL_BIND_BOUND)
+	return NULL;
+    return &Str_Table[entry->value];
+}
+
+static void
+Check_Tensor_Extension (TY_IDX ty)
+{
+    Is_True(TY_is_tensor_extension (ty),
+	    ("TY_IDX %u is not a tensor extension type", TY_IDX_index(ty)));
+}
+
+static void
+Check_Tensor_Metadata_Symbol (ST_IDX st)
+{
+    Is_True(ST_IDX_index(st) != 0,
+	    ("cannot attach tensor metadata to null ST_IDX"));
+}
+
+TY_IDX
+TY_Create_Tensor_Extension_Type (const char *name, TY_IDX element_ty,
+				 INT32 rank)
+{
+    TY_IDX ty_idx;
+    TY& ty = New_TY(ty_idx);
+    TY_Init(ty, 0, KIND_STRUCT, MTYPE_M,
+	    Save_Str(name ? name : "__dsl_tensor"));
+    TY_Mark_Tensor_Extension (ty_idx, element_ty, rank);
+    return ty_idx;
+}
+
+void
+TY_Mark_Tensor_Extension (TY_IDX ty, TY_IDX element_ty, INT32 rank)
+{
+    Is_True(TY_IDX_index(ty) != 0, ("cannot mark null TY as tensor"));
+    Ensure_Tensor_Extension (ty, element_ty, rank);
+}
+
+BOOL
+TY_is_tensor_extension (TY_IDX ty)
+{
+    return TY_IDX_index(ty) != 0 && Find_Tensor_Extension (ty) != NULL;
+}
+
+BOOL
+TY_Get_Tensor_Extension_Info (TY_IDX ty, TY_TENSOR_EXTENSION_INFO *info)
+{
+    TY_TENSOR_EXTENSION_STORE *ext = Find_Tensor_Extension (ty);
+    if (ext == NULL)
+	return FALSE;
+
+    if (info != NULL) {
+	info->ty = ext->ty;
+	info->element_ty = ext->element_ty;
+	info->rank = ext->rank;
+	info->attribute_count = ext->attribute_count;
+    }
+    return TRUE;
+}
+
+TY_IDX
+TY_tensor_element_ty (TY_IDX ty)
+{
+    Check_Tensor_Extension (ty);
+    return Find_Tensor_Extension (ty)->element_ty;
+}
+
+INT32
+TY_tensor_rank (TY_IDX ty)
+{
+    Check_Tensor_Extension (ty);
+    return Find_Tensor_Extension (ty)->rank;
+}
+
+void
+TY_tensor_declare_attribute (TY_IDX ty, const char *key)
+{
+    Check_Tensor_Extension (ty);
+    TY_TENSOR_EXTENSION_STORE *ext = Find_Tensor_Extension (ty);
+    Declare_Tensor_KV (ext->attribute_head, ext->attribute_count, key);
+}
+
+void
+TY_tensor_bind_attribute (TY_IDX ty, const char *key, const char *value)
+{
+    Check_Tensor_Extension (ty);
+    TY_TENSOR_EXTENSION_STORE *ext = Find_Tensor_Extension (ty);
+    Bind_Tensor_KV (ext->attribute_head, ext->attribute_count, key, value);
+}
+
+BOOL
+TY_tensor_attribute_is_bound (TY_IDX ty, const char *key)
+{
+    TY_TENSOR_EXTENSION_STORE *ext = Find_Tensor_Extension (ty);
+    return ext != NULL && Tensor_KV_Is_Bound (ext->attribute_head, key);
+}
+
+const char *
+TY_tensor_attribute (TY_IDX ty, const char *key)
+{
+    TY_TENSOR_EXTENSION_STORE *ext = Find_Tensor_Extension (ty);
+    return ext == NULL ? NULL : Tensor_KV_Value (ext->attribute_head, key);
+}
+
+void
+ST_tensor_declare_metadata (ST_IDX st, const char *key)
+{
+    Check_Tensor_Metadata_Symbol (st);
+    ST_TENSOR_METADATA_STORE &metadata = Ensure_Tensor_Metadata (st);
+    Declare_Tensor_KV (metadata.metadata_head, metadata.metadata_count, key);
+}
+
+void
+ST_tensor_bind_metadata (ST_IDX st, const char *key, const char *value)
+{
+    Check_Tensor_Metadata_Symbol (st);
+    ST_TENSOR_METADATA_STORE &metadata = Ensure_Tensor_Metadata (st);
+    Bind_Tensor_KV (metadata.metadata_head, metadata.metadata_count, key, value);
+}
+
+BOOL
+ST_tensor_metadata_is_bound (ST_IDX st, const char *key)
+{
+    ST_TENSOR_METADATA_STORE *metadata = Find_Tensor_Metadata (st);
+    return metadata != NULL && Tensor_KV_Is_Bound (metadata->metadata_head, key);
+}
+
+const char *
+ST_tensor_metadata (ST_IDX st, const char *key)
+{
+    ST_TENSOR_METADATA_STORE *metadata = Find_Tensor_Metadata (st);
+    return metadata == NULL ? NULL : Tensor_KV_Value (metadata->metadata_head,
+						      key);
+}
+
+void
+TY_tensor_declare_metadata (TY_IDX ty, const char *key)
+{
+    TY_tensor_declare_attribute (ty, key);
+}
+
+void
+TY_tensor_bind_metadata (TY_IDX ty, const char *key, const char *value)
+{
+    TY_tensor_bind_attribute (ty, key, value);
+}
+
+BOOL
+TY_tensor_metadata_is_bound (TY_IDX ty, const char *key)
+{
+    return TY_tensor_attribute_is_bound (ty, key);
+}
+
+const char *
+TY_tensor_metadata (TY_IDX ty, const char *key)
+{
+    return TY_tensor_attribute (ty, key);
+}
+
+void
+ST_tensor_declare_attribute (ST_IDX st, const char *key)
+{
+    ST_tensor_declare_metadata (st, key);
+}
+
+void
+ST_tensor_bind_attribute (ST_IDX st, const char *key, const char *value)
+{
+    ST_tensor_bind_metadata (st, key, value);
+}
+
+BOOL
+ST_tensor_attribute_is_bound (ST_IDX st, const char *key)
+{
+    return ST_tensor_metadata_is_bound (st, key);
+}
+
+const char *
+ST_tensor_attribute (ST_IDX st, const char *key)
+{
+    return ST_tensor_metadata (st, key);
+}
 
 //----------------------------------------------------------------------
 // ST-related utilities
@@ -1411,6 +1733,14 @@ Reset_misc_symtab()
 
   // reset intrinsic table
   intrinsic_list.clear();
+
+  // reset DSL type extension side tables
+  while (Ty_tensor_extensions.Size() > 0)
+    Ty_tensor_extensions.Delete_last();
+  while (St_tensor_metadata.Size() > 0)
+    St_tensor_metadata.Delete_last();
+  while (Tensor_dsl_kv_table.Size() > 0)
+    Tensor_dsl_kv_table.Delete_last();
 }
 
 /* ty either is union or has union in one of its fields (called recursively) */
@@ -2527,9 +2857,10 @@ std::ostream& operator<<(std::ostream &os, const ST &st )
 	    break;
 	}
 
-        os << std::endl << "\t\tSclass: "
-           << Sclass_Name(st.storage_class) << std::endl;
-    }
+	    os << std::endl << "\t\tSclass: "
+	       << Sclass_Name(st.storage_class) << std::endl;
+	}
+	return os;
 } // ST::Print
 
 void
@@ -2896,9 +3227,53 @@ Print_global_symtab (FILE *f)
     fprintf (f, "%sST_ATTRs:\n", DBar);
     For_all (St_Attr_Table, GLOBAL_SYMTAB, print_op<ST_ATTR> (f));
 
+    Print_tensor_dsl_symtab (f);
+
     fprintf (f, "%sString table size = %lld\n", DBar, STR_Table_Size());
     fprintf (f, "%s\n", DBar);
 } // Print_global_symtab
+
+static void
+Print_tensor_kv_chain (FILE *f, UINT32 head)
+{
+    for (UINT32 handle = head; handle != 0;
+	 handle = Tensor_dsl_kv_table[handle - 1].next) {
+	const TY_DSL_KV &entry = Tensor_dsl_kv_table[handle - 1];
+	const char *key = entry.key == 0 ? "<null>" : &Str_Table[entry.key];
+	const char *value = entry.value == 0 ? "<unbound>" : &Str_Table[entry.value];
+	fprintf (f, "      [%u] %s = %s%s\n", handle - 1, key, value,
+		entry.state == TY_DSL_BIND_BOUND ? "" : " (pending)");
+    }
+}
+
+void
+Print_tensor_dsl_symtab (FILE *f)
+{
+    if (Ty_tensor_extensions.Size() == 0 &&
+	St_tensor_metadata.Size() == 0 &&
+	Tensor_dsl_kv_table.Size() == 0)
+	return;
+
+    fprintf (f, "%sDSL Tensor Type Extensions:\n", DBar);
+    for (UINT32 i = 0; i < Ty_tensor_extensions.Size(); ++i) {
+	const TY_TENSOR_EXTENSION_STORE &ext = Ty_tensor_extensions[i];
+	fprintf (f, "  [%u] ty=%u element_ty=%u rank=%d attributes=%u\n",
+		i, TY_IDX_index(ext.ty), TY_IDX_index(ext.element_ty),
+		ext.rank, ext.attribute_count);
+	Print_tensor_kv_chain (f, ext.attribute_head);
+    }
+
+    fprintf (f, "%sDSL Tensor Symbol Metadata:\n", DBar);
+    for (UINT32 i = 0; i < St_tensor_metadata.Size(); ++i) {
+	const ST_TENSOR_METADATA_STORE &metadata = St_tensor_metadata[i];
+	fprintf (f, "  [%u] st=%u metadata=%u\n", i,
+		ST_IDX_index(metadata.st), metadata.metadata_count);
+	Print_tensor_kv_chain (f, metadata.metadata_head);
+    }
+
+    fprintf (f, "%sDSL Tensor KV Table: entries=%u\n", DBar,
+	    Tensor_dsl_kv_table.Size());
+}
 
 // for ease of debugging, because I don't know how to call Print
 // routines from dbx, add simple dump routines.

--- a/osprey/common/com/symtab.h
+++ b/osprey/common/com/symtab.h
@@ -431,6 +431,110 @@ Is_Composite_Type (const TY& ty)
 inline BOOL
 Is_Composite_Type (TY_IDX ty)	{ return Is_Composite_Type (Ty_Table[ty]); }
 
+//----------------------------------------------------------------------
+// DSL type extensions
+//----------------------------------------------------------------------
+
+enum TY_DSL_EXTENSION_KIND {
+    TY_DSL_EXTENSION_NONE = 0,
+    TY_DSL_EXTENSION_TENSOR = 1
+};
+
+enum TY_DSL_BIND_STATE {
+    TY_DSL_BIND_PENDING = 0,
+    TY_DSL_BIND_BOUND = 1
+};
+
+struct TY_DSL_KV {
+    STR_IDX key;
+    STR_IDX value;
+    mUINT32 state;
+    UINT32 next;
+};
+
+struct TY_TENSOR_EXTENSION_STORE {
+    TY_IDX ty;
+    TY_IDX element_ty;
+    INT32 rank;
+    UINT32 attribute_head;
+    UINT32 attribute_count;
+
+    TY_TENSOR_EXTENSION_STORE() :
+	ty(TY_IDX_ZERO), element_ty(TY_IDX_ZERO), rank(-1),
+	attribute_head(0), attribute_count(0) {}
+};
+
+struct ST_TENSOR_METADATA_STORE {
+    ST_IDX st;
+    UINT32 metadata_head;
+    UINT32 metadata_count;
+
+    ST_TENSOR_METADATA_STORE() :
+	st(ST_IDX_ZERO), metadata_head(0), metadata_count(0) {}
+};
+
+typedef SEGMENTED_ARRAY<TY_TENSOR_EXTENSION_STORE> TY_TENSOR_EXTENSION_TABLE;
+typedef SEGMENTED_ARRAY<ST_TENSOR_METADATA_STORE> ST_TENSOR_METADATA_TABLE;
+typedef SEGMENTED_ARRAY<TY_DSL_KV> TY_DSL_KV_TABLE;
+
+extern TY_TENSOR_EXTENSION_TABLE Ty_tensor_extensions;
+extern ST_TENSOR_METADATA_TABLE St_tensor_metadata;
+extern TY_DSL_KV_TABLE Tensor_dsl_kv_table;
+
+struct TY_TENSOR_EXTENSION_INFO {
+    TY_IDX ty;
+    TY_IDX element_ty;
+    INT32 rank;
+    UINT32 attribute_count;
+};
+
+extern TY_IDX TY_Create_Tensor_Extension_Type (const char *name,
+					      TY_IDX element_ty,
+					      INT32 rank);
+extern void TY_Mark_Tensor_Extension (TY_IDX ty, TY_IDX element_ty,
+				      INT32 rank);
+extern BOOL TY_is_tensor_extension (TY_IDX ty);
+extern BOOL TY_Get_Tensor_Extension_Info (TY_IDX ty,
+					 TY_TENSOR_EXTENSION_INFO *info);
+extern TY_IDX TY_tensor_element_ty (TY_IDX ty);
+extern INT32 TY_tensor_rank (TY_IDX ty);
+
+/*
+ * Tensor attributes complete TensorDescriptorIR semantic state: TensorTypeCore,
+ * TensorTraitSet, TensorRepresentationDescriptor, and TensorLineageMetadata.
+ * Use these for facts required before tensor computation or lowering.
+ */
+extern void TY_tensor_declare_attribute (TY_IDX ty, const char *key);
+extern void TY_tensor_bind_attribute (TY_IDX ty, const char *key,
+				     const char *value);
+extern BOOL TY_tensor_attribute_is_bound (TY_IDX ty, const char *key);
+extern const char *TY_tensor_attribute (TY_IDX ty, const char *key);
+
+/*
+ * Tensor metadata carries compiler context: source locations, diagnostics,
+ * pass ownership, lowering hints, and profiling.  It must not be required to
+ * complete TensorDescriptorIR semantics.
+ */
+extern void ST_tensor_declare_metadata (ST_IDX st, const char *key);
+extern void ST_tensor_bind_metadata (ST_IDX st, const char *key,
+				    const char *value);
+extern BOOL ST_tensor_metadata_is_bound (ST_IDX st, const char *key);
+extern const char *ST_tensor_metadata (ST_IDX st, const char *key);
+
+/* Compatibility wrappers for the pre-TensorDescriptorIR naming. */
+extern void TY_tensor_declare_metadata (TY_IDX ty, const char *key);
+extern void TY_tensor_bind_metadata (TY_IDX ty, const char *key,
+				    const char *value);
+extern BOOL TY_tensor_metadata_is_bound (TY_IDX ty, const char *key);
+extern const char *TY_tensor_metadata (TY_IDX ty, const char *key);
+extern void ST_tensor_declare_attribute (ST_IDX st, const char *key);
+extern void ST_tensor_bind_attribute (ST_IDX st, const char *key,
+				     const char *value);
+extern BOOL ST_tensor_attribute_is_bound (ST_IDX st, const char *key);
+extern const char *ST_tensor_attribute (ST_IDX st, const char *key);
+
+extern void Print_tensor_dsl_symtab (FILE *f);
+
 void
 Reset_misc_symtab();
 
@@ -761,5 +865,3 @@ Reset_STB_flags (ST* s, UINT16 flags)	{
 #define Reset_STB_compiler_layout(s)	(Reset_STB_flags (s, BLK_COMPILER_LAYOUT))
 
 #endif /* symtab_INCLUDED */
-
-

--- a/osprey/common/com/symtab_access.h
+++ b/osprey/common/com/symtab_access.h
@@ -2052,6 +2052,7 @@ TY_register_parm (const TY& ty) {
 		return 1;
 	if (ty.Pu_flags() & TY_HAS_2_REG_PARM)
 		return 2;
+	return 0;
 }
 
 inline void

--- a/osprey/common/com/symtab_defs.h
+++ b/osprey/common/com/symtab_defs.h
@@ -1137,7 +1137,10 @@ enum SHDR_TYPE
     SHDR_INITO	= 12,
     SHDR_INITV	= 13,
     SHDR_BLK 	= 14,
-    SHDR_ST_ATTR= 15
+    SHDR_ST_ATTR= 15,
+    SHDR_TY_TENSOR_EXT = 16,
+    SHDR_ST_TENSOR_METADATA = 17,
+    SHDR_TENSOR_DSL_KV = 18
 }; // SHDR_TYPE
 
 
@@ -1162,12 +1165,20 @@ struct SYMTAB_HEADER
 }; // SYMTAB_HEADER
 
 
-#define GLOBAL_SYMTAB_TABLES	(13)	// # of tables in global symtab:
+// Readers accept both the legacy 13-table global symtab and the DSL-extended
+// 16-table form so older WHIRL files remain loadable.
+#define GLOBAL_SYMTAB_TABLES_LEGACY (13) // # of pre-DSL global symtab tables
+#define GLOBAL_SYMTAB_TABLES	(16)	// # of tables in global symtab:
 					// FILE_INFO, ST, TY, PU, FLD, ARB,
 					// TYLIST, TCON, STR, INITO, INITV,
-					// BLK, and ST_ATTR
+					// BLK, ST_ATTR, TY_TENSOR_EXT,
+					// ST_TENSOR_METADATA, and
+					// TENSOR_DSL_KV
 #define LOCAL_SYMTAB_TABLES	(5)	// # of tables in local symtab:
 					// ST, LABEL, PREG, INITO, and ST_ATTR
+
+#define SYMTAB_HEADER_TABLE_SIZE(entries) \
+    (sizeof(mUINT32) + sizeof(mUINT32) + (entries) * sizeof(SYMTAB_HEADER))
 
 template <UINT table_size>
 struct SYMTAB_HEADER_TABLE
@@ -1195,4 +1206,3 @@ typedef SYMTAB_HEADER_TABLE<GLOBAL_SYMTAB_TABLES> GLOBAL_SYMTAB_HEADER_TABLE;
 typedef SYMTAB_HEADER_TABLE<LOCAL_SYMTAB_TABLES> LOCAL_SYMTAB_HEADER_TABLE;
 
 #endif /* symtab_defs_INCLUDED */
-

--- a/osprey/common/com/tests/dsl_common_add_print_test.cxx
+++ b/osprey/common/com/tests/dsl_common_add_print_test.cxx
@@ -1,0 +1,487 @@
+/*
+ * Smoke test for representing a common.add DSL operation with compatible
+ * WHIRL nodes and printing it through the standard fdump_tree interface.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "defs.h"
+#include "mempool.h"
+#include "wn.h"
+#include "wn_util.h"
+#include "stab.h"
+#include "symtab.h"
+#include "symtab_utils.h"
+#include "ir_reader.h"
+#include "erglob.h"
+#include "errors.h"
+#include "err_host.tab"
+
+BOOL Run_vsaopt = FALSE;
+INT8 Debug_Level = 0;
+
+void
+Signal_Cleanup(INT sig) {}
+
+const char *
+Host_Format_Parm(INT kind, MEM_PTR parm)
+{
+  return "";
+}
+
+static char *Read_File(FILE *fp);
+static const char *Trace_File_Path(void);
+static int Write_Common_Add_Trace(const char *tree_text,
+				  const char *annotation_text);
+
+static void
+Initialize_Test_Context(void)
+{
+  MEM_Initialize();
+  Set_Error_Tables(Phases, host_errlist);
+  Init_Error_Handler(10);
+  Set_Error_File(NULL);
+  Set_Error_Line(ERROR_LINE_UNKNOWN);
+
+  Initialize_Symbol_Tables(FALSE);
+  New_Scope(GLOBAL_SYMTAB, Malloc_Mem_Pool, FALSE);
+}
+
+static WN *
+Create_Common_Add_Test_Tree(WN **dsl_marker_out)
+{
+  WN *block = WN_CreateBlock();
+  WN *const_i32_2x2_zero =
+    DSL_WN_Create_Tensor_Const ("const_i32_2x2_zero",
+			     "int32",
+			     2,
+			     "[2,2]",
+			     "splat",
+			     "0");
+  WN *const_i32_2x2_one =
+    DSL_WN_Create_Tensor_Const ("const_i32_2x2_one",
+			     "int32",
+			     2,
+			     "[2,2]",
+			     "splat",
+			     "1");
+  WN *dsl_marker =
+    DSL_WN_Create_Opcode (DSL_OPCODE_COMMON_ADD,
+			1,
+			"kid0=const_i32_2x2_zero;kid1=const_i32_2x2_one;attr.broadcast_rule=none");
+
+  if (dsl_marker_out != NULL)
+    *dsl_marker_out = dsl_marker;
+
+  WN_INSERT_BlockLast(block, const_i32_2x2_zero);
+  WN_INSERT_BlockLast(block, const_i32_2x2_one);
+  WN_INSERT_BlockLast(block, dsl_marker);
+
+  WN *kid0 = WN_CreateIntconst(OPR_INTCONST, MTYPE_I4, MTYPE_V, 1);
+  WN *kid1 = WN_CreateIntconst(OPR_INTCONST, MTYPE_I4, MTYPE_V, 2);
+  WN *add = WN_Add(MTYPE_I4, kid0, kid1);
+  WN_INSERT_BlockLast(block, WN_CreateEval(add));
+
+  return block;
+}
+
+static int
+Check_Common_Add_Annotation(WN *dsl_marker)
+{
+  DSL_OPCODE_ANNOTATION annotation;
+  int failed = 0;
+
+  if (!DSL_WN_Get_Opcode_Annotation (dsl_marker, &annotation)) {
+    fprintf(stderr, "common.add marker was not decoded as a DSL opcode\n");
+    return 1;
+  }
+
+  if (annotation.name_len != strlen(DSL_OPCODE_COMMON_ADD) ||
+      strncmp(annotation.name, DSL_OPCODE_COMMON_ADD, annotation.name_len) != 0) {
+    fprintf(stderr, "decoded DSL opcode name is not common.add\n");
+    failed = 1;
+  }
+
+  if (annotation.version != 1) {
+    fprintf(stderr, "decoded common.add DSL opcode version is not 1\n");
+    failed = 1;
+  }
+
+  if (strcmp(annotation.payload,
+	     "kid0=const_i32_2x2_zero;kid1=const_i32_2x2_one;attr.broadcast_rule=none") != 0) {
+    fprintf(stderr, "decoded common.add DSL opcode payload changed\n");
+    failed = 1;
+  }
+
+  return failed;
+}
+
+static int
+Check_Tensor_Const_Annotation(WN *tensor_const, const char *name,
+			      const char *value)
+{
+  DSL_OPCODE_ANNOTATION annotation;
+  int failed = 0;
+
+  if (!DSL_WN_Get_Opcode_Annotation (tensor_const, &annotation)) {
+    fprintf(stderr, "tensor_const marker did not decode\n");
+    return 1;
+  }
+
+  if (annotation.name_len != strlen(DSL_OPCODE_COMMON_TENSOR_CONST) ||
+      strncmp(annotation.name, DSL_OPCODE_COMMON_TENSOR_CONST,
+	      annotation.name_len) != 0) {
+    fprintf(stderr, "decoded DSL opcode name is not common.tensor_const\n");
+    failed = 1;
+  }
+
+  if (annotation.version != 1) {
+    fprintf(stderr, "decoded tensor_const DSL opcode version is not 1\n");
+    failed = 1;
+  }
+
+  if (strstr(annotation.payload, name) == NULL ||
+      strstr(annotation.payload, "dtype=int32") == NULL ||
+      strstr(annotation.payload, "rank=2") == NULL ||
+      strstr(annotation.payload, "shape=[2,2]") == NULL ||
+      strstr(annotation.payload, "value_kind=splat") == NULL ||
+      strstr(annotation.payload, value) == NULL) {
+    fprintf(stderr, "decoded tensor_const payload changed\n");
+    failed = 1;
+  }
+
+  return failed;
+}
+
+static int
+Check_Common_Add_On_Tensor_Constants(void)
+{
+  WN *const_i32_2x2_zero =
+    DSL_WN_Create_Tensor_Const ("const_i32_2x2_zero", "int32", 2, "[2,2]", "splat", "0");
+  WN *const_i32_2x2_one =
+    DSL_WN_Create_Tensor_Const ("const_i32_2x2_one", "int32", 2, "[2,2]", "splat", "1");
+  WN *common_add =
+    DSL_WN_Create_Opcode (DSL_OPCODE_COMMON_ADD,
+			1,
+			"kid0=const_i32_2x2_zero;kid1=const_i32_2x2_one;attr.broadcast_rule=none");
+  DSL_OPCODE_ANNOTATION annotation;
+  FILE *dump = tmpfile();
+  char *text;
+  int failed = 0;
+
+  failed |= Check_Tensor_Const_Annotation(const_i32_2x2_zero, "name=const_i32_2x2_zero",
+					  "value=0");
+  failed |= Check_Tensor_Const_Annotation(const_i32_2x2_one, "name=const_i32_2x2_one",
+					  "value=1");
+
+  if (!DSL_WN_Get_Opcode_Annotation (common_add, &annotation)) {
+    fprintf(stderr, "common.add tensor-constant marker did not decode\n");
+    return 1;
+  }
+
+  if (annotation.name_len != strlen(DSL_OPCODE_COMMON_ADD) ||
+      strncmp(annotation.name, DSL_OPCODE_COMMON_ADD, annotation.name_len) != 0) {
+    fprintf(stderr, "tensor-constant DSL opcode name is not common.add\n");
+    failed = 1;
+  }
+
+  if (annotation.version != 1) {
+    fprintf(stderr, "tensor-constant common.add version is not 1\n");
+    failed = 1;
+  }
+
+  if (strcmp(annotation.payload,
+	     "kid0=const_i32_2x2_zero;kid1=const_i32_2x2_one;attr.broadcast_rule=none") != 0) {
+    fprintf(stderr, "tensor-constant common.add payload changed\n");
+    failed = 1;
+  }
+
+  if (dump == NULL) {
+    perror("tmpfile");
+    return 1;
+  }
+
+  fdump_tree(dump, common_add);
+  text = Read_File(dump);
+  fclose(dump);
+
+  if (text == NULL) {
+    fprintf(stderr, "failed to read common.add tensor-constant dump\n");
+    return 1;
+  }
+
+  fputs(text, stdout);
+
+  if (strstr(text, "__WHIRL_DSL__:opcode:common.add:v1:") == NULL) {
+    fprintf(stderr, "common.add tensor-constant marker was not printed\n");
+    failed = 1;
+  }
+
+  free(text);
+  return failed;
+}
+
+static int
+Check_Zero_Initializer_Operators(void)
+{
+  WN *zero_init = DSL_WN_Create_Zero_Init ("zero_init", "int32");
+  WN *zero_like = DSL_WN_Create_Zero_Like ("zero_like_input",
+					"const_i32_2x2_zero");
+  DSL_OPCODE_ANNOTATION annotation;
+  int failed = 0;
+
+  if (!DSL_WN_Get_Opcode_Annotation (zero_init, &annotation)) {
+    fprintf(stderr, "zero_init marker did not decode\n");
+    failed = 1;
+  } else {
+    if (annotation.name_len != strlen(DSL_OPCODE_COMMON_ZERO_INIT) ||
+	strncmp(annotation.name, DSL_OPCODE_COMMON_ZERO_INIT,
+		annotation.name_len) != 0) {
+      fprintf(stderr, "decoded DSL opcode name is not common.zero_init\n");
+      failed = 1;
+    }
+    if (strstr(annotation.payload, "name=zero_init") == NULL ||
+	strstr(annotation.payload, "dtype_hint=int32") == NULL ||
+	strstr(annotation.payload, "descriptor_state=infer") == NULL) {
+      fprintf(stderr, "decoded zero_init payload changed\n");
+      failed = 1;
+    }
+  }
+
+  if (!DSL_WN_Get_Opcode_Annotation (zero_like, &annotation)) {
+    fprintf(stderr, "zero_like marker did not decode\n");
+    failed = 1;
+  } else {
+    if (annotation.name_len != strlen(DSL_OPCODE_COMMON_ZERO_LIKE) ||
+	strncmp(annotation.name, DSL_OPCODE_COMMON_ZERO_LIKE,
+		annotation.name_len) != 0) {
+      fprintf(stderr, "decoded DSL opcode name is not common.zero_like\n");
+      failed = 1;
+    }
+    if (strstr(annotation.payload, "name=zero_like_input") == NULL ||
+	strstr(annotation.payload, "source=const_i32_2x2_zero") == NULL ||
+	strstr(annotation.payload, "descriptor_state=copy_source") == NULL) {
+      fprintf(stderr, "decoded zero_like payload changed\n");
+      failed = 1;
+    }
+  }
+
+  return failed;
+}
+
+static int
+Check_Tensor_Dsl_Symtab_Print(void)
+{
+  TY_IDX tensor_ty =
+    TY_Create_Tensor_Extension_Type("tensor_i32_2x2",
+				    MTYPE_To_TY(MTYPE_I4),
+				    2);
+  ST *tensor_st = New_ST();
+  FILE *dump = tmpfile();
+  char *text;
+  int failed = 0;
+
+  TY_tensor_bind_attribute(tensor_ty, "dtype", "int32");
+  TY_tensor_bind_attribute(tensor_ty, "shape", "[2,2]");
+  TY_tensor_bind_attribute(tensor_ty, "layout", "row_major");
+
+  ST_Init(tensor_st, Save_Str("tensor_tmp"), CLASS_VAR, SCLASS_UGLOBAL,
+	  EXPORT_LOCAL, tensor_ty);
+  ST_tensor_bind_metadata(ST_st_idx(*tensor_st),
+			  "source_layer_name",
+			  "dsl_common_add_print_test");
+
+  if (dump == NULL) {
+    perror("tmpfile");
+    return 1;
+  }
+
+  Print_global_symtab(dump);
+  text = Read_File(dump);
+  fclose(dump);
+
+  if (text == NULL) {
+    fprintf(stderr, "failed to read tensor DSL symtab dump\n");
+    return 1;
+  }
+
+  if (strstr(text, "DSL Tensor Type Extensions:") == NULL ||
+      strstr(text, "rank=2") == NULL ||
+      strstr(text, "dtype = int32") == NULL ||
+      strstr(text, "shape = [2,2]") == NULL ||
+      strstr(text, "layout = row_major") == NULL) {
+    fprintf(stderr, "missing tensor descriptor attributes in symtab dump\n");
+    failed = 1;
+  }
+
+  if (strstr(text, "DSL Tensor Symbol Metadata:") == NULL ||
+      strstr(text, "source_layer_name = dsl_common_add_print_test") == NULL) {
+    fprintf(stderr, "missing tensor compiler metadata in symtab dump\n");
+    failed = 1;
+  }
+
+  free(text);
+  return failed;
+}
+
+static char *
+Read_File(FILE *fp)
+{
+  long size;
+  char *buffer;
+
+  fflush(fp);
+  if (fseek(fp, 0, SEEK_END) != 0)
+    return NULL;
+  size = ftell(fp);
+  if (size < 0)
+    return NULL;
+  if (fseek(fp, 0, SEEK_SET) != 0)
+    return NULL;
+
+  buffer = (char *) malloc((size_t) size + 1);
+  if (buffer == NULL)
+    return NULL;
+
+  if (size != 0 &&
+      fread(buffer, 1, (size_t) size, fp) != (size_t) size) {
+    free(buffer);
+    return NULL;
+  }
+  buffer[size] = '\0';
+  return buffer;
+}
+
+static const char *
+Trace_File_Path(void)
+{
+  static char path[4096];
+  const char *source = __FILE__;
+  const char *slash = strrchr(source, '/');
+
+  if (slash == NULL) {
+    snprintf(path, sizeof(path), "dsl_common_add_print_test.trace");
+  } else {
+    size_t dir_len = (size_t) (slash - source);
+    snprintf(path, sizeof(path), "%.*s/dsl_common_add_print_test.trace",
+	     (int) dir_len, source);
+  }
+
+  return path;
+}
+
+static int
+Write_Common_Add_Trace(const char *tree_text, const char *annotation_text)
+{
+  const char *trace_path = Trace_File_Path();
+  FILE *trace = fopen(trace_path, "w");
+
+  if (trace == NULL) {
+    perror(trace_path);
+    return 1;
+  }
+
+  fprintf(trace, "dsl_common_add_print_test trace\n");
+  fprintf(trace, "created_operator=%s\n", DSL_OPCODE_COMMON_ADD);
+  fprintf(trace, "\n[fdump_tree]\n");
+  fputs(tree_text, trace);
+  fprintf(trace, "\n[dsl_annotation]\n");
+  fputs(annotation_text, trace);
+
+  if (fclose(trace) != 0) {
+    perror(trace_path);
+    return 1;
+  }
+
+  return 0;
+}
+
+int
+main(void)
+{
+  Initialize_Test_Context();
+
+  WN *dsl_marker = NULL;
+  WN *tree = Create_Common_Add_Test_Tree(&dsl_marker);
+  FILE *dump = tmpfile();
+  FILE *annotation = tmpfile();
+  char *text;
+  char *annotation_text;
+  int failed = 0;
+
+  if (dump == NULL || annotation == NULL) {
+    perror("tmpfile");
+    return 1;
+  }
+
+  if (!DSL_WN_Has_Opcode (dsl_marker)) {
+    fprintf(stderr, "common.add marker was not recognized as a DSL opcode\n");
+    failed = 1;
+  }
+  failed |= Check_Common_Add_Annotation(dsl_marker);
+  failed |= Check_Common_Add_On_Tensor_Constants();
+  failed |= Check_Zero_Initializer_Operators();
+  failed |= Check_Tensor_Dsl_Symtab_Print();
+
+  fdump_tree(dump, tree);
+  text = Read_File(dump);
+  fclose(dump);
+
+  DSL_fprint_opcode_annotation (annotation, dsl_marker);
+  annotation_text = Read_File(annotation);
+  fclose(annotation);
+
+  if (text == NULL || annotation_text == NULL) {
+    fprintf(stderr, "failed to read test output\n");
+    return 1;
+  }
+
+  fputs(text, stdout);
+  fputs(annotation_text, stdout);
+  failed |= Write_Common_Add_Trace(text, annotation_text);
+
+  if (strstr(text, "__WHIRL_DSL__:opcode:common.add:") == NULL) {
+    fprintf(stderr, "missing common.add DSL marker in fdump_tree output\n");
+    failed = 1;
+  }
+
+  if (strstr(text, "__WHIRL_DSL__:opcode:common.tensor_const:v1:") == NULL ||
+      strstr(text, "name=const_i32_2x2_zero") == NULL ||
+      strstr(text, "name=const_i32_2x2_one") == NULL) {
+    fprintf(stderr, "missing tensor_const DSL markers in fdump_tree output\n");
+    failed = 1;
+  }
+
+  if (strstr(text, "I4ADD") == NULL && strstr(text, "ADD") == NULL) {
+    fprintf(stderr, "missing standard WHIRL ADD in fdump_tree output\n");
+    failed = 1;
+  }
+
+  if (strstr(annotation_text, "dsl_opcode=common.add.v1") == NULL) {
+    fprintf(stderr, "missing formatted common.add DSL opcode annotation\n");
+    failed = 1;
+  }
+
+  {
+    FILE *trace = fopen(Trace_File_Path(), "r");
+    char *trace_text = trace == NULL ? NULL : Read_File(trace);
+
+    if (trace != NULL)
+      fclose(trace);
+
+    if (trace_text == NULL ||
+	strstr(trace_text, "created_operator=common.add") == NULL ||
+	strstr(trace_text, "__WHIRL_DSL__:opcode:common.add:") == NULL) {
+      fprintf(stderr, "missing common.add creation trace file content\n");
+      failed = 1;
+    }
+
+    free(trace_text);
+  }
+
+  free(text);
+  free(annotation_text);
+  return failed;
+}

--- a/osprey/common/com/tests/dsl_common_add_print_test.trace
+++ b/osprey/common/com/tests/dsl_common_add_print_test.trace
@@ -1,0 +1,10 @@
+dsl_common_add_print_test trace
+created_operator=common.add
+
+[fdump_tree]
+__WHIRL_DSL__:opcode:common.tensor_const:v1:name=const_i32_2x2_zero;dtype=int32;rank=2;shape=[2,2];value_kind=splat;value=0
+__WHIRL_DSL__:opcode:common.tensor_const:v1:name=const_i32_2x2_one;dtype=int32;rank=2;shape=[2,2];value_kind=splat;value=1
+__WHIRL_DSL__:opcode:common.add:v1:kid0=const_i32_2x2_zero;kid1=const_i32_2x2_one;attr.broadcast_rule=none
+
+[dsl_annotation]
+dsl_opcode=common.add.v1 payload="kid0=const_i32_2x2_zero;kid1=const_i32_2x2_one;attr.broadcast_rule=none"

--- a/osprey/common/com/tests/dsl_common_matmul_print_test.cxx
+++ b/osprey/common/com/tests/dsl_common_matmul_print_test.cxx
@@ -1,0 +1,307 @@
+/*
+ * Smoke test for representing a common.matmul DSL operation with tensor-one
+ * operands and printing it through the standard fdump_tree interface.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "defs.h"
+#include "mempool.h"
+#include "wn.h"
+#include "wn_util.h"
+#include "stab.h"
+#include "ir_reader.h"
+#include "erglob.h"
+#include "errors.h"
+#include "err_host.tab"
+
+BOOL Run_vsaopt = FALSE;
+INT8 Debug_Level = 0;
+
+void
+Signal_Cleanup(INT sig) {}
+
+const char *
+Host_Format_Parm(INT kind, MEM_PTR parm)
+{
+  return "";
+}
+
+static char *Read_File(FILE *fp);
+static const char *Trace_File_Path(void);
+static int Write_Common_Matmul_Trace(const char *tree_text,
+				     const char *annotation_text);
+
+static void
+Initialize_Test_Context(void)
+{
+  MEM_Initialize();
+  Set_Error_Tables(Phases, host_errlist);
+  Init_Error_Handler(10);
+  Set_Error_File(NULL);
+  Set_Error_Line(ERROR_LINE_UNKNOWN);
+
+  Initialize_Symbol_Tables(FALSE);
+  New_Scope(GLOBAL_SYMTAB, Malloc_Mem_Pool, FALSE);
+}
+
+static WN *
+Create_Common_Matmul_Test_Tree(WN **dsl_marker_out)
+{
+  WN *block = WN_CreateBlock();
+  WN *tensor_one_kid0 =
+    DSL_WN_Create_Tensor_Const ("tensor_one_kid0",
+			     "int32",
+			     2,
+			     "[2,2]",
+			     "splat",
+			     "1");
+  WN *tensor_one_kid1 =
+    DSL_WN_Create_Tensor_Const ("tensor_one_kid1",
+			     "int32",
+			     2,
+			     "[2,2]",
+			     "splat",
+			     "1");
+  WN *dsl_marker =
+    DSL_WN_Create_Opcode (DSL_OPCODE_COMMON_MATMUL,
+			1,
+			"kid0=tensor_one_kid0;kid1=tensor_one_kid1;attr.transpose_kid0=false;attr.transpose_kid1=false");
+
+  if (dsl_marker_out != NULL)
+    *dsl_marker_out = dsl_marker;
+
+  WN_INSERT_BlockLast(block, tensor_one_kid0);
+  WN_INSERT_BlockLast(block, tensor_one_kid1);
+  WN_INSERT_BlockLast(block, dsl_marker);
+
+  return block;
+}
+
+static int
+Check_Tensor_One_Annotation(WN *tensor_const, const char *name)
+{
+  DSL_OPCODE_ANNOTATION annotation;
+  int failed = 0;
+
+  if (!DSL_WN_Get_Opcode_Annotation (tensor_const, &annotation)) {
+    fprintf(stderr, "tensor-one marker did not decode\n");
+    return 1;
+  }
+
+  if (annotation.name_len != strlen(DSL_OPCODE_COMMON_TENSOR_CONST) ||
+      strncmp(annotation.name, DSL_OPCODE_COMMON_TENSOR_CONST,
+	      annotation.name_len) != 0) {
+    fprintf(stderr, "decoded DSL opcode name is not common.tensor_const\n");
+    failed = 1;
+  }
+
+  if (annotation.version != 1) {
+    fprintf(stderr, "decoded tensor_const DSL opcode version is not 1\n");
+    failed = 1;
+  }
+
+  if (strstr(annotation.payload, name) == NULL ||
+      strstr(annotation.payload, "dtype=int32") == NULL ||
+      strstr(annotation.payload, "rank=2") == NULL ||
+      strstr(annotation.payload, "shape=[2,2]") == NULL ||
+      strstr(annotation.payload, "value_kind=splat") == NULL ||
+      strstr(annotation.payload, "value=1") == NULL) {
+    fprintf(stderr, "decoded tensor-one payload changed\n");
+    failed = 1;
+  }
+
+  return failed;
+}
+
+static int
+Check_Common_Matmul_Annotation(WN *dsl_marker)
+{
+  DSL_OPCODE_ANNOTATION annotation;
+  int failed = 0;
+
+  if (!DSL_WN_Get_Opcode_Annotation (dsl_marker, &annotation)) {
+    fprintf(stderr, "common.matmul marker was not decoded as a DSL opcode\n");
+    return 1;
+  }
+
+  if (annotation.name_len != strlen(DSL_OPCODE_COMMON_MATMUL) ||
+      strncmp(annotation.name, DSL_OPCODE_COMMON_MATMUL,
+	      annotation.name_len) != 0) {
+    fprintf(stderr, "decoded DSL opcode name is not common.matmul\n");
+    failed = 1;
+  }
+
+  if (annotation.version != 1) {
+    fprintf(stderr, "decoded common.matmul DSL opcode version is not 1\n");
+    failed = 1;
+  }
+
+  if (strcmp(annotation.payload,
+	     "kid0=tensor_one_kid0;kid1=tensor_one_kid1;attr.transpose_kid0=false;attr.transpose_kid1=false") != 0) {
+    fprintf(stderr, "decoded common.matmul DSL opcode payload changed\n");
+    failed = 1;
+  }
+
+  return failed;
+}
+
+static char *
+Read_File(FILE *fp)
+{
+  long size;
+  char *buffer;
+
+  fflush(fp);
+  if (fseek(fp, 0, SEEK_END) != 0)
+    return NULL;
+  size = ftell(fp);
+  if (size < 0)
+    return NULL;
+  if (fseek(fp, 0, SEEK_SET) != 0)
+    return NULL;
+
+  buffer = (char *) malloc((size_t) size + 1);
+  if (buffer == NULL)
+    return NULL;
+
+  if (size != 0 &&
+      fread(buffer, 1, (size_t) size, fp) != (size_t) size) {
+    free(buffer);
+    return NULL;
+  }
+  buffer[size] = '\0';
+  return buffer;
+}
+
+static const char *
+Trace_File_Path(void)
+{
+  static char path[4096];
+  const char *source = __FILE__;
+  const char *slash = strrchr(source, '/');
+
+  if (slash == NULL) {
+    snprintf(path, sizeof(path), "dsl_common_matmul_print_test.trace");
+  } else {
+    size_t dir_len = (size_t) (slash - source);
+    snprintf(path, sizeof(path), "%.*s/dsl_common_matmul_print_test.trace",
+	     (int) dir_len, source);
+  }
+
+  return path;
+}
+
+static int
+Write_Common_Matmul_Trace(const char *tree_text, const char *annotation_text)
+{
+  const char *trace_path = Trace_File_Path();
+  FILE *trace = fopen(trace_path, "w");
+
+  if (trace == NULL) {
+    perror(trace_path);
+    return 1;
+  }
+
+  fprintf(trace, "dsl_common_matmul_print_test trace\n");
+  fprintf(trace, "created_operator=%s\n", DSL_OPCODE_COMMON_MATMUL);
+  fprintf(trace, "\n[fdump_tree]\n");
+  fputs(tree_text, trace);
+  fprintf(trace, "\n[dsl_annotation]\n");
+  fputs(annotation_text, trace);
+
+  if (fclose(trace) != 0) {
+    perror(trace_path);
+    return 1;
+  }
+
+  return 0;
+}
+
+int
+main(void)
+{
+  Initialize_Test_Context();
+
+  WN *dsl_marker = NULL;
+  WN *tree = Create_Common_Matmul_Test_Tree(&dsl_marker);
+  FILE *dump = tmpfile();
+  FILE *annotation = tmpfile();
+  char *text;
+  char *annotation_text;
+  int failed = 0;
+
+  if (dump == NULL || annotation == NULL) {
+    perror("tmpfile");
+    return 1;
+  }
+
+  if (!DSL_WN_Has_Opcode (dsl_marker)) {
+    fprintf(stderr, "common.matmul marker was not recognized as a DSL opcode\n");
+    failed = 1;
+  }
+  failed |= Check_Common_Matmul_Annotation(dsl_marker);
+
+  failed |= Check_Tensor_One_Annotation(WN_first(tree),
+					"name=tensor_one_kid0");
+  failed |= Check_Tensor_One_Annotation(WN_next(WN_first(tree)),
+					"name=tensor_one_kid1");
+
+  fdump_tree(dump, tree);
+  text = Read_File(dump);
+  fclose(dump);
+
+  DSL_fprint_opcode_annotation (annotation, dsl_marker);
+  annotation_text = Read_File(annotation);
+  fclose(annotation);
+
+  if (text == NULL || annotation_text == NULL) {
+    fprintf(stderr, "failed to read test output\n");
+    return 1;
+  }
+
+  fputs(text, stdout);
+  fputs(annotation_text, stdout);
+  failed |= Write_Common_Matmul_Trace(text, annotation_text);
+
+  if (strstr(text, "__WHIRL_DSL__:opcode:common.matmul:") == NULL) {
+    fprintf(stderr, "missing common.matmul DSL marker in fdump_tree output\n");
+    failed = 1;
+  }
+
+  if (strstr(text, "__WHIRL_DSL__:opcode:common.tensor_const:v1:") == NULL ||
+      strstr(text, "name=tensor_one_kid0") == NULL ||
+      strstr(text, "name=tensor_one_kid1") == NULL ||
+      strstr(text, "value=1") == NULL) {
+    fprintf(stderr, "missing tensor-one DSL markers in fdump_tree output\n");
+    failed = 1;
+  }
+
+  if (strstr(annotation_text, "dsl_opcode=common.matmul.v1") == NULL) {
+    fprintf(stderr, "missing formatted common.matmul DSL opcode annotation\n");
+    failed = 1;
+  }
+
+  {
+    FILE *trace = fopen(Trace_File_Path(), "r");
+    char *trace_text = trace == NULL ? NULL : Read_File(trace);
+
+    if (trace != NULL)
+      fclose(trace);
+
+    if (trace_text == NULL ||
+	strstr(trace_text, "created_operator=common.matmul") == NULL ||
+	strstr(trace_text, "__WHIRL_DSL__:opcode:common.matmul:") == NULL) {
+      fprintf(stderr, "missing common.matmul creation trace file content\n");
+      failed = 1;
+    }
+
+    free(trace_text);
+  }
+
+  free(text);
+  free(annotation_text);
+  return failed;
+}

--- a/osprey/common/com/tests/dsl_common_matmul_print_test.trace
+++ b/osprey/common/com/tests/dsl_common_matmul_print_test.trace
@@ -1,0 +1,10 @@
+dsl_common_matmul_print_test trace
+created_operator=common.matmul
+
+[fdump_tree]
+__WHIRL_DSL__:opcode:common.tensor_const:v1:name=tensor_one_kid0;dtype=int32;rank=2;shape=[2,2];value_kind=splat;value=1
+__WHIRL_DSL__:opcode:common.tensor_const:v1:name=tensor_one_kid1;dtype=int32;rank=2;shape=[2,2];value_kind=splat;value=1
+__WHIRL_DSL__:opcode:common.matmul:v1:kid0=tensor_one_kid0;kid1=tensor_one_kid1;attr.transpose_kid0=false;attr.transpose_kid1=false
+
+[dsl_annotation]
+dsl_opcode=common.matmul.v1 dsl_payload=kid0=tensor_one_kid0;kid1=tensor_one_kid1;attr.transpose_kid0=false;attr.transpose_kid1=false

--- a/osprey/common/com/wn.cxx
+++ b/osprey/common/com/wn.cxx
@@ -68,6 +68,9 @@
 #endif /* USE_PCH */
 #pragma hdrstop
 #include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "defs.h"
 #include "stab.h"
@@ -2131,6 +2134,269 @@ STR_IDX WN_GetComment (const WN *wn)
 {
 	Is_True(WN_opcode(wn) == OPC_COMMENT, ("Bad opcode in WN_GetComment"));
 	return ST_name_idx(WN_st(wn));
+}
+
+const char *
+WN_DSL_Comment_Prefix (void)
+{
+  return WN_DSL_COMMENT_PREFIX;
+}
+
+WN *
+WN_Create_DSL_Comment (const char *domain, const char *feature,
+		     const char *payload)
+{
+  const char *safe_domain = domain ? domain : "";
+  const char *safe_feature = feature ? feature : "";
+  const char *safe_payload = payload ? payload : "";
+  const size_t len = strlen (WN_DSL_COMMENT_PREFIX) +
+		     strlen (safe_domain) + 1 +
+		     strlen (safe_feature) + 1 +
+		     strlen (safe_payload) + 1;
+  char *comment = new char[len];
+
+  snprintf (comment, len, "%s%s:%s:%s", WN_DSL_COMMENT_PREFIX,
+	   safe_domain, safe_feature, safe_payload);
+  WN *wn = WN_CreateComment (comment);
+  delete [] comment;
+
+  return wn;
+}
+
+WN *
+WN_Create_DSL_Assert (const char *domain, const char *condition,
+		    const char *message)
+{
+  const char *safe_condition = condition ? condition : "";
+  const char *safe_message = message ? message : "";
+  const size_t len = strlen (safe_condition) + 1 +
+		     strlen (safe_message) + 1;
+  char *payload = new char[len];
+
+  snprintf (payload, len, "%s:%s", safe_condition, safe_message);
+  WN *wn = WN_Create_DSL_Comment (domain, "assert", payload);
+  delete [] payload;
+
+  return wn;
+}
+
+BOOL
+WN_Is_DSL_Comment (const WN *wn)
+{
+  if (wn == NULL || WN_opcode(wn) != OPC_COMMENT)
+    return FALSE;
+
+  const char *comment = Index_To_Str (WN_GetComment (wn));
+  return strncmp (comment, WN_DSL_COMMENT_PREFIX,
+		  strlen (WN_DSL_COMMENT_PREFIX)) == 0;
+}
+
+BOOL
+WN_Is_DSL_Assert (const WN *wn)
+{
+  if (!WN_Is_DSL_Comment (wn))
+    return FALSE;
+
+  const char *comment = Index_To_Str (WN_GetComment (wn)) +
+			strlen (WN_DSL_COMMENT_PREFIX);
+  const char *domain_end = strchr (comment, ':');
+  if (domain_end == NULL)
+    return FALSE;
+
+  const char *feature = domain_end + 1;
+  const char *feature_end = strchr (feature, ':');
+  if (feature_end == NULL)
+    return FALSE;
+
+  const char *assert_feature = "assert";
+  const size_t assert_feature_len = strlen (assert_feature);
+  return (size_t)(feature_end - feature) == assert_feature_len &&
+	 strncmp (feature, assert_feature, assert_feature_len) == 0;
+}
+
+const char *
+WN_Get_DSL_Comment_Payload (const WN *wn)
+{
+  if (!WN_Is_DSL_Comment (wn))
+    return NULL;
+
+  const char *payload = Index_To_Str (WN_GetComment (wn)) +
+			strlen (WN_DSL_COMMENT_PREFIX);
+  payload = strchr (payload, ':');
+  if (payload == NULL)
+    return "";
+  payload = strchr (payload + 1, ':');
+  if (payload == NULL)
+    return "";
+
+  return payload + 1;
+}
+
+WN *
+DSL_WN_Create_Opcode (const char *name, UINT32 version, const char *payload)
+{
+  const char *safe_name = name ? name : "";
+  const char *safe_payload = payload ? payload : "";
+  char version_buf[32];
+
+  snprintf (version_buf, sizeof(version_buf), "v%u", version);
+
+  const size_t len = strlen (version_buf) + 1 + strlen (safe_payload) + 1;
+  char *dsl_payload = new char[len];
+  snprintf (dsl_payload, len, "%s:%s", version_buf, safe_payload);
+
+  WN *wn = WN_Create_DSL_Comment ("opcode", safe_name, dsl_payload);
+  delete [] dsl_payload;
+  return wn;
+}
+
+WN *
+DSL_WN_Create_Tensor_Const (const char *value_name,
+			  const char *dtype,
+			  UINT32 rank,
+			  const char *shape,
+			  const char *value_kind,
+			  const char *value)
+{
+  const char *safe_name = value_name ? value_name : "";
+  const char *safe_dtype = dtype ? dtype : "";
+  const char *safe_shape = shape ? shape : "";
+  const char *safe_value_kind = value_kind ? value_kind : "";
+  const char *safe_value = value ? value : "";
+  const size_t len = strlen ("name=;dtype=;rank=;shape=;value_kind=;value=") +
+		     strlen (safe_name) +
+		     strlen (safe_dtype) +
+		     10 +
+		     strlen (safe_shape) +
+		     strlen (safe_value_kind) +
+		     strlen (safe_value) +
+		     1;
+  char *payload = new char[len];
+
+  snprintf (payload, len,
+	   "name=%s;dtype=%s;rank=%u;shape=%s;value_kind=%s;value=%s",
+	   safe_name,
+	   safe_dtype,
+	   rank,
+	   safe_shape,
+	   safe_value_kind,
+	   safe_value);
+  WN *wn = DSL_WN_Create_Opcode (DSL_OPCODE_COMMON_TENSOR_CONST, 1, payload);
+  delete [] payload;
+  return wn;
+}
+
+WN *
+DSL_WN_Create_Zero_Init (const char *value_name, const char *dtype_hint)
+{
+  const char *safe_name = value_name ? value_name : "";
+  const char *safe_dtype = dtype_hint ? dtype_hint : "";
+  const size_t len = strlen ("name=;dtype_hint=;descriptor_state=infer") +
+		     strlen (safe_name) +
+		     strlen (safe_dtype) +
+		     1;
+  char *payload = new char[len];
+
+  snprintf (payload, len,
+	   "name=%s;dtype_hint=%s;descriptor_state=infer",
+	   safe_name,
+	   safe_dtype);
+  WN *wn = DSL_WN_Create_Opcode (DSL_OPCODE_COMMON_ZERO_INIT, 1, payload);
+  delete [] payload;
+  return wn;
+}
+
+WN *
+DSL_WN_Create_Zero_Like (const char *value_name, const char *source_name)
+{
+  const char *safe_name = value_name ? value_name : "";
+  const char *safe_source = source_name ? source_name : "";
+  const size_t len = strlen ("name=;source=;descriptor_state=copy_source") +
+		     strlen (safe_name) +
+		     strlen (safe_source) +
+		     1;
+  char *payload = new char[len];
+
+  snprintf (payload, len,
+	   "name=%s;source=%s;descriptor_state=copy_source",
+	   safe_name,
+	   safe_source);
+  WN *wn = DSL_WN_Create_Opcode (DSL_OPCODE_COMMON_ZERO_LIKE, 1, payload);
+  delete [] payload;
+  return wn;
+}
+
+BOOL
+DSL_WN_Has_Opcode (const WN *wn)
+{
+  if (!WN_Is_DSL_Comment (wn))
+    return FALSE;
+
+  const char *comment = Index_To_Str (WN_GetComment (wn)) +
+			strlen (WN_DSL_COMMENT_PREFIX);
+  const char *domain_end = strchr (comment, ':');
+  if (domain_end == NULL)
+    return FALSE;
+
+  const char *opcode_domain = "opcode";
+  const size_t opcode_domain_len = strlen (opcode_domain);
+  return (size_t)(domain_end - comment) == opcode_domain_len &&
+	 strncmp (comment, opcode_domain, opcode_domain_len) == 0;
+}
+
+BOOL
+DSL_WN_Get_Opcode_Annotation (const WN *wn,
+			      DSL_OPCODE_ANNOTATION *annotation)
+{
+  if (!DSL_WN_Has_Opcode (wn))
+    return FALSE;
+
+  const char *comment = Index_To_Str (WN_GetComment (wn)) +
+			strlen (WN_DSL_COMMENT_PREFIX);
+  const char *name = strchr (comment, ':');
+  if (name == NULL)
+    return FALSE;
+  name++;
+
+  const char *version = strchr (name, ':');
+  if (version == NULL)
+    return FALSE;
+
+  version++;
+  if (version[0] != 'v')
+    return FALSE;
+
+  char *version_end;
+  unsigned long version_value = strtoul (version + 1, &version_end, 10);
+  if (version_end == version + 1)
+    return FALSE;
+  if (*version_end != ':' && *version_end != '\0')
+    return FALSE;
+
+  if (annotation != NULL) {
+    annotation->name = name;
+    annotation->name_len = (UINT32)((version - 1) - name);
+    annotation->version = (UINT32)version_value;
+    annotation->payload = *version_end == ':' ? version_end + 1 : "";
+  }
+
+  return TRUE;
+}
+
+void
+DSL_fprint_opcode_annotation (FILE *f, const WN *wn)
+{
+  DSL_OPCODE_ANNOTATION annotation;
+
+  if (f == NULL || !DSL_WN_Get_Opcode_Annotation (wn, &annotation))
+    return;
+
+  fprintf (f, " # dsl_opcode=%.*s.v%u",
+	  (int)annotation.name_len,
+	  annotation.name,
+	  annotation.version);
+  if (annotation.payload[0] != '\0')
+    fprintf (f, " dsl_payload=%s", annotation.payload);
 }
 
 WN *WN_CopyNode (const WN* src_wn)

--- a/osprey/common/com/wn.h
+++ b/osprey/common/com/wn.h
@@ -1034,6 +1034,69 @@ WN_CreateRcomma (OPCODE opc, WN *value, WN *block) {
 extern WN *WN_CreateComment (const char *s);	/* create comment node */
 extern STR_IDX WN_GetComment (const WN *wn);  /* get string idx from comment node */
 
+/*
+ * Very-high-level WHIRL extension marker.
+ *
+ * DSL and AI-compiler front ends can use this comment format to attach
+ * structured intent to otherwise standard WHIRL.  Older phases continue to
+ * treat the node as OPR_COMMENT, while DSL-aware phases can recognize the
+ * marker and lower it deliberately before canonical optimization.
+ */
+#define WN_DSL_COMMENT_PREFIX "__WHIRL_DSL__:"
+#define DSL_OPCODE_COMMON_ADD "common.add"
+#define DSL_OPCODE_COMMON_MATMUL "common.matmul"
+#define DSL_OPCODE_COMMON_TENSOR_CONST "common.tensor_const"
+#define DSL_OPCODE_COMMON_ZERO_INIT "common.zero_init"
+#define DSL_OPCODE_COMMON_ZERO_LIKE "common.zero_like"
+typedef struct {
+  const char *name;
+  UINT32 name_len;
+  UINT32 version;
+  const char *payload;
+} DSL_OPCODE_ANNOTATION;
+
+extern const char *WN_DSL_Comment_Prefix (void);
+extern WN *WN_Create_DSL_Comment (const char *domain,
+				  const char *feature,
+				  const char *payload);
+extern WN *WN_Create_DSL_Assert (const char *domain,
+				 const char *condition,
+				 const char *message);
+extern BOOL WN_Is_DSL_Comment (const WN *wn);
+extern BOOL WN_Is_DSL_Assert (const WN *wn);
+extern const char *WN_Get_DSL_Comment_Payload (const WN *wn);
+extern WN *DSL_WN_Create_Opcode (const char *name,
+				 UINT32 version,
+				 const char *payload);
+/*
+ * Create a fully specified tensor constant.  Use this when dtype, rank, shape,
+ * and value are known at IR construction time.
+ */
+extern WN *DSL_WN_Create_Tensor_Const (const char *value_name,
+				     const char *dtype,
+				     UINT32 rank,
+				     const char *shape,
+				     const char *value_kind,
+				     const char *value);
+/*
+ * Create a zero initializer whose tensor descriptor may be completed later from
+ * assignment target or use-site context.  Do not use this when rank and shape
+ * are already known; prefer DSL_WN_Create_Tensor_Const for that case.
+ */
+extern WN *DSL_WN_Create_Zero_Init (const char *value_name,
+				  const char *dtype_hint);
+/*
+ * Create a zero tensor with dtype/rank/shape copied from another tensor value.
+ * Use this when the initializer is explicitly "zero with the same descriptor as
+ * source_name".
+ */
+extern WN *DSL_WN_Create_Zero_Like (const char *value_name,
+				  const char *source_name);
+extern BOOL DSL_WN_Has_Opcode (const WN *wn);
+extern BOOL DSL_WN_Get_Opcode_Annotation (const WN *wn,
+					  DSL_OPCODE_ANNOTATION *annotation);
+extern void DSL_fprint_opcode_annotation (FILE *f, const WN *wn);
+
 extern WN *WN_CreateAsm_Stmt (INT16 kid_count, char *asm_string);
 
 extern WN *WN_CreateAsm_Input (char *constraint, UINT32 opnd_num, WN *opnd_expr);
@@ -1564,6 +1627,3 @@ extern WN* WN_CreateFork(INT32 label_number, BOOL major);
 extern BOOL WN_Intrinsic_OP_Slave(WN * wn);
 #endif // TARG_SL
 #endif /* wn_INCLUDED */
-
-
-


### PR DESCRIPTION
## Summary

This change adds the first WHIRL/DSL common infrastructure slice: tensor descriptor side tables, binary IR persistence, text dumping, DSL opcode markers, and focused tests for `common.add` and `common.matmul`.

## Source Changes

### `wn.h` / `wn.cxx`

- Add DSL WHIRL marker helpers using standard `OPR_COMMENT` nodes with the prefix `__WHIRL_DSL__:`.
- Add common substrate opcode names:
  - `common.add`
  - `common.matmul`
  - `common.tensor_const`
  - `common.zero_init`
  - `common.zero_like`
- Add APIs for creating and decoding DSL opcode annotations:
  - `WN_Create_DSL_Comment`
  - `WN_Create_DSL_Assert`
  - `DSL_WN_Create_Opcode`
  - `DSL_WN_Create_Tensor_Const`
  - `DSL_WN_Create_Zero_Init`
  - `DSL_WN_Create_Zero_Like`
  - `DSL_WN_Has_Opcode`
  - `DSL_WN_Get_Opcode_Annotation`
  - `DSL_fprint_opcode_annotation`
- Preserve backward compatibility because the underlying WHIRL node remains a normal comment node unless a DSL-aware pass interprets it.

### `symtab.h` / `symtab.cxx`

- Add segmented side tables for tensor DSL extensions:
  - `Ty_tensor_extensions`
  - `St_tensor_metadata`
  - `Tensor_dsl_kv_table`
- Add tensor extension APIs:
  - `TY_Create_Tensor_Extension_Type`
  - `TY_Mark_Tensor_Extension`
  - `TY_is_tensor_extension`
  - `TY_Get_Tensor_Extension_Info`
  - `TY_tensor_element_ty`
  - `TY_tensor_rank`
- Clarify the semantic split:
  - `TY_tensor_*attribute*` APIs complete tensor semantic state.
  - `ST_tensor_*metadata*` APIs carry compiler context such as source layer name, diagnostics, pass ownership, lowering hints, and profiling.
  - Compatibility wrappers keep older metadata/attribute naming usable temporarily.
- Add `Print_tensor_dsl_symtab()` and hook it into `Print_global_symtab()` so `ir_b2a -st`-style dumps can expose the new tables.

### `symtab_defs.h`

- Extend global symtab binary table headers with:
  - `SHDR_TY_TENSOR_EXT`
  - `SHDR_ST_TENSOR_METADATA`
  - `SHDR_TENSOR_DSL_KV`
- Increase `GLOBAL_SYMTAB_TABLES` from 13 to 16.
- Preserve `GLOBAL_SYMTAB_TABLES_LEGACY` so older WHIRL binary files remain readable.

### `ir_bcom.cxx` / `ir_bread.cxx`

- Write the new tensor DSL side tables into the global symbol table section of binary WHIRL files.
- Read both legacy 13-table and new 16-table global symtab layouts.
- Load tensor extension, symbol metadata, and DSL key-value tables when present.

### `symtab_access.h`

- Fix a pre-existing return-type warning in `TY_register_parm()` by adding a default `return 0;`.

## Tests

Adds focused smoke tests under `osprey/common/com/tests`:

- `dsl_common_add_print_test.cxx`
- `dsl_common_matmul_print_test.cxx`

The add test creates:

- two rank-2 `int32` tensor constants: zero and one
- a `common.add` DSL opcode using `kid0` and `kid1`
- zero initializer / zero-like operators
- tensor type attributes and symbol metadata
- a standard WHIRL ADD as comparison

The matmul test creates:

- two rank-2 `int32` tensor-one constants
- a `common.matmul` DSL opcode using `kid0` and `kid1`
- transpose attributes as static opcode attributes

Both tests verify that:

- DSL opcode markers decode correctly.
- `fdump_tree` prints the DSL markers through the normal WHIRL print path.
- formatted opcode annotations are emitted.
- trace files are generated in the same directory.

Trace files added:

- `dsl_common_add_print_test.trace`
- `dsl_common_matmul_print_test.trace`