### PR TITLE
Fix WSSA iterator return warnings

### DIFF
--- a/osprey/be/com/wssa_core.h
+++ b/osprey/be/com/wssa_core.h
@@ -282,6 +282,7 @@ public:
     _Tnode* cur_node = _mgr->template Get_node<_Tnode::NODE_KIND>(_cur_idx);
     Is_True(cur_node != NULL, ("cur node is NULL"));
     _cur_idx = cur_node->Next();
+    return *this;
   }
   bool operator==(const WSSA_NODE_ITERATOR<_Tmgr, _Tnode>& rit) {
     return (_mgr == rit._mgr) && (_cur_idx == rit._cur_idx);

--- a/osprey/be/com/wssa_mgr.h
+++ b/osprey/be/com/wssa_mgr.h
@@ -570,6 +570,7 @@ public:
     _cur_ver = rit._cur_ver;
     _def_wn = rit._def_wn;
     _def_type = rit._def_type;
+    return *this;
   }
 };
 


### PR DESCRIPTION
## Summary

- return `*this` from `WSSA_NODE_ITERATOR::operator++()` after advancing the
  iterator
- return `*this` from `WSSA_UD_ITERATOR::operator=()` after copying iterator
  state
- remove the corresponding `-Wreturn-type` diagnostics without changing the
  iterator operations or public interfaces

## Validation

- configured a fresh Linux/amd64 torch2whirl/Open64 build from current
  `develop`
- rebuilt the WSSA consumers and linked `ir_b2a`
- confirmed the missing-return diagnostics for `wssa_core.h` and `wssa_mgr.h`
  no longer appear
- ran the native Python `ir_b2a -st` smoke successfully
- `git diff --check` passed
- no tab characters were introduced

## Scope

This PR intentionally addresses only the two previously reviewed iterator
warnings. Other pre-existing diagnostics in `wssa_mgr.cxx`, `targ_sim.cxx`,
`ir_reader.cxx`, and JsonCpp are not changed here.
