### PR TITLE
Canonicalize Tensor TY descriptors for DSL ingestion

### DIFF
--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -34,6 +34,8 @@ static PU_Info *DSL_Builder_PU_Root = NULL;
 static PU_Info *DSL_Builder_PU_Last = NULL;
 static UINT32 DSL_Builder_Result_Number = 0;
 static DST_INFO_IDX DSL_Builder_CU_DST = DST_INVALID_INIT;
+static std::vector<std::string> DSL_builder_source_files;
+static std::vector<std::string> DSL_builder_source_directories;
 
 typedef struct {
     WN *assignment;
@@ -1014,7 +1016,8 @@ DSL_Builder_Attach_Tensor_Descriptor
         (TY_IDX ty,
          const DSL_BUILDER_TENSOR_DESCRIPTOR *descriptor)
 {
-    if (descriptor == NULL || !TY_is_tensor_extension (ty))
+    if (descriptor == NULL || !TY_is_tensor_extension (ty) ||
+        TY_tensor_is_canonical(ty))
         return FALSE;
 
     DSL_Builder_Bind_Attribute_If_Present
@@ -1049,6 +1052,86 @@ DSL_Builder_Attach_Tensor_Descriptor
         (ty, TY_TENSOR_SCHEMA_LINEAGE, descriptor->lineage.lineage);
 
     return TRUE;
+}
+
+TY_IDX
+DSL_Builder_Intern_Tensor_Type
+        (const char *name,
+         TY_IDX element_ty,
+         const DSL_BUILDER_TENSOR_DESCRIPTOR *descriptor)
+{
+    DSL_BUILDER_TENSOR_DESCRIPTOR type_descriptor;
+    TY_IDX tensor_ty;
+
+    if (descriptor == NULL || TY_IDX_index(element_ty) == 0 ||
+        descriptor->type_core.kind == NULL ||
+        descriptor->type_core.kind[0] == '\0' ||
+        descriptor->type_core.dtype == NULL ||
+        descriptor->type_core.dtype[0] == '\0' ||
+        descriptor->type_core.rank < 0 ||
+        descriptor->type_core.logical_shape == NULL ||
+        descriptor->type_core.logical_shape[0] == '\0')
+        return TY_IDX_ZERO;
+
+    type_descriptor = *descriptor;
+    type_descriptor.representation.runtime_state = NULL;
+    type_descriptor.lineage.lineage = NULL;
+    tensor_ty = DSL_Builder_Create_Tensor_Type_Core
+                    (name, element_ty, &type_descriptor.type_core);
+    if (!DSL_Builder_Attach_Tensor_Descriptor(tensor_ty, &type_descriptor) ||
+        !TY_tensor_seal(tensor_ty))
+        return TY_IDX_ZERO;
+
+    for (UINT32 index = 1; index < Ty_tab.Size(); ++index) {
+        TY_IDX candidate = TY_IDX_ZERO;
+        Set_TY_IDX_index(candidate, index);
+        if (candidate != tensor_ty && TY_is_tensor_extension(candidate) &&
+            TY_tensor_is_canonical(candidate) &&
+            TY_are_equivalent(candidate, tensor_ty, TY_EQUIV_IGNORE_NAMES))
+            return candidate;
+    }
+    return tensor_ty;
+}
+
+BOOL
+DSL_Builder_Get_Tensor_Descriptor
+        (TY_IDX ty,
+         DSL_BUILDER_TENSOR_DESCRIPTOR *descriptor)
+{
+    if (descriptor == NULL || !TY_is_tensor_extension(ty))
+        return FALSE;
+
+    memset(descriptor, 0, sizeof(*descriptor));
+    descriptor->type_core.kind =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_KIND);
+    descriptor->type_core.dtype =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_DTYPE);
+    descriptor->type_core.rank = TY_tensor_rank(ty);
+    descriptor->type_core.logical_shape =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_SHAPE);
+    descriptor->traits.traits =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_TRAITS);
+    descriptor->representation.layout =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_LAYOUT);
+    descriptor->representation.sharding =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_SHARDING);
+    descriptor->representation.placement =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_PLACEMENT);
+    descriptor->representation.memory =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_MEMORY);
+    descriptor->representation.quantization =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_QUANTIZATION);
+    descriptor->representation.runtime_state =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_RUNTIME_STATE);
+    descriptor->lineage.lineage =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_LINEAGE);
+    return TRUE;
+}
+
+BOOL
+DSL_Builder_Tensor_Type_Is_Canonical (TY_IDX ty)
+{
+    return TY_tensor_is_canonical(ty);
 }
 
 ST_IDX
@@ -1494,6 +1577,49 @@ DSL_Builder_Create_Operator
     return wn;
 }
 
+DSL_BUILDER_OPERATOR
+DSL_Builder_Create_Operator_With_Result
+        (DSL_OPCODE_ID opcode_id,
+         UINT16 version,
+         DSL_BUILDER_VALUE *kids,
+         UINT32 kid_count,
+         const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count,
+         const char *result_name,
+         TY_IDX result_ty)
+{
+    DSL_OPCODE_INFO info;
+    DSL_OPERATOR dsl_operator;
+    char *payload;
+    DSL_BUILDER_OPERATOR result;
+
+    if (!DSL_Opcode_Get_Info(opcode_id, &info) ||
+        result_name == NULL || result_name[0] == '\0' ||
+        !DSL_Builder_Tensor_Type_Is_Canonical(result_ty) ||
+        (kid_count != 0 && kids == NULL) ||
+        (attr_count != 0 && attrs == NULL) ||
+        (info.nkids >= 0 && (UINT32)info.nkids != kid_count))
+        return NULL;
+
+    for (UINT32 i = 0; i < attr_count; ++i) {
+        if (attrs[i].name == NULL || attrs[i].name[0] == '\0')
+            return NULL;
+    }
+
+    dsl_operator = DSL_Operator_Find(info.name, strlen(info.name), version);
+    if (dsl_operator == OPR_DSLUNKNOWN)
+        return NULL;
+
+    payload = DSL_Builder_Format_Operator_Payload
+                  (kids, kid_count, attrs, attr_count);
+    result = DSL_Builder_Create_Native_Value
+                 (dsl_operator, version, payload, kids, kid_count, attrs,
+                  attr_count, result_name, result_ty,
+                  DSL_IR_VALUE_OPERATOR_RESULT);
+    delete [] payload;
+    return result;
+}
+
 BOOL
 DSL_Builder_Attach_Contract (DSL_BUILDER_OPERATOR wn,
                              DSL_CONTRACT_ID contract_id)
@@ -1521,6 +1647,61 @@ DSL_Builder_Attach_Metadata
     }
 
     return TRUE;
+}
+
+BOOL
+DSL_Builder_Attach_Value_Metadata
+        (DSL_BUILDER_VALUE value,
+         const DSL_BUILDER_COMPILER_METADATA *metadata,
+         UINT32 metadata_count)
+{
+    DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
+
+    return record != NULL &&
+           DSL_Builder_Attach_Metadata
+               (record->result_st, metadata, metadata_count);
+}
+
+BOOL
+DSL_Builder_Attach_Value_Lineage
+        (DSL_BUILDER_VALUE value,
+         const char *lineage)
+{
+    DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
+
+    if (record == NULL || lineage == NULL || lineage[0] == '\0')
+        return FALSE;
+    ST_tensor_bind_attribute
+        (record->result_st,
+         TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_LINEAGE), lineage);
+    return TRUE;
+}
+
+TY_IDX
+DSL_Builder_Get_Value_Type (DSL_BUILDER_VALUE value)
+{
+    DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
+    return record == NULL ? TY_IDX_ZERO : record->result_ty;
+}
+
+ST_IDX
+DSL_Builder_Get_Value_Result_Symbol (DSL_BUILDER_VALUE value)
+{
+    DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
+    return record == NULL ? ST_IDX_ZERO : record->result_st;
+}
+
+BOOL
+DSL_Builder_Begin_Program (void)
+{
+    DSL_Builder_Reset_Program();
+    return TRUE;
+}
+
+void
+DSL_Builder_Abort_Program (void)
+{
+    DSL_Builder_Reset_Program();
 }
 
 DSL_BUILDER_PROGRAM_UNIT
@@ -1613,6 +1794,126 @@ DSL_Builder_Create_Minimal_PU (const char *name)
     DSL_Builder_PU_Last = pu_info;
 
     return pu_info;
+}
+
+UINT32
+DSL_Builder_Register_Source_File
+        (DSL_BUILDER_PROGRAM_UNIT pu,
+         const char *path)
+{
+    std::string full_path;
+    std::string directory;
+    std::string file_name;
+    std::string::size_type separator;
+    UINT32 directory_id = 0;
+
+    if (DSL_Builder_PU_Body(pu) == NULL || path == NULL || path[0] == '\0')
+        return 0;
+
+    full_path = path;
+    for (UINT32 i = 0; i < DSL_builder_source_files.size(); ++i) {
+        if (DSL_builder_source_files[i] == full_path)
+            return i + 1;
+    }
+    if (DSL_builder_source_files.size() >= 65535)
+        return 0;
+
+    separator = full_path.rfind('/');
+    if (separator == std::string::npos) {
+        directory = ".";
+        file_name = full_path;
+    } else {
+        directory = separator == 0 ? "/" : full_path.substr(0, separator);
+        file_name = full_path.substr(separator + 1);
+    }
+    if (file_name.empty())
+        return 0;
+
+    for (UINT32 i = 0; i < DSL_builder_source_directories.size(); ++i) {
+        if (DSL_builder_source_directories[i] == directory) {
+            directory_id = i + 1;
+            break;
+        }
+    }
+    if (directory_id == 0) {
+        if (DSL_builder_source_directories.size() >= 65535)
+            return 0;
+        DST_mk_include_dir((char *)directory.c_str());
+        DSL_builder_source_directories.push_back(directory);
+        directory_id = DSL_builder_source_directories.size();
+    }
+
+    DST_mk_file_name((char *)file_name.c_str(), directory_id, 0, 0);
+    DSL_builder_source_files.push_back(full_path);
+    return DSL_builder_source_files.size();
+}
+
+BOOL
+DSL_Builder_Set_Value_Source_Position
+        (DSL_BUILDER_VALUE value,
+         const DSL_BUILDER_SOURCE_POSITION *source_position)
+{
+    DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
+    USRCPOS position;
+
+    if (record == NULL || source_position == NULL ||
+        source_position->file_id == 0 ||
+        source_position->file_id > DSL_builder_source_files.size() ||
+        source_position->line < 0 || source_position->column > 4095)
+        return FALSE;
+
+    USRCPOS_clear(position);
+    USRCPOS_filenum(position) = source_position->file_id;
+    USRCPOS_linenum(position) = source_position->line;
+    USRCPOS_column(position) = source_position->column;
+    USRCPOS_stmt_begin(position) = source_position->statement_begin != 0;
+    USRCPOS_bb_begin(position) = source_position->basic_block_begin != 0;
+    WN_Set_Linenum(record->assignment, USRCPOS_srcpos(position));
+    return TRUE;
+}
+
+BOOL
+DSL_Builder_Verify_Program (DSL_BUILDER_VERIFY_RESULT *result)
+{
+    DSL_GATEKEEPER_RESULT gatekeeper_result;
+    FILE *diagnostic = NULL;
+    char *buffer = result == NULL ? NULL : result->diagnostic;
+    UINT32 capacity = result == NULL ? 0 : result->diagnostic_capacity;
+
+    if (buffer != NULL && capacity != 0) {
+        buffer[0] = '\0';
+        diagnostic = tmpfile();
+    }
+
+    if (DSL_Builder_PU_Root == NULL) {
+        if (buffer != NULL && capacity != 0)
+            snprintf(buffer, capacity,
+                     "DSL builder verification error: no program unit");
+        if (result != NULL) {
+            result->native_node_count = 0;
+            result->result_symbol_count = 0;
+            result->error_count = 1;
+        }
+        if (diagnostic != NULL)
+            fclose(diagnostic);
+        return FALSE;
+    }
+
+    BOOL valid = DSL_Gatekeeper_Verify_Program
+                     (DSL_Builder_PU_Root, diagnostic, &gatekeeper_result);
+    if (diagnostic != NULL) {
+        rewind(diagnostic);
+        size_t count = fread(buffer, 1, capacity - 1, diagnostic);
+        buffer[count] = '\0';
+        fclose(diagnostic);
+    }
+
+    if (result != NULL) {
+        result->native_node_count = gatekeeper_result.native_node_count;
+        result->result_symbol_count = gatekeeper_result.result_symbol_count;
+        result->error_count = gatekeeper_result.error_count;
+    }
+    return valid;
 }
 
 BOOL

--- a/osprey/common/com/dsl_builder.h
+++ b/osprey/common/com/dsl_builder.h
@@ -82,6 +82,22 @@ typedef struct {
 } DSL_BUILDER_MAPPED_IMAGE_REQUEST;
 
 typedef struct {
+    UINT32 file_id;
+    INT32 line;
+    UINT16 column;
+    UINT8 statement_begin;
+    UINT8 basic_block_begin;
+} DSL_BUILDER_SOURCE_POSITION;
+
+typedef struct {
+    UINT32 native_node_count;
+    UINT32 result_symbol_count;
+    UINT32 error_count;
+    char *diagnostic;
+    UINT32 diagnostic_capacity;
+} DSL_BUILDER_VERIFY_RESULT;
+
+typedef struct {
     const char *storage_format;
     const char *side_file;
     const char *tensor_key;
@@ -106,6 +122,14 @@ extern TY_IDX DSL_Builder_Create_Tensor_Type_Core
 extern BOOL DSL_Builder_Attach_Tensor_Descriptor
                                 (TY_IDX ty,
                                  const DSL_BUILDER_TENSOR_DESCRIPTOR *descriptor);
+extern TY_IDX DSL_Builder_Intern_Tensor_Type
+                                (const char *name,
+                                 TY_IDX element_ty,
+                                 const DSL_BUILDER_TENSOR_DESCRIPTOR *descriptor);
+extern BOOL DSL_Builder_Get_Tensor_Descriptor
+                                (TY_IDX ty,
+                                 DSL_BUILDER_TENSOR_DESCRIPTOR *descriptor);
+extern BOOL DSL_Builder_Tensor_Type_Is_Canonical (TY_IDX ty);
 extern ST_IDX DSL_Builder_Create_Symbol
                                 (const char *name,
                                  TY_IDX ty,
@@ -143,6 +167,15 @@ extern DSL_BUILDER_OPERATOR DSL_Builder_Create_Operator
                                  UINT32 kid_count,
                                  const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
                                  UINT32 attr_count);
+extern DSL_BUILDER_OPERATOR DSL_Builder_Create_Operator_With_Result
+                                (DSL_OPCODE_ID opcode_id,
+                                 UINT16 version,
+                                 DSL_BUILDER_VALUE *kids,
+                                 UINT32 kid_count,
+                                 const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+                                 UINT32 attr_count,
+                                 const char *result_name,
+                                 TY_IDX result_ty);
 extern BOOL DSL_Builder_Attach_Contract
                                 (DSL_BUILDER_OPERATOR wn,
                                  DSL_CONTRACT_ID contract_id);
@@ -150,8 +183,28 @@ extern BOOL DSL_Builder_Attach_Metadata
                                 (ST_IDX st,
                                  const DSL_BUILDER_COMPILER_METADATA *metadata,
                                  UINT32 metadata_count);
+extern BOOL DSL_Builder_Attach_Value_Metadata
+                                (DSL_BUILDER_VALUE value,
+                                 const DSL_BUILDER_COMPILER_METADATA *metadata,
+                                 UINT32 metadata_count);
+extern BOOL DSL_Builder_Attach_Value_Lineage
+                                (DSL_BUILDER_VALUE value,
+                                 const char *lineage);
+extern TY_IDX DSL_Builder_Get_Value_Type (DSL_BUILDER_VALUE value);
+extern ST_IDX DSL_Builder_Get_Value_Result_Symbol (DSL_BUILDER_VALUE value);
+extern BOOL DSL_Builder_Begin_Program (void);
+extern void DSL_Builder_Abort_Program (void);
 extern DSL_BUILDER_PROGRAM_UNIT DSL_Builder_Create_Minimal_PU
                                 (const char *name);
+extern UINT32 DSL_Builder_Register_Source_File
+                                (DSL_BUILDER_PROGRAM_UNIT pu,
+                                 const char *path);
+extern BOOL DSL_Builder_Set_Value_Source_Position
+                                (DSL_BUILDER_VALUE value,
+                                 const DSL_BUILDER_SOURCE_POSITION
+                                     *source_position);
+extern BOOL DSL_Builder_Verify_Program
+                                (DSL_BUILDER_VERIFY_RESULT *result);
 /*
  * Formal VHO DSL value representation.
  *

--- a/osprey/common/com/symtab.cxx
+++ b/osprey/common/com/symtab.cxx
@@ -209,6 +209,8 @@ TY_tensor_schema_key_name (TY_TENSOR_SCHEMA_KEY key)
         return "lowering_hint";
     case TY_TENSOR_SCHEMA_NO_ALIAS:
         return "no_alias";
+    case TY_TENSOR_SCHEMA_CANONICAL:
+        return "__canonical_tensor_descriptor";
     case TY_TENSOR_SCHEMA_UNKNOWN:
     default:
         return "";
@@ -346,6 +348,56 @@ Tensor_KV_At (UINT32 head, UINT32 ordinal, const char **key,
     }
 
     return FALSE;
+}
+
+static BOOL
+Tensor_KV_Is_Type_Identity_Key (const char *key)
+{
+    return strcmp(key,
+                  TY_tensor_schema_key_name
+                      (TY_TENSOR_SCHEMA_RUNTIME_STATE)) != 0 &&
+           strcmp(key,
+                  TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_LINEAGE)) != 0;
+}
+
+static UINT32
+Tensor_KV_Type_Identity_Count (UINT32 head)
+{
+    UINT32 count = 0;
+
+    for (UINT32 handle = head; handle != 0;
+         handle = Tensor_dsl_kv_table[handle - 1].next) {
+        const TY_DSL_KV &entry = Tensor_dsl_kv_table[handle - 1];
+        if (Tensor_KV_Is_Type_Identity_Key(&Str_Table[entry.key]))
+            ++count;
+    }
+    return count;
+}
+
+static BOOL
+Tensor_KV_Are_Equivalent (UINT32 head1, UINT32 head2)
+{
+    if (Tensor_KV_Type_Identity_Count(head1) !=
+        Tensor_KV_Type_Identity_Count(head2))
+        return FALSE;
+
+    for (UINT32 handle = head1; handle != 0;
+         handle = Tensor_dsl_kv_table[handle - 1].next) {
+        const TY_DSL_KV &entry1 = Tensor_dsl_kv_table[handle - 1];
+        const char *key = &Str_Table[entry1.key];
+        if (!Tensor_KV_Is_Type_Identity_Key(key))
+            continue;
+        const TY_DSL_KV *entry2 = Find_Tensor_KV_Const(head2, key);
+
+        if (entry2 == NULL || entry1.state != entry2->state)
+            return FALSE;
+        if (entry1.state == TY_DSL_BIND_BOUND &&
+            strcmp(&Str_Table[entry1.value],
+                   &Str_Table[entry2->value]) != 0)
+            return FALSE;
+    }
+
+    return TRUE;
 }
 
 static void
@@ -517,6 +569,8 @@ void
 TY_tensor_declare_attribute (TY_IDX ty, const char *key)
 {
     Check_Tensor_Extension (ty);
+    Is_True(!TY_tensor_is_canonical(ty),
+            ("cannot mutate canonical tensor descriptor"));
     TY_TENSOR_EXTENSION_STORE *ext = Find_Tensor_Extension (ty);
     Declare_Tensor_KV (ext->attribute_head, ext->attribute_count, key);
 }
@@ -525,6 +579,8 @@ void
 TY_tensor_bind_attribute (TY_IDX ty, const char *key, const char *value)
 {
     Check_Tensor_Extension (ty);
+    Is_True(!TY_tensor_is_canonical(ty),
+            ("cannot mutate canonical tensor descriptor"));
     TY_TENSOR_EXTENSION_STORE *ext = Find_Tensor_Extension (ty);
     Bind_Tensor_KV (ext->attribute_head, ext->attribute_count, key, value);
 }
@@ -582,6 +638,45 @@ TY_tensor_attribute_at (TY_IDX ty, UINT32 ordinal, const char **key,
     TY_TENSOR_EXTENSION_STORE *ext = Find_Tensor_Extension (ty);
     return ext == NULL ? FALSE :
         Tensor_KV_At (ext->attribute_head, ordinal, key, value, state);
+}
+
+BOOL
+TY_tensor_attributes_are_equivalent (TY_IDX ty1, TY_IDX ty2)
+{
+    TY_TENSOR_EXTENSION_STORE *ext1 = Find_Tensor_Extension(ty1);
+    TY_TENSOR_EXTENSION_STORE *ext2 = Find_Tensor_Extension(ty2);
+
+    return ext1 != NULL && ext2 != NULL &&
+           Tensor_KV_Are_Equivalent(ext1->attribute_head,
+                                    ext2->attribute_head);
+}
+
+BOOL
+TY_tensor_is_canonical (TY_IDX ty)
+{
+    TY_TENSOR_EXTENSION_STORE *ext = Find_Tensor_Extension(ty);
+    const char *value;
+
+    if (ext == NULL)
+        return FALSE;
+    value = Tensor_KV_Value
+                (ext->attribute_head,
+                 TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_CANONICAL));
+    return value != NULL && strcmp(value, "true") == 0;
+}
+
+BOOL
+TY_tensor_seal (TY_IDX ty)
+{
+    TY_TENSOR_EXTENSION_STORE *ext = Find_Tensor_Extension(ty);
+
+    if (ext == NULL)
+        return FALSE;
+    if (!TY_tensor_is_canonical(ty))
+        Bind_Tensor_KV
+            (ext->attribute_head, ext->attribute_count,
+             TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_CANONICAL), "true");
+    return TRUE;
 }
 
 UINT32
@@ -1997,7 +2092,7 @@ TY_are_equivalent (TY_IDX ty_id1, TY_IDX ty_id2, UINT32 flags)
             TY_Get_Tensor_Extension_Info (ty_id1, &info1) &&
             TY_Get_Tensor_Extension_Info (ty_id2, &info2) &&
             info1.rank == info2.rank &&
-            info1.attribute_count == info2.attribute_count &&
+            TY_tensor_attributes_are_equivalent(ty_id1, ty_id2) &&
             TY_are_equivalent (info1.element_ty, info2.element_ty, flags);
         }
         break;

--- a/osprey/common/com/symtab.h
+++ b/osprey/common/com/symtab.h
@@ -462,7 +462,8 @@ enum TY_TENSOR_SCHEMA_KEY {
     TY_TENSOR_SCHEMA_LINEAGE,
     TY_TENSOR_SCHEMA_SOURCE_LAYER_NAME,
     TY_TENSOR_SCHEMA_LOWERING_HINT,
-    TY_TENSOR_SCHEMA_NO_ALIAS
+    TY_TENSOR_SCHEMA_NO_ALIAS,
+    TY_TENSOR_SCHEMA_CANONICAL
 };
 
 struct TY_DSL_KV {
@@ -595,6 +596,9 @@ extern BOOL TY_tensor_attribute_at (TY_IDX ty, UINT32 ordinal,
 				   const char **key,
 				   const char **value,
 				   TY_DSL_BIND_STATE *state);
+extern BOOL TY_tensor_attributes_are_equivalent (TY_IDX ty1, TY_IDX ty2);
+extern BOOL TY_tensor_is_canonical (TY_IDX ty);
+extern BOOL TY_tensor_seal (TY_IDX ty);
 extern UINT32 TY_tensor_unbound_required_attribute_count
 				    (TY_IDX ty,
 				     const TY_TENSOR_SCHEMA_KEY *required,

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -29,6 +29,7 @@
 #include "controls.h"
 #include "config_targ_opt.h"
 #include "dwarf_DST_mem.h"
+#include "srcpos.h"
 #include "dsl_builder.h"
 #include "dsl_gatekeeper.h"
 
@@ -131,6 +132,189 @@ Check_Tensor_Type_And_Descriptor(void)
         fprintf(stderr, "builder accepted descriptor for non-tensor type\n");
         failed = 1;
     }
+
+    return failed;
+}
+
+static int
+Check_Upgraded_Ingestion_APIs(void)
+{
+    DSL_BUILDER_TENSOR_DESCRIPTOR descriptor;
+    DSL_BUILDER_TENSOR_DESCRIPTOR different_descriptor;
+    DSL_BUILDER_TENSOR_DESCRIPTOR observed;
+    DSL_BUILDER_OPERATOR_ATTRIBUTE attribute;
+    DSL_BUILDER_COMPILER_METADATA metadata;
+    DSL_BUILDER_SOURCE_POSITION source_position;
+    DSL_BUILDER_VERIFY_RESULT verify_result;
+    DSL_BUILDER_VALUE kids[2];
+    DSL_DOMAIN_ID common_id;
+    DSL_OPCODE_ID add_id;
+    TY_IDX tensor_ty;
+    TY_IDX duplicate_ty;
+    TY_IDX contextual_duplicate_ty;
+    TY_IDX different_ty;
+    DSL_BUILDER_PROGRAM_UNIT pu;
+    DSL_BUILDER_VALUE add;
+    ST_IDX add_st;
+    UINT32 file_id;
+    char diagnostic[1024];
+    USRCPOS observed_position;
+    int failed = 0;
+
+    memset(&descriptor, 0, sizeof(descriptor));
+    descriptor.type_core.kind = "tensor";
+    descriptor.type_core.dtype = "int32";
+    descriptor.type_core.rank = 2;
+    descriptor.type_core.logical_shape = "[2,2]";
+    descriptor.traits.traits = "activation";
+    descriptor.representation.layout = "row_major";
+    descriptor.representation.sharding = "replicated";
+    descriptor.representation.placement = "host";
+    descriptor.representation.memory = "contiguous";
+    descriptor.representation.quantization = "none";
+    descriptor.representation.runtime_state = "static";
+    descriptor.lineage.lineage = "canonical_contract";
+
+    tensor_ty = DSL_Builder_Intern_Tensor_Type
+                    ("canonical_tensor_a", MTYPE_To_TY(MTYPE_I4),
+                     &descriptor);
+    duplicate_ty = DSL_Builder_Intern_Tensor_Type
+                       ("canonical_tensor_b", MTYPE_To_TY(MTYPE_I4),
+                        &descriptor);
+    different_descriptor = descriptor;
+    different_descriptor.representation.runtime_state = "dynamic";
+    different_descriptor.lineage.lineage = "different_value_lineage";
+    contextual_duplicate_ty = DSL_Builder_Intern_Tensor_Type
+                                  ("canonical_tensor_contextual",
+                                   MTYPE_To_TY(MTYPE_I4),
+                                   &different_descriptor);
+    different_descriptor = descriptor;
+    different_descriptor.type_core.logical_shape = "[4,2]";
+    different_ty = DSL_Builder_Intern_Tensor_Type
+                       ("canonical_tensor_c", MTYPE_To_TY(MTYPE_I4),
+                        &different_descriptor);
+
+    if (tensor_ty == TY_IDX_ZERO || duplicate_ty != tensor_ty ||
+        contextual_duplicate_ty != tensor_ty ||
+        different_ty == TY_IDX_ZERO || different_ty == tensor_ty ||
+        !DSL_Builder_Tensor_Type_Is_Canonical(tensor_ty) ||
+        !TY_tensor_attributes_are_equivalent(tensor_ty, duplicate_ty) ||
+        TY_tensor_attributes_are_equivalent(tensor_ty, different_ty)) {
+        fprintf(stderr, "canonical tensor interning contract changed\n");
+        failed = 1;
+    }
+
+    memset(&observed, 0, sizeof(observed));
+    if (!DSL_Builder_Get_Tensor_Descriptor(tensor_ty, &observed) ||
+        observed.type_core.rank != 2 ||
+        observed.type_core.logical_shape == NULL ||
+        strcmp(observed.type_core.logical_shape, "[2,2]") != 0 ||
+        observed.representation.runtime_state != NULL ||
+        observed.lineage.lineage != NULL ||
+        DSL_Builder_Attach_Tensor_Descriptor(tensor_ty, &descriptor)) {
+        fprintf(stderr, "canonical tensor descriptor query changed\n");
+        failed = 1;
+    }
+
+    DSL_Builder_Begin_Program();
+    DSL_Opcode_Register_Common_Substrate();
+    common_id = DSL_Domain_Find("common");
+    add_id = DSL_Opcode_Find(common_id, DSL_OPCODE_COMMON_ADD, 1);
+    pu = DSL_Builder_Create_Minimal_PU("upgraded_ingestion_contract");
+    file_id = DSL_Builder_Register_Source_File(pu, "model.py");
+
+    kids[0] = DSL_Builder_Create_Model_Input("input0", tensor_ty, 0);
+    kids[1] = DSL_Builder_Create_Model_Input("input1", tensor_ty, 1);
+    attribute.name = "attr.broadcast_rule";
+    attribute.value = "none";
+    add = DSL_Builder_Create_Operator_With_Result
+              (add_id, 1, kids, 2, &attribute, 1, "explicit_add", tensor_ty);
+    add_st = DSL_Builder_Get_Value_Result_Symbol(add);
+
+    metadata.name = "source_layer_name";
+    metadata.value = "residual_add";
+    memset(&source_position, 0, sizeof(source_position));
+    source_position.file_id = file_id;
+    source_position.line = 27;
+    source_position.column = 9;
+    source_position.statement_begin = 1;
+
+    if (pu == NULL || file_id == 0 || kids[0] == NULL || kids[1] == NULL ||
+        add == NULL || DSL_Builder_Get_Value_Type(add) != tensor_ty ||
+        ST_IDX_index(add_st) == 0 ||
+        !DSL_Builder_Attach_Value_Metadata(add, &metadata, 1) ||
+        !DSL_Builder_Attach_Value_Lineage(add, "residual_path") ||
+        !DSL_Builder_Set_Value_Source_Position(add, &source_position)) {
+        fprintf(stderr, "upgraded value-oriented builder API failed\n");
+        failed = 1;
+    }
+
+    observed_position.srcpos = WN_Get_Linenum(add);
+    if (USRCPOS_filenum(observed_position) != file_id ||
+        USRCPOS_linenum(observed_position) != 27 ||
+        USRCPOS_column(observed_position) != 9 ||
+        !USRCPOS_stmt_begin(observed_position) ||
+        !ST_tensor_metadata_is_bound(add_st, "source_layer_name") ||
+        strcmp(ST_tensor_metadata(add_st, "source_layer_name"),
+               "residual_add") != 0 ||
+        !ST_tensor_attribute_is_bound
+             (add_st,
+              TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_LINEAGE)) ||
+        strcmp(ST_tensor_attribute
+                   (add_st,
+                    TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_LINEAGE)),
+               "residual_path") != 0) {
+        fprintf(stderr, "value source position or metadata changed\n");
+        failed = 1;
+    }
+
+    if (!DSL_Builder_Append_PU_Value(pu, kids[0]) ||
+        !DSL_Builder_Append_PU_Value(pu, kids[1]) ||
+        !DSL_Builder_Append_PU_Value(pu, add)) {
+        fprintf(stderr, "upgraded program construction failed\n");
+        failed = 1;
+    }
+
+    memset(&verify_result, 0, sizeof(verify_result));
+    verify_result.diagnostic = diagnostic;
+    verify_result.diagnostic_capacity = sizeof(diagnostic);
+    if (!DSL_Builder_Verify_Program(&verify_result) ||
+        verify_result.native_node_count != 3 ||
+        verify_result.result_symbol_count != 3 ||
+        verify_result.error_count != 0 || diagnostic[0] != '\0') {
+        fprintf(stderr, "structured builder verification failed: %s\n",
+                diagnostic);
+        failed = 1;
+    }
+
+    DSL_Builder_Abort_Program();
+    memset(&verify_result, 0, sizeof(verify_result));
+    verify_result.diagnostic = diagnostic;
+    verify_result.diagnostic_capacity = sizeof(diagnostic);
+    if (DSL_Builder_Get_Value_Type(add) != TY_IDX_ZERO ||
+        DSL_Builder_Verify_Program(&verify_result) ||
+        verify_result.error_count != 1 ||
+        strstr(diagnostic, "no program unit") == NULL) {
+        fprintf(stderr, "builder abort did not isolate program state\n");
+        failed = 1;
+    }
+
+    DSL_Builder_Begin_Program();
+    pu = DSL_Builder_Create_Minimal_PU("second_ingestion_contract");
+    kids[0] = DSL_Builder_Create_Model_Input("second_input", tensor_ty, 0);
+    memset(&verify_result, 0, sizeof(verify_result));
+    verify_result.diagnostic = diagnostic;
+    verify_result.diagnostic_capacity = sizeof(diagnostic);
+    if (pu == NULL || kids[0] == NULL ||
+        !DSL_Builder_Append_PU_Value(pu, kids[0]) ||
+        !DSL_Builder_Verify_Program(&verify_result) ||
+        verify_result.native_node_count != 1 ||
+        verify_result.result_symbol_count != 1 ||
+        verify_result.error_count != 0) {
+        fprintf(stderr, "second builder program inherited stale state\n");
+        failed = 1;
+    }
+    DSL_Builder_Abort_Program();
 
     return failed;
 }
@@ -1012,11 +1196,11 @@ Check_Production_Native_Builder(void)
         DSL_Builder_Create_Minimal_PU("gatekeeper_missing_attribute");
     DSL_BUILDER_VALUE bad_kids[2];
     bad_kids[0] = DSL_Builder_Create_Tensor_Constant
-                      ("bad_attr_kid0", tensor_ty, "int32", 2, "[2,2]",
-                       "splat", "1");
+                  ("bad_attr_kid0", tensor_ty, "int32", 2, "[2,2]",
+                   "splat", "1");
     bad_kids[1] = DSL_Builder_Create_Tensor_Constant
-                      ("bad_attr_kid1", tensor_ty, "int32", 2, "[2,2]",
-                       "splat", "1");
+                  ("bad_attr_kid1", tensor_ty, "int32", 2, "[2,2]",
+                   "splat", "1");
     DSL_BUILDER_VALUE bad_matmul = DSL_Builder_Create_Operator
                                        (matmul_id, 1, bad_kids, 2, NULL, 0);
     DSL_Builder_Append_PU_Value(bad_pu, bad_kids[0]);
@@ -1425,6 +1609,8 @@ main(void)
     int failed = 0;
 
     Initialize_Test_Context();
+    if (getenv("OPEN64_DSL_INGESTION_API_ONLY") != NULL)
+        return Check_Upgraded_Ingestion_APIs();
 
     failed |= Check_Tensor_Type_And_Descriptor();
     failed |= Check_Symbol_Metadata();

--- a/osprey/common/com/ttype.cxx
+++ b/osprey/common/com/ttype.cxx
@@ -365,7 +365,7 @@ Equivalent_Types (TY_IDX t1, TY_IDX t2, QUAL_CHECK consider_qualifiers)
 		TY_Get_Tensor_Extension_Info (t1, &info1) &&
 		TY_Get_Tensor_Extension_Info (t2, &info2) &&
 		info1.rank == info2.rank &&
-		info1.attribute_count == info2.attribute_count &&
+                TY_tensor_attributes_are_equivalent (t1, t2) &&
 		Equivalent_Types (info1.element_ty, info2.element_ty,
 				  consider_qualifiers);
 	}


### PR DESCRIPTION
## Summary

- intern complete tensor descriptors as canonical `TY_IDX` values
- exclude runtime state and lineage from tensor type identity
- seal canonical tensor attributes against later mutation
- add value-oriented result, metadata, lifecycle, source-position, and verifier APIs
- extend the native builder contract regression test

## Compatibility

- preserves the existing tensor extension storage and binary WHIRL image layout
- does not add `KIND_TENSOR`, change opcode encoding, or add an ELF section
- keeps runtime state, lineage, and compiler metadata outside Tensor TY equivalence

## Validation

- focused canonical ingestion contract test passed
- C++98 native syntax fixture passed
- DSL physical operator compatibility matrix passed for x86-64, MIPS, SL, Loongson, generic KEY, and baseline layouts
- `git diff --check` and added-line no-tab scan passed