### PR TITLE
Add source-interleaved ir_b2a inspection

### DIFF
--- a/osprey/common/com/ir_reader.cxx
+++ b/osprey/common/com/ir_reader.cxx
@@ -271,6 +271,7 @@ BOOL IR_dump_map_info = FALSE;
 BOOL IR_dump_region = FALSE;
 BOOL IR_DUMPDEP_info = FALSE;
 BOOL IR_dump_line_numbers = TRUE;
+BOOL IR_dump_source = FALSE;
 
 WN_MAP IR_alias_map = WN_MAP_UNDEFINED;
 const struct ALIAS_MANAGER *IR_alias_mgr = NULL;
@@ -709,12 +710,17 @@ print_source (SRCPOS srcpos)
   else if (cur_file->max_line_printed != USRCPOS_linenum(usrcpos)
 	&& USRCPOS_linenum(usrcpos) != 0) 
   {
-    /* 
-     * could be a line before the last LOC;
-     * too hard to print text, but at least print LOC
-     */
-    fprintf (ir_ofile, " LOC %d %d\n", cur_file_index, 
-	USRCPOS_linenum(usrcpos));
+    rewind(cur_file->fileptr);
+    for (i = 0; i < USRCPOS_linenum(usrcpos); i++) {
+      if (fgets(text, sizeof(text), cur_file->fileptr) == NULL)
+        break;
+    }
+    if (i == USRCPOS_linenum(usrcpos))
+      fprintf(ir_ofile, " LOC %d %d %s", cur_file_index, i, text);
+    else
+      fprintf(ir_ofile, " LOC %d %d\n", cur_file_index,
+              USRCPOS_linenum(usrcpos));
+    cur_file->max_line_printed = i;
   }
 }
 
@@ -1444,7 +1450,8 @@ static void ir_put_stmt(WN * wn, INT indent)
       fprintf(ir_ofile, "%*sLOC %d %d\n", indent, "",
 		USRCPOS_filenum(srcpos), USRCPOS_linenum(srcpos));
 #else
-      //print_source(USRCPOS_srcpos(srcpos));
+      if (IR_dump_source)
+        print_source(USRCPOS_srcpos(srcpos));
 #endif
     }
 

--- a/osprey/common/com/ir_reader.h
+++ b/osprey/common/com/ir_reader.h
@@ -108,6 +108,8 @@ extern BOOL IR_dump_map_info;
 extern BOOL IR_dump_region;
 /* whether to dump the line numbers; defaults to FALSE */
 extern BOOL IR_dump_line_numbers;
+/* whether to interleave original source lines; defaults to FALSE */
+extern BOOL IR_dump_source;
 
 /* whether to dump in prefix order or postfix order */
 extern BOOL IR_set_dump_order( BOOL dump_prefix);
@@ -124,4 +126,3 @@ extern void WN_TREE_dump_tree(WN *wn);
 extern void WN_TREE_fdump_tree(FILE *f, WN *wn);
 
 #endif /* ir_reader_INCLUDED */
-

--- a/osprey/ir_tools/README.md
+++ b/osprey/ir_tools/README.md
@@ -127,6 +127,16 @@ We can also dump the `symbol table` of the WHIRL IR:
 ir_b2a -st2 a.O
 ```
 
+Use `-src` with `-st` to interleave available original source lines with the
+WHIRL statements and dump the symbol tables for review:
+
+```shell
+ir_b2a -st -src a.O a.T
+```
+
+The source files must remain accessible at the pathnames recorded in the
+binary WHIRL DST.
+
 ## TODO
 ---
 The document of the following tools is coming.
@@ -134,5 +144,4 @@ The document of the following tools is coming.
 - whirl2mpl
 - ir_size
 - ...
-
 

--- a/osprey/ir_tools/ir_a2b.cxx
+++ b/osprey/ir_tools/ir_a2b.cxx
@@ -359,10 +359,11 @@ usage (char *progname)
   if (a2b) {
       fprintf (stderr, "New symbol table format not supported by ir_a2b (yet)\n");
   } else if (b2a) {
-    fprintf (stderr, "Usage: %s [-st] [-v] [-verify] <Binary IR> [<ASCII IR>]\n",
+    fprintf (stderr, "Usage: %s [-st] [-src] [-v] [-verify] <Binary IR> [<ASCII IR>]\n",
 	     progname);
     fprintf (stderr, "\t(will write to stdout if ascii file not given)\n");
     fprintf (stderr, "\t-st option will also print out the symbol table\n");
+    fprintf (stderr, "\t-src option will interleave available source lines\n");
     fprintf (stderr, "\t-opcodes option will print out opcodes as seen\n");
     fprintf (stderr, "\t-lines option will print out line numbers\n");
     fprintf (stderr, "\t-global_local <.G file> option will use separate global table\n");
@@ -428,6 +429,8 @@ main (INT argc, char *argv[])
 	while (*argv[binarg] == '-') {
 	   if (strncmp(argv[binarg], "-st", 3) == 0) {
 	      stflag = TRUE;
+           } else if (strcmp(argv[binarg], "-src") == 0) {
+              IR_dump_source = TRUE;
 	   } else if (strcmp(argv[binarg], "-fb") == 0) {
 	       fbflag = TRUE;
 	   } else if (strcmp(argv[binarg], "-v") == 0) {


### PR DESCRIPTION
## Summary

- add an opt-in `ir_b2a -src` mode
- interleave original source lines using existing DST and `SRCPOS` information
- support backward source traversal so repeated module bodies remain reviewable
- document the standard `ir_b2a -st -src input.B input.T` workflow

## Compatibility

- ordinary `ir_b2a` output is unchanged unless `-src` is requested
- no binary WHIRL layout, reader, writer, or opcode change
- missing source files fall back to location evidence

## Validation

- rebuilt the amd64 `ir_b2a` tool successfully
- generated `resnet.T` from `resnet.B` with `-st -src`
- verified all 63 DSL result statements have nonzero source positions
- verified source text for CNN operations, residual add, and output return
- `git diff --check` and added-line no-tab scan passed