### PR TITLE
Document the common DSL REGION substrate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ builder should own all WHIRL-specific construction.
    tests in the same staged change.
 2. The binary WHIRL artifact is the frontend boundary. Avoid special in-memory
    bypasses from Python into the compiler pipeline; artifacts should be
-   inspectable with `ir_b2a -st` before combined driver integration.
+   inspectable with `ir_b2a -st -src` before combined driver integration.
 3. Run gatekeeper verification before canonical lowering. Missing tensor
    attributes, invalid operand compatibility, unknown contracts, unsupported
    opcodes, and domain legality failures should be diagnosed before WOPT, LNO,
@@ -141,18 +141,57 @@ builder should own all WHIRL-specific construction.
    equivalence.
 6. Do not add `KIND_TENSOR` or new binary tensor descriptor sections casually.
    First-class tensor type or tensor descriptor binary-section changes must land
-   with printer, `ir_b2a -st`, binary reader, binary writer, ASCII
+   with printer, `ir_b2a -st -src`, binary reader, binary writer, ASCII
    reader/printer plan, verifier, and fallback behavior.
 7. `torch2whirl`, Python bindings, and the native frontend bridge must not
    depend on backend code generation. Backend, runtime, and kernel lowering
    happen after gatekeeper verification.
+
+## Reviewable Test Artifacts
+
+1. Human review of compiler artifacts is part of the development and
+   validation process. Tests that produce meaningful WHIRL evidence should
+   retain the binary `.B` file, `ir_b2a -st -src` output, requested phase `.t`
+   traces, side payloads, and relevant diagnostics after the test exits.
+2. Clean the designated artifact directory at the start of the next run, not
+   at the end of the current run. A completed run must leave its evidence
+   available until it is replaced by a later run.
+3. Docker tests must write reviewable artifacts through an explicit host bind
+   mount. Do not leave the only copy in a container filesystem or a container
+   temporary directory that disappears when Docker exits.
+4. Keep artifact families in clearly named per-test or per-stage directories
+   so one smoke test does not erase another test's evidence.
+5. Failed runs must not leave partial output with the name of a valid `.B`
+   artifact. Preserve failure logs and diagnostics when useful, while keeping
+   artifact publication atomic.
+6. At the end of validation, report the absolute host paths of retained
+   artifacts so reviewers can inspect them directly.
+7. Generated review artifacts are normally local build evidence. Do not add
+   them to Git unless the task explicitly requests checked-in golden files or
+   review fixtures.
+8. When completing a task that produces or validates a compiler trace, include
+   a directly viewable link to the retained trace in the final report. Show a
+   short representative excerpt or summarize the concrete evidence it contains;
+   do not report trace-based validation as complete using only a pass/fail
+   statement.
+9. Use both `-st` and `-src` whenever running `ir_b2a` for validation or human
+   review. Preserve or mount the original source file at the pathname recorded
+   in the binary WHIRL DST so `-src` can interleave source statements with the
+   IR. If the active `ir_b2a` build does not yet support `-src`, treat that as a
+   tooling gap to fix; do not silently omit source cross-reference evidence.
+10. The `ir_b2a` output must use the input `.B` file's stem, for example
+   `ir_b2a -st -src resnet.B resnet.T`. On case-insensitive filesystems where
+   `resnet.T` collides with a driver-produced `resnet.t`, preserve the phase
+   trace under a descriptive non-colliding name such as `resnet.vho.t` before
+   producing `resnet.T`.
 
 ## Near-Term Coding Priorities
 
 1. Stabilize native DSL/common infrastructure before adding Python package
    code.
 2. Add or maintain native tests under `osprey/common/com/tests` for tensor
-   types, tensor constants, `common.add`, `common.matmul`, and `ir_b2a -st`
+   types, tensor constants, `common.add`, `common.matmul`, and
+   `ir_b2a -st -src`
    visibility.
 3. Keep the first builder API narrow. Python-facing bindings should pass opaque
    handles and values; C++ should create real WHIRL objects.

--- a/doc/Open64_Domain_Specific_Compiler_IR_Design.md
+++ b/doc/Open64_Domain_Specific_Compiler_IR_Design.md
@@ -1,0 +1,1958 @@
+---
+marp: true
+theme: default
+paginate: true
+backgroundColor: #ffffff
+---
+# Domain Specific Compiler IR Master Design
+
+This document is an incremental coding plan for introducing a domain-specific
+compiler IR layer on top of WHIRL.  The design should land in stages so the
+compiler remains buildable and each stage has a clear validation point.
+
+## Guiding Model
+
+The DSL IR layer should preserve domain intent without forcing an early WHIRL
+lowering decision.  WHIRL remains the executable IR backbone, while DSL
+extensions add semantic information that later passes can lower to canonical
+WHIRL, runtime calls, target intrinsics, or target-specific machine types.
+This plan is aligned with the Word design document
+`DSC_Master_Design_Doc_v0.10.docx`, especially the Chapter 7 Python
+DSL ingestion architecture, but stages the namespace-heavy architecture
+carefully for the existing Open64 code base.
+
+The current staging model is:
+
+```text
+Python model / DSL
+  -> torch.export / FX / DSC capture graph
+  -> WhirlExportInterpreter
+  -> C++ WHIRL builder extension
+  -> binary very-high-level WHIRL artifact
+  -> first-class domain/common operators
+  -> TensorDescriptorIR-completing attributes and compiler metadata
+  -> VHO-adjacent DSL lowering
+  -> canonical High/Mid/Low WHIRL
+```
+
+The Python process is a source-language frontend and import-time normalization
+layer.  It must not become the compiler middle end.  The C++ WHIRL builder owns
+WHIRL node creation, symbol and type table construction, tensor descriptor
+registration, opcode attributes, contracts, metadata, and mapped binary image
+finalization.  The binary WHIRL artifact is the boundary between Python capture
+and the Open64 pipeline.
+
+The long-term type model is:
+
+```text
+Common tensor type:
+  TY_KIND = KIND_TENSOR
+  semantic tensor attributes
+
+Tensor object symbol:
+  ST_IDX
+  compiler metadata such as source context, diagnostics, and lowering hints
+
+Target-lowered tensor fragment:
+  target-specific MTYPE or ABI representation
+  e.g. NVIDIA Tensor Core WMMA/MMA fragment
+```
+
+`TensorDescriptorIR` is owned by the `TY` domain.  A producer first completes
+the descriptor, including its element type, rank, logical shape, traits, and
+representation facts, and then asks the type system to canonicalize it.  The
+canonicalization operation hashes and compares the complete descriptor,
+returns the existing `TY_IDX` for an equal descriptor, or installs one new
+`KIND_TENSOR` entry.  A canonical descriptor is frozen: clients must not append
+or mutate identity-bearing attributes after it enters the type-uniqueness
+table.  Thus equal tensor descriptors share one `TY_IDX`, while unequal
+descriptors denote distinct tensor types.
+
+The current implementation is only a staging foundation for that rule.
+`Hash_ty_tensor_table` exists, but its hash currently covers only element type
+and rank, and its equivalence test covers only element type, rank, and
+attribute count.  Counting attributes is not descriptor equivalence.  The
+canonical API must compare normalized key/value contents and must replace the
+incremental create-then-mutate pattern with build, seal, and intern operations.
+Compatibility wrappers may retain the old API temporarily, but must intern the
+completed descriptor before exposing it as canonical.
+
+Source position is not tensor state or auxiliary compiler metadata.  For a
+statement-level WN, the authoritative source position is the existing 64-bit
+`SRCPOS` value in the statement WN slot accessed historically through
+`WN_Set_Linenum`, `WN_Get_Linenum`, and `WN_linenum`.  DSL statement wrappers,
+including stores, regions, pragmas, and barriers, must propagate that value.
+Source module paths and graph-node names may remain compiler metadata for
+diagnostics, but they do not replace the WN source position.
+
+The long-term opcode model is:
+
+```text
+Domain opcode namespace
+  -> domain contract and gatekeeper verification
+  -> optional common opcode wrapper/lowering
+  -> target/runtime lowering
+```
+
+The Common Compiler Substrate owns domain-neutral compiler and tensor
+semantics.  Domain namespaces own domain-specific ABI, gatekeeper checks,
+conformance tests, and diagnostics.  CNN and Transformer domains may therefore
+share opcodes such as `common.linear`, `common.residual_add`,
+`common.layout_cast`, and `common.dispatch`, while preserving wrappers such as
+`cnn.linear`, `cnn.conv2d`, `transformer.q_projection`, and
+`transformer.attention` when domain-specific meaning matters.
+
+Implementation similarity is not semantic equivalence.  For example, CNN
+convolution and Transformer attention may both lower to tensor contractions,
+but they must remain visible as domain operations until their padding, layout,
+mask, position, runtime-state, and ABI contracts have been verified.
+
+## Continuous IR Tool Compatibility
+
+Every stage must keep `osprey/ir_tools/ir_a2b.cxx` working.  This source covers
+both the ASCII-to-binary `ir_a2b` flow and the binary-to-ASCII `ir_b2a` flow, so
+it is a compatibility gate for the public WHIRL node, symbol-table, ASCII
+reader/printer, and binary IR image assumptions used by existing tools.
+
+Open64 binary IR is not a portable interchange encoding.  The binary IR file is
+an image of the compiler's in-memory WHIRL-related data structures, and the
+reader relies on mapping that image back into memory, including mmap-based
+paths.  The DSL plan must therefore preserve binary image layout compatibility
+within Open64's existing assumptions instead of introducing a new
+cross-platform file format.
+
+Rules:
+
+1. Stages must not introduce required DSL syntax that `ir_a2b` cannot preserve,
+   ignore safely, or diagnose deterministically.
+2. Early DSL metadata should use legal existing WHIRL constructs, such as
+   `OPR_COMMENT` markers and side tables keyed by existing IDs.
+3. Any future binary IR image layout change, especially `TY_KIND = KIND_TENSOR`,
+   must be accompanied by ASCII reader/printer, binary image writer, binary
+   image reader, dumper, and verifier updates before that stage exits.
+4. `ir_a2b` should be part of each stage's smoke test: ASCII WHIRL containing
+   existing constructs must still move through `ir_a2b` and `ir_b2a`, and
+   DSL-marked WHIRL must either survive that path or fail with a clear
+   unsupported-feature diagnostic.
+
+## Staged Driver Artifact Boundary
+
+The first DSL ingestion workflow should be a two-step artifact flow:
+
+```text
+torch2whirl model.py -o model.B
+opencc -x whirl model.B ...
+```
+
+`torch2whirl` is the Python-facing frontend command.  It owns Python model
+capture, graph normalization, source mapping, and calls into the native WHIRL
+builder to produce a binary very-high-level WHIRL artifact.  Its output is a
+compiler artifact, not an in-process Python object that the Open64 middle end
+must understand.
+
+`opencc -x whirl model.B ...` is the Open64 compiler invocation over that
+artifact.  This preserves the same architectural split used by other Open64
+frontends: source-language ingestion finishes before the middle-end pipeline
+starts.  It also makes validation easier because developers can inspect
+`model.B` with `ir_b2a -st`, compare mapped-image sections, and reproduce
+compiler behavior without re-running Python capture.
+
+The combined driver mode is deferred:
+
+```text
+opencc -frontend=torch2whirl model.py ...
+```
+
+That mode should be only a driver convenience wrapper around the same artifact
+boundary.  It must not become a special in-memory bypass around binary WHIRL
+finalization, `ir_b2a` visibility, TensorDescriptorIR persistence, or gatekeeper
+validation.  The combined mode can start only after the two-step flow proves
+that the WHIRL artifact boundary is stable, inspectable, and compatible with
+existing Open64 IR tools.
+
+Near-term driver requirements:
+
+1. `torch2whirl` writes a binary very-high-level WHIRL file.
+2. The file is inspectable with `ir_b2a -st`.
+3. TensorDescriptorIR state, opcode attributes, contracts, compiler metadata,
+   and source mapping survive the artifact boundary.
+4. `opencc -x whirl` consumes the artifact without importing Python.
+5. Combined `opencc -frontend=torch2whirl ...` mode remains deferred until the
+   two-step path is validated.
+
+## Namespace Staging Policy
+
+The Word design uses namespace examples such as
+`ant::domain::transformer::rl_posttraining::rollout` to describe hierarchical
+domain ownership.  In this Open64 implementation plan, those names should first
+be represented as semantic domain identifiers, for example
+`ant.domain.transformer.rl_posttraining.rollout`, and registered through a
+domain registry.  They should not immediately become C++ namespaces in the
+common WHIRL implementation.
+
+Some newer Open64 islands already use C++ namespaces, for example `clang2whirl`
+and WSSA utilities.  The core WHIRL and symbol-table layers, especially
+`osprey/common/com`, still expose mostly global C/C++ APIs and are included by
+old frontends, backends, IPA, and tools.  The DSL IR design may use namespaces
+in new leaf components, but namespace adoption must be staged carefully and
+must not force a broad common-core API migration.
+
+Rules:
+
+1. Do not wrap existing `common/com` headers or exported WHIRL APIs in a new
+   namespace.
+2. New common-core APIs should follow existing naming style, such as
+   `WN_Create_DSL_Comment` and `TY_tensor_bind_attribute`.
+3. Namespace-based C++ classes may be introduced first in new leaf modules,
+   adapters, or experimental DSL lowering components.
+4. Any namespaced implementation that must be called from old Open64 code must
+   expose a small global wrapper API.
+5. Namespace migration of existing code is a separate refactor and should not be
+   mixed with tensor type-system or DSL lowering changes.
+6. Domain hierarchy should be stored as registry data before it is mirrored as
+   C++ namespace structure.
+7. Use dot-separated domain IDs in metadata and diagnostics first; add C++
+   namespace wrappers only after the registry contracts are stable.
+
+The tensor symbol-table additions follow the same rule deliberately:
+`TY_tensor_*` APIs operate on TensorDescriptorIR-completing attributes owned by
+`TY_IDX`, and `ST_tensor_*` APIs operate on compiler metadata owned by
+`ST_IDX`.  These
+functions remain global `common/com` APIs so old Open64 components can call
+them without adopting a new C++ namespace.  A future namespace facade may wrap
+these functions, but the ABI-facing common-core entry points should remain
+prefix-grouped in the existing Open64 style.
+
+## Stage 0: Infrastructure Markers
+
+Goal: Provide a low-risk way to preserve DSL intent in existing WHIRL files.
+
+Coding changes:
+
+1. Add DSL marker helpers over `OPR_COMMENT`.
+2. Use a reserved marker prefix such as `__WHIRL_DSL__:`.
+3. Provide helper APIs to create, detect, and extract DSL marker payloads.
+4. Document marker format and lowering expectations.
+
+Primary files:
+
+```text
+osprey/common/com/wn.h
+osprey/common/com/wn.cxx
+doc/WHIRL-DSL-INFRASTRUCTURE.md
+```
+
+Validation:
+
+1. Existing WHIRL readers continue to see legal `OPR_COMMENT` nodes.
+2. DSL-aware code can detect markers through the new helper API.
+3. No WHIRL operator enum or binary format change is required.
+4. New helper APIs follow existing global `WN_*` naming instead of introducing
+   namespaces in common WHIRL headers.
+5. `ir_a2b` continues to accept ASCII WHIRL with ordinary comments, and DSL
+   markers are still represented as legal `OPR_COMMENT` nodes.
+
+Exit criteria:
+
+1. A frontend can emit a DSL marker.
+2. A later pass can identify the marker without parsing arbitrary comments.
+3. ASCII-to-binary conversion remains unchanged for non-DSL input.
+
+## Stage 1: Python DSL Frontend Emits Very-High WHIRL
+
+Goal: Make the Python DSL ingestion path create binary very-high-level WHIRL
+with first-class domain/common operators rather than plain High WHIRL or early
+intrinsic-call placeholders.
+
+### Chapter 7 Ingestion Boundary Design Note
+
+The Chapter 7 architecture in `DSC_Master_Design_Doc_v0.10.docx` defines Python
+as a source-language frontend for DSL authoring, model capture, and import-time
+normalization.  Python may use `torch.export`, FX, a dedicated DSC Python DSL,
+or another graph capture mechanism, but it must produce a compiler artifact and
+must not remain in the Open64 middle-end path.
+
+The first Python package boundary is `open64_dsc`.  It should be thin: capture
+the user model, classify graph nodes, preserve source context, and call the
+native WHIRL builder.  It should expose a small API surface such as
+`export_to_whirl`, `save_as_whirl`, `WhirlExportOptions`, and a
+`WhirlExportInterpreter`.  The readable WHIRL dump is diagnostic output; the
+binary very-high-level WHIRL artifact is the compiler input.
+
+The C++ WHIRL builder boundary owns Open64 IR construction.  That boundary owns
+module/function creation, WHIRL node creation, `TY` and `ST` table creation,
+TensorDescriptorIR attachment, opcode attributes, contracts, compiler metadata,
+and mapped binary image finalization.  Python must not implement the WHIRL
+object model or directly own Open64 table layout.  The builder-facing API should
+create first-class DSL operators through names such as `CreateOperator`; it
+should not expose intrinsic creation as the frontend construction API.
+
+The artifact boundary is a mapped WHIRL binary image finalized by the design
+component named `WhirlMappedImageFinalizer`.  This name is intentional: the
+builder is populating Open64-compatible mapped IR state and finalizing it, not
+performing semantic format conversion or object-stream encoding.  Tensor descriptors,
+opcode attributes, contracts, source metadata, weights/constants, and
+version/capability records may be represented by side tables or extension
+sections, but architecturally they are part of the compiler IR image.
+
+The ingestion artifact must preserve first-class domain/common operators long
+enough for gatekeeper verification, TensorDescriptorIR validation, opcode
+attribute validation, target-independent operator optimization, common-substrate
+cleanup, and parallelization planning.  Intrinsic ops, runtime calls, library
+calls, and target kernels are lowering products introduced by later compiler
+passes after semantic legality and optimization opportunities have been
+processed.
+
+`mpl2whirl` is not the active DSL ingestion path.  It remains parked until MPL
+tensor syntax and its MIR type representation are explicitly defined.  The
+first staged workflow is therefore two-step and inspectable:
+
+```text
+torch2whirl model.py -o model.B
+opencc -x whirl model.B ...
+```
+
+The later combined driver mode may dispatch the Python frontend through
+`opencc`, but only after the binary WHIRL artifact boundary is stable:
+
+```text
+opencc -frontend=torch2whirl model.py ...
+```
+
+### First ResNet Inference Vertical Slice
+
+The first Python ingestion target should be a ResNet inference path.  This
+vertical slice is deliberately CNN-heavy because it exercises tensor type
+creation, symbol creation, constant/parameter lifting, domain gatekeeper checks,
+residual lineage, common activation/projection operators, and mapped binary
+artifact generation without requiring Transformer runtime state.
+
+The initial operator list is:
+
+| Operator | Domain role | Operand policy | Opcode attributes | TensorDescriptorIR / metadata ownership |
+| --- | --- | --- | --- | --- |
+| `cnn.conv2d` | CNN domain executable | `kid0` input tensor, `kid1` weight tensor, optional bias | `kernel_shape`, `stride`, `padding`, `dilation`, `groups`, `data_layout`, `weight_layout` | Tensor descriptors own dtype, rank, logical shape, layout, sharding, placement, quantization, and runtime state; compiler metadata owns source layer name and lowering hints. |
+| `cnn.batch_norm_infer` | CNN domain executable | activation tensor, scale, bias, mean, variance | `epsilon`, `momentum_policy`, `axis`, `training=false` | Descriptor state records representation/layout; metadata records checkpoint/source parameter names. |
+| `common.relu` | Common executable | activation tensor | optional `inplace_allowed=false` and activation policy | Descriptor state propagates dtype/shape/layout; metadata records source node/layer. |
+| `cnn.max_pool2d` | CNN domain executable | activation tensor | `kernel_shape`, `stride`, `padding`, `dilation`, `ceil_mode` | Domain verifier owns pooling semantics before lowering to `common.window_reduce`. |
+| `common.residual_add` | Common executable with residual contract | `kid0` main path tensor, `kid1` skip path tensor | `broadcast_rule=none`, optional `residual_policy` | Descriptor state records compatible dtype/shape/layout; TensorLineageMetadata preserves residual identity. |
+| `cnn.global_avg_pool2d` | CNN domain executable | activation tensor | `axes`, `keepdims`, `data_layout` | Domain verifier owns image-axis interpretation before lowering to reduction/common substrate. |
+| `common.flatten` | Common executable | tensor | `start_axis`, `end_axis` | Descriptor state records new logical shape and lineage from prior tensor. |
+| `common.linear` | Common executable | input tensor, weight tensor, optional bias | `transpose_weight`, `bias_axis`, `layout_contract` | Descriptor state records projection shape/layout; metadata records source fully connected layer. |
+| `common.output_logits` | Common declaration | logits tensor | `class_axis`, optional `activation=none` | Descriptor state records final output shape/dtype; metadata records model output name. |
+
+The slice intentionally keeps CNN-specific operators as domain operators until
+their domain gatekeeper has validated image layout, padding, stride, dilation,
+groups, pooling policy, and batch-normalization inference semantics.  Lowering
+may then produce common substrate operators such as `common.window_reduce`,
+`common.matmul`, `common.gemm`, or canonical WHIRL/runtime calls, but those are
+not the ingestion representation.
+
+### CNN Structured Regions
+
+ResNet `BasicBlock`, `Bottleneck`, and shortcut semantics shall be represented
+with the existing WHIRL `OPR_REGION` structure rather than by treating a bare
+`OPR_BLOCK` as a tensor-valued operator.  This follows the established WHIRL
+use of regions for semantically governed statement scopes, including parallel
+regions produced by automatic parallelization.
+
+The initial CNN form uses `REGION_KIND_PRAGMA`.  Its exit block is empty, its
+pragma block declares the CNN contract, and its body block contains the ordered
+DSL computation.  The contract identifies at least the domain construct and
+version, BasicBlock or Bottleneck kind, input value, result value, identity or
+projection shortcut kind, and optional ResNet stage and block ordinal.  Source
+module paths remain compiler metadata.  Static parameters such as convolution
+stride, padding, dilation, and groups remain attributes of the corresponding
+operators inside the region.
+
+Construction should follow the automatic-parallelization precedent in
+`be/lno/ara_loop.cxx`: form the body, call `WN_CreateRegion`, populate
+`WN_region_pragmas`, propagate source positions, parentize the completed tree,
+and insert the region into its parent block.  The first pragma is the stable
+region classifier; later pragmas refine the contract.  Each region receives a
+stable region ID.  LNO also creates and links an RID because it constructs the
+region inside an active optimizer.  The Python layer must not inspect region
+internals, but the native `common/com` builder creates the region's common RID
+state and managed WN-to-RID relation.  Stable region rows use the reserved
+`WT_REGIONS` PU subsection.  Mapped rows contain IDs, kinds, parent relations,
+and PU-tree-relative WN offsets rather than process pointers.  Opening the image
+restores the managed relation and creates the in-memory RID objects.
+
+Reusable RID identity and hierarchy, region construction, pragma-list access,
+declared symbol interfaces, structural verification, logical inspection, and
+body-splicing mechanics belong in `common/com` as a common WHIRL region
+substrate.  They do not belong in `common/util`, because they operate directly
+on WN layout, WHIRL pragmas, source positions, symbol tables, and mapped IR
+invariants.  Derived optimizer levels, alias and preg boundary analysis, region
+bounds, and target lowering remain in `be/region`.  Migration from backend
+helpers must be staged behind compatibility wrappers and differential LNO tests
+so automatic parallelization behavior does not change.
+
+`OPR_REGION` is statement-level and does not itself produce a tensor value.
+Its interface instead declares repeatable symbol bindings with the provisional
+roles `INPUT`, `OUTPUT`, `INOUT`, and `RESULT`.  `RESULT` is an output with the
+additional meaning that it carries a logical result of the region; a region may
+declare more than one.  An input is defined outside and referenced inside.  An
+output is defined inside and may be referenced outside.  An `INOUT` symbol has
+both roles.  Any value defined inside the region and used outside must appear
+in the declared output interface.
+
+The enclosing region or PU owns each output/result symbol and its logical
+storage, analogous to a caller-owned structure-return location or C++ reference
+output parameter.  The inner region stores its result into that designated
+symbol.  For a DSL operator result, the outer owner creates a complete tensor
+temporary and asserts `no_alias=true`; the inner region does not allocate an
+independent result object.  Physical tensor-memory allocation remains a later
+lowering decision.
+
+The mapped region image therefore includes a fixed-row, repeatable region
+symbol-interface table keyed by stable region ID and ordinal.  Each row carries
+an `ST_IDX`, role bits, and compatibility flags; it carries no pointer or STL
+ownership.  The existing RID `used_in`, `def_in_live_out`, and preg boundary
+sets remain derived optimizer facts and can later verify or refine the declared
+interface.  They are not substituted for the source-level declaration.
+
+This interface is intentionally an abstraction rather than a final SSA model.
+The DSL middle-end may later translate region inputs and outputs into SSA uses,
+definitions, block arguments, or merge values.  Until that design is proven,
+clients use the common region-interface API and must not depend on the physical
+table layout.  A bare nested `OPR_BLOCK` is not a semantic boundary because
+normal block insertion can splice its statements into the enclosing block.
+
+The CNN gatekeeper must verify that the region body implements its declared
+block and shortcut contract before the region is dissolved or its operators
+are promoted to the common substrate.  Identity shortcuts must consume the
+region input directly.  Projection shortcuts must contain and identify the
+required projection computation.  `ir_b2a` must display the logical CNN region
+and pragma contract without exposing private DSL record indices or escape-tag
+details.  Region dissolution should follow the established MP-lowering pattern
+of reconnecting the body statement list to the parent block, while preserving
+definitions, uses, source positions, and the region result temporary.
+
+All static operation parameters remain opcode attributes.  Examples include
+`kernel_shape`, `stride`, `padding`, `dilation`, `groups`, `epsilon`,
+`ceil_mode`, `start_axis`, `end_axis`, and `class_axis`.  Tensor semantic state
+is represented through TensorDescriptorIR and its split components:
+TensorTypeCore, TensorTraitSet, TensorRepresentationDescriptor, and
+TensorLineageMetadata.  Compiler metadata is reserved for source context,
+diagnostics, pass ownership, lowering hints, checkpoint/source parameter names,
+and profiling information.
+
+### Values, Tensor Access, Effects, And Ordering
+
+Do not introduce a generic multiple-result facility as the default answer to
+every operation that appears to produce more than one observable fact.  Each
+case must first be classified by its WHIRL semantics:
+
+1. An ordinary pure DSL expression produces one value with one canonical
+   tensor `TY_IDX`.
+2. A tensor plus one or more indices denotes tensor access.  Its abstraction
+   should follow High WHIRL `OPR_ARRAY`: a base, dimension information, and
+   ordered index expressions form an address expression, which is then used by
+   the appropriate load or store.  Indices are operands, not secondary
+   results.
+3. A value defined inside a region and consumed outside is represented through
+   the declared region symbol interface and caller-owned result temporary.
+4. Runtime status, mutable buffers, random-generator state, communication
+   state, and similar observations are memory/state effects.  They are not
+   ordinary tensor results merely because a source framework returns them.
+5. Ordering and visibility requirements use WHIRL barrier semantics.  A state
+   effect and a barrier are related but are not interchangeable.
+
+The VHO DSL middle end shall model abstract state using an HSSA-style
+interface.  A possible read of an abstract state is a `MU`-like use.  A
+possible modification is a `CHI`-like old-state operand and new-state result.
+Virtual state objects group accesses that may interact, following WOPT virtual
+symbols and alias analysis.  The VHO API must remain independent of WOPT's
+physical `AUX_ID`, `CODEREP`, `MU_NODE`, and `CHI_NODE` classes; lowering into
+those backend structures occurs when DSL HSSA/WOPT form is built.
+
+This direction follows Chow, Chan, Liu, Lo, and Streich, *Effective
+Representation of Aliases and Indirect Memory Operations in SSA Form*, CC
+1996, pages 253-267, DOI `10.1007/3-540-61053-7_66`.  HSSA uses virtual
+variables plus `MU` and `CHI` nodes to expose indirect-memory dependences while
+controlling version growth.  Open64 WOPT is the concrete implementation
+reference for the DSL design.
+
+WHIRL already provides `OPR_FORWARD_BARRIER` and `OPR_BACKWARD_BARRIER` with a
+variable list of affected references.  WOPT conservatively maps a barrier to
+may-use and may-def information so prohibited memory motion cannot cross it.
+DSL synchronization and collective ordering should reuse this abstraction
+where its semantics fit.  A side-effecting operator can require `MU`/`CHI`
+without requiring a barrier; synchronization can require both.
+
+### Fused Regions And Dispatch
+
+Operator fusion and graph capture are represented as a logical `FUSED`
+contract on the common `OPR_REGION` substrate.  The region body contains the
+ordered logical DSL expressions, its declared interface identifies externally
+visible inputs and results, and its effect and barrier contracts constrain
+legal transformation.  A CUDA Graph is one possible target realization of a
+certified fused region; it is not the common VHO representation.
+
+Library and kernel dispatch contracts are a separate major design topic.  They
+must eventually cover semantic versions, supported operators and fused
+patterns, tensor types and representations, workspace ownership, alias and
+effect behavior, synchronization, asynchronous completion, error reporting,
+target ABI, capability versioning, and deterministic implementation selection.
+Do not encode these decisions as compiler metadata or settle them incidentally
+while introducing regions, HSSA effects, or canonical tensor types.
+
+Coding changes:
+
+1. Treat Python capture through `torch.export`, FX, or a dedicated DSC Python DSL
+   as the first planned DSL ingestion path.
+2. Add a thin `open64_dsc` Python package boundary with `export_to_whirl`,
+   `save_as_whirl`, `WhirlExportOptions`, and a `WhirlExportInterpreter`.
+3. Add a C++ WHIRL builder extension boundary that owns module, function, type,
+   symbol, tensor descriptor, operator, attribute, contract, metadata, and mapped
+   image construction.
+4. Emit first-class very-high-level operators such as `common.add`,
+   `common.matmul`, `cnn.conv2d`, and `cnn.residual_add` at ingestion time.
+5. Keep operator-to-intrinsic, runtime-call, library-call, or target-kernel
+   translation as a later explicit lowering phase.
+6. Finalize the artifact through a mapped binary WHIRL image boundary, named
+   `WhirlMappedImageFinalizer` in the design, using the existing ELF section and
+   mapped-image mechanisms.
+7. Keep `mpl2whirl` parked until MPL tensor syntax and its MIR type
+   representation are explicitly defined.
+
+Primary files:
+
+```text
+open64_dsc/                         # future Python package boundary
+libopen64_whirl_builder.so          # future C++ builder library boundary
+osprey/common/com/dsl_opcode.h
+osprey/common/com/dsl_opcode.cxx
+osprey/common/com/symtab.h
+osprey/common/com/symtab.cxx
+doc/Open64_Domain_Specific_Compiler_IR_Design.md
+```
+
+Validation:
+
+1. The frontend boundary can produce a binary very-high-level WHIRL artifact
+   without requiring Python in the Open64 middle-end path.
+2. Imported operators remain first-class domain/common operators through the
+   gatekeeper and target-independent optimization window.
+3. Tensor descriptors, opcode attributes, contracts, and compiler metadata are
+   preserved in the mapped binary image boundary.
+4. Intrinsic ops and runtime calls appear only after an explicit lowering pass.
+5. The initial driver workflow is two-step and inspectable:
+   `torch2whirl model.py -o model.B`, then `opencc -x whirl model.B ...`.
+
+Exit criteria:
+
+1. A Python DSL or exported graph can be mapped to first-class very-high-level
+   WHIRL operators with tensor descriptors and source metadata.
+2. Open64 can consume the binary WHIRL artifact without the original Python
+   interpreter.
+3. Existing non-DSL frontends remain unchanged.
+4. `mpl2whirl` is not modified speculatively for this stage.
+
+## Stage 2: DSL Type Extension Registry
+
+Goal: Allow DSL-specific types, tensor attributes, and compiler metadata to
+exist before WHIRL lowering is chosen.
+
+Coding changes:
+
+1. Add a side-table keyed by `TY_IDX` for DSL type extensions and tensor
+   attributes.
+2. Introduce tensor as the first extension kind.
+3. Support delayed binding for `TY_IDX` tensor attributes and `ST_IDX` compiler
+   metadata.
+4. Keep the current carrier type compatible with existing WHIRL type records.
+5. Keep common type-extension APIs in global Open64 style; avoid namespace-only
+   interfaces in `common/com`.
+
+Primary files:
+
+```text
+osprey/common/com/symtab.h
+osprey/common/com/symtab.cxx
+doc/WHIRL-DSL-INFRASTRUCTURE.md
+```
+
+Validation:
+
+1. A frontend can create or mark a tensor extension type.
+2. Attribute keys can be declared before values are known.
+3. Tensor attributes and compiler metadata can be bound later by type inference,
+   DSL analysis, placement analysis, alias analysis, or pass planning.
+4. Type extension state resets with symbol-table side tables.
+5. `ir_a2b` still sees the carrier as an existing legal `TY_KIND`, so ASCII and
+   binary conversion do not require tensor-specific binary IR image changes yet.
+
+Exit criteria:
+
+1. Tensor semantic data can be represented without choosing aggregate WHIRL,
+   descriptors, runtime handles, or target fragments.
+2. Existing type records remain compatible with `ir_a2b` and `ir_b2a`.
+
+## Stage 3: Domain Registry And Semantic Namespace IDs
+
+Goal: Implement the Word design's namespace hierarchy as data first, avoiding a
+premature C++ namespace migration.
+
+Coding changes:
+
+1. Add a domain descriptor structure with fields for domain ID, parent domain,
+   version, owned operations, owned types, verifier hooks, pass hooks, and
+   diagnostic prefix.
+2. Represent namespace identity as strings such as
+   `ant.domain.transformer.inference`.
+3. Add registry APIs using existing Open64 global naming conventions, for
+   example `DSL_Register_Domain`, `DSL_Find_Domain`, and
+   `DSL_Domain_Inherits`.
+4. Add sub-domain inheritance metadata without using C++ inheritance.
+5. Allow DSL markers and tensor attributes to carry a `domain` key that references
+   a registered domain ID.
+6. Add diagnostics for unknown domain IDs and invalid parent relationships.
+
+Primary files:
+
+```text
+osprey/common/com/dsl_domain.h
+osprey/common/com/dsl_domain.cxx
+osprey/common/com/wn.h
+osprey/common/com/symtab.h
+doc/Open64_Domain_Specific_Compiler_IR_Design.md
+doc/WHIRL-DSL-INFRASTRUCTURE.md
+```
+
+Validation:
+
+1. A domain such as `ant.domain.transformer` can be registered.
+2. A sub-domain such as `ant.domain.transformer.inference` can declare its
+   parent and inherited contracts.
+3. Domain lookup works without requiring any C++ namespace.
+4. Bad parent references produce deterministic diagnostics.
+5. Domain IDs carried in markers or metadata do not change `ir_a2b` behavior
+   unless the stage explicitly adds matching reader/writer support.
+
+Exit criteria:
+
+1. Namespace hierarchy from the Word design is represented as compiler data.
+2. Common Open64 code still exposes global C-style APIs.
+3. `ir_a2b` remains independent of namespaced DSL implementation classes.
+
+## Stage 4: Contract Registry And Gatekeeper Metadata
+
+Goal: Add the contract-carrying part of the Word design without yet building a
+full gatekeeper.
+
+Coding changes:
+
+1. Add a contract descriptor with source domain, target domain, required checks,
+   diagnostic codes, and version.
+2. Add global APIs such as `DSL_Register_Contract` and `DSL_Find_Contract`.
+3. Allow DSL markers or tensor attributes to reference contract IDs.
+4. Add a verifier stub that reports which contracts are present, missing, or
+   unresolved.
+5. Keep verifier hooks as function pointers or global wrapper callbacks first;
+   do not require namespaced C++ classes.
+
+Primary files:
+
+```text
+osprey/common/com/dsl_domain.h
+osprey/common/com/dsl_domain.cxx
+osprey/be/vho/*
+doc/Open64_Domain_Specific_Compiler_IR_Design.md
+```
+
+Validation:
+
+1. A contract can be registered between two domain IDs.
+2. The compiler can list required contracts for a domain boundary.
+3. Missing contracts are reported before lowering.
+
+Exit criteria:
+
+1. The gatekeeper architecture has a concrete metadata representation.
+2. Namespaced implementation remains optional and isolated.
+
+## Stage 5: Common Compiler Substrate Opcode Architecture
+
+Goal: Introduce the Chapter 6 opcode ownership model as compiler data before
+lowering domain operations into canonical WHIRL or target-specific forms.
+
+The opcode substrate should classify IR constructs by responsibility, not only
+by runtime behavior:
+
+```text
+Executable op:
+  Performs dataflow or numerical computation.
+  Examples: common.matmul, common.add, cnn.conv2d, transformer.attention
+
+Declaration op:
+  Declares model boundary, structure, or tensor role.
+  Examples: common.model_input, cnn.input_image, transformer.input_tokens
+
+Contract op:
+  Declares ABI, semantic, layout, state, or policy obligations.
+  Examples: cnn.preprocess_contract, transformer.tokenizer_contract
+
+Verifier op:
+  Represents a check that may produce diagnostics or generated tests.
+  Examples: common.shape_assert, cnn.residual_shape_check,
+            transformer.logprob_replay_check
+
+Lowering-policy op:
+  Guides compiler control or target selection without changing model semantics.
+  Examples: common.fusion_contract, cnn.conv_algorithm_choice,
+            common.shape_bucket
+```
+
+Common opcodes should be organized into levels.  A level is a registry
+classification for how foundational or semantically specialized an operator is;
+it is not a WHIRL opcode number, execution order, pass order, or lowering
+priority.  Lower levels are more universal substrate concepts that many
+domains can share directly.  Higher levels carry more model, compiler-policy,
+runtime, or distributed-execution intent and are more likely to be wrapped by
+domain-specific operators before lowering.
+
+The level characterization is:
+
+```text
+Level 0: Core IR structure
+  Program structure and side-effect framing.
+
+Level 1: Tensor, shape, and layout
+  Tensor identity, shape facts, symbolic shape formulas, layout transforms,
+  and view/materialization requirements.
+
+Level 2: Numeric tensor ops
+  Domain-neutral tensor computation such as elementwise math, contraction,
+  activation, and reduction.
+
+Level 3: Neural-network common ops
+  Common model semantics such as boundaries, residuals, normalization,
+  quantization, and fusion contracts.
+
+Level 4: Parallel and runtime common ops
+  Distribution, collective intent, runtime state, dispatch, guards, and
+  kernel variant selection.
+```
+
+The initial level assignment is:
+
+```text
+Level 0: Core IR structure
+  common.module, common.function, common.region, common.call,
+  common.return, common.constant, common.effect
+
+Level 1: Tensor, shape, and layout
+  common.tensor, common.shape_of, common.shape_formula,
+  common.shape_assert, common.runtime_shape_guard, common.reshape,
+  common.flatten, common.transpose, common.slice, common.concat,
+  common.pad, common.layout_cast, common.contiguous
+
+Level 2: Numeric tensor ops
+  common.add, common.mul, common.bias_add, common.matmul, common.gemm,
+  common.linear, common.activation, common.relu, common.gelu, common.silu,
+  common.softmax, common.reduce, common.reduce_sum, common.reduce_mean,
+  common.reduce_max, common.window_reduce
+
+Level 3: Neural-network common ops
+  common.model_input, common.model_output, common.output_logits,
+  common.residual_add, common.residual_shape_check,
+  common.normalization_base, common.fusion_group, common.fusion_contract,
+  common.quantize, common.dequantize, common.requantize,
+  common.quantization_contract
+
+Level 4: Parallel and runtime common ops
+  common.shard, common.reshard, common.dispatch, common.gather,
+  common.scatter, common.reduce_scatter_intent, common.all_reduce_intent,
+  common.all_gather_intent, common.all_to_all_intent,
+  common.runtime_state_handle, common.runtime_guard, common.shape_bucket,
+  common.kernel_variant
+```
+
+The first implementation should seed a deliberately small `common.v0`
+operator set.  This set is the contract to implement before adding broad
+domain coverage.  It should be large enough to express shared CNN and
+Transformer substrate behavior, but small enough that every operator has an
+explicit shape rule, effect model, and lowering responsibility.
+
+### Initial Common Substrate Operator Set
+
+| Opcode | Category | Level | Required operands / attributes | Purpose |
+| --- | --- | --- | --- | --- |
+| `common.tensor` | declaration | 1 | `TY_IDX`, element type, rank, shape attributes | Names a semantic tensor value or tensor-bearing symbol. |
+| `common.shape_of` | declaration | 1 | tensor operand | Produces the symbolic or concrete shape descriptor for a tensor. |
+| `common.shape_formula` | declaration | 1 | formula payload, input shape refs | Records a derived shape before all dimensions are concrete. |
+| `common.shape_assert` | verifier | 1 | condition payload, diagnostic message | Requires a shape fact before lowering or code generation. |
+| `common.runtime_shape_guard` | verifier | 1 | runtime condition, fallback policy | Emits or records a dynamic guard for partially symbolic shape. |
+| `common.reshape` | executable | 1 | tensor, target shape | Changes tensor view/descriptor without changing element values. |
+| `common.transpose` | executable | 1 | tensor, permutation | Reorders dimensions. |
+| `common.slice` | executable | 1 | tensor, offsets, sizes, strides | Extracts a tensor region. |
+| `common.concat` | executable | 1 | tensor list, axis | Concatenates compatible tensors. |
+| `common.pad` | executable | 1 | tensor, per-axis padding, pad value | Pads tensor boundaries. |
+| `common.layout_cast` | executable | 1 | tensor, source layout, target layout | Converts between layouts such as NCHW, NHWC, packed, or blocked. |
+| `common.contiguous` | executable | 1 | tensor, layout | Materializes or asserts contiguous storage for a layout. |
+| `common.add` | executable | 2 | `kid0` tensor/scalar, `kid1` tensor/scalar, broadcast rule | Elementwise addition. |
+| `common.mul` | executable | 2 | `kid0` tensor/scalar, `kid1` tensor/scalar, broadcast rule | Elementwise multiplication. |
+| `common.bias_add` | executable | 2 | tensor, bias tensor, axis/layout | Adds bias with explicit broadcast axis. |
+| `common.matmul` | executable | 2 | `kid0`, `kid1`, transpose flags, batch dims | Matrix multiply or batched matrix multiply. |
+| `common.gemm` | executable | 2 | `kid0`, `kid1`, optional bias, alpha/beta | Lowering-oriented generalized matrix multiply. |
+| `common.linear` | executable | 2 | input, weight, optional bias, layout contract | Domain-neutral affine projection. |
+| `common.relu` | executable | 2 | tensor | ReLU activation. |
+| `common.gelu` | executable | 2 | tensor, approximation mode | GELU activation. |
+| `common.silu` | executable | 2 | tensor | SiLU activation. |
+| `common.softmax` | executable | 2 | tensor, axis, stability policy | Softmax over an explicit axis. |
+| `common.reduce_sum` | executable | 2 | tensor, axes, keepdims | Sum reduction. |
+| `common.reduce_mean` | executable | 2 | tensor, axes, keepdims | Mean reduction. |
+| `common.reduce_max` | executable | 2 | tensor, axes, keepdims | Max reduction. |
+| `common.window_reduce` | executable | 2 | tensor, window, stride, padding, reduce kind | Shared base for pooling-style reductions after domain verification. |
+| `common.model_input` | declaration | 3 | symbol, tensor type, boundary name | Declares model input boundary. |
+| `common.model_output` | declaration | 3 | symbol/value, tensor type, boundary name | Declares model output boundary. |
+| `common.output_logits` | declaration | 3 | tensor, class/token axis | Marks logits without binding to CNN or Transformer vocabulary. |
+| `common.residual_add` | executable | 3 | `kid0`, `kid1`, residual lineage metadata | Adds residual path while preserving residual identity for diagnostics. |
+| `common.residual_shape_check` | verifier | 3 | `kid0` shape, `kid1` shape, policy | Verifies residual operands are compatible before lowering. |
+| `common.normalization_base` | executable | 3 | tensor, axes, epsilon, scale/bias flags | Shared base for layer/rms/batch-style normalization after domain checks. |
+| `common.quantize` | executable | 3 | tensor, scale, zero point, target dtype | Converts from high precision to quantized representation. |
+| `common.dequantize` | executable | 3 | tensor, scale, zero point, source dtype | Converts from quantized representation to high precision. |
+| `common.requantize` | executable | 3 | tensor, source scale, target scale/dtype | Converts between quantized representations. |
+| `common.fusion_group` | lowering-policy | 3 | region/op list, legality payload | Groups ops as a fusion candidate without changing semantics. |
+| `common.fusion_contract` | lowering-policy | 3 | fusion group, legality constraints | Records required fusion legality checks. |
+| `common.shard` | lowering-policy | 4 | tensor, partition spec, mesh/device spec | Describes partitioning intent. |
+| `common.reshard` | lowering-policy | 4 | tensor, source shard, target shard | Describes redistribution intent. |
+| `common.dispatch` | lowering-policy | 4 | op/region, target/runtime key, variant constraints | Selects runtime or target lowering path. |
+| `common.gather` | executable | 4 | tensor, indices, axis | Gathers indexed slices. |
+| `common.scatter` | executable | 4 | tensor, indices, updates, axis, combine mode | Scatters updates into a tensor. |
+| `common.all_reduce_intent` | lowering-policy | 4 | tensor, reduction kind, group | Records collective all-reduce intent. |
+| `common.all_gather_intent` | lowering-policy | 4 | tensor, axis/group | Records collective all-gather intent. |
+| `common.reduce_scatter_intent` | lowering-policy | 4 | tensor, reduction kind, shard spec | Records collective reduce-scatter intent. |
+| `common.runtime_state_handle` | declaration | 4 | state kind, ABI key | Represents opaque runtime state without exposing domain ABI. |
+| `common.runtime_guard` | verifier | 4 | condition payload, action | Records a runtime legality or availability guard. |
+| `common.shape_bucket` | lowering-policy | 4 | shape expression, bucket policy | Groups dynamic shapes for dispatch or specialization. |
+| `common.kernel_variant` | lowering-policy | 4 | target key, variant ID, constraints | Names a selected or candidate implementation variant. |
+
+The initial set intentionally excludes semantically rich domain operators:
+
+| Domain opcode | Common substrate relationship |
+| --- | --- |
+| `cnn.conv2d` | Domain verifier owns padding, stride, dilation, groups, and image layout; lowering may use `common.window_reduce`, `common.matmul`, or `common.gemm` style substrate ops only after verification. |
+| `cnn.pool2d` | Domain verifier owns pooling policy; lowering may use `common.window_reduce`. |
+| `transformer.attention` | Domain verifier owns mask, head layout, positional semantics, and KV-cache ABI; lowering may use `common.matmul`, `common.softmax`, and `common.dispatch`. |
+| `transformer.layer_norm` / `transformer.rms_norm` | Domain verifier owns exact axis/epsilon/checkpoint contract; lowering may use `common.normalization_base`. |
+| `cnn.preprocess_contract` / `transformer.tokenizer_contract` | Contract content remains domain-specific; only the contract mechanism is common. |
+
+Every `common.v0` operator descriptor must include:
+
+1. Stable string ID, for example `common.add`.
+2. Category: `executable`, `declaration`, `contract`, `verifier`, or
+   `lowering_policy`.
+3. Level: 0 through 4.
+4. Version: start with `1`.
+5. Operand count policy: fixed, variadic, or payload-defined.
+6. Required tensor attribute keys.
+7. Shape rule kind: identity, broadcast, contraction, reduction, view,
+   layout, runtime-guarded, or opaque.
+8. Effect model: pure, verifier-only, declaration-only, lowering-policy, or
+   runtime-effect.
+9. Lowering obligation: canonical WHIRL, runtime call, intrinsic sequence,
+   target-specific object, or marker-only until a later pass.
+10. Diagnostic prefix for missing traits, unsupported shape, or illegal
+    domain promotion.
+
+### DSL Opcode Compatibility Guarantee
+
+The common substrate registry must preserve backward compatibility for every
+public DSL opcode enum, string operator name, category, level, trait enum, shape
+rule enum, effect enum, and promotion-state enum.  DSL opcodes are compiler IR
+contracts, not local implementation details.  Once an opcode name or enum value
+has appeared in a released IR file, test, dump, or domain registry, it must not
+be reused for a different meaning.
+
+Compatibility rules:
+
+1. Treat the stable string ID, such as `common.add`, as the primary external
+   identity.  Numeric enum values and table handles are implementation details
+   unless explicitly included in binary WHIRL image contracts.
+2. Never rename or delete a public operator name in place.  If a name changes,
+   keep the old name as an alias that resolves to the new descriptor and emits
+   an optional deprecation diagnostic.
+3. Never reorder public enum values after release.  Add new enum values only at
+   the end, and reserve tombstones for removed experimental values.
+4. Every opcode descriptor has an explicit version.  Incompatible semantic
+   changes require a new version, for example `common.add` version `2`, not a
+   silent mutation of version `1`.
+5. Keep old descriptor versions loadable.  A reader may lower an old version
+   through a compatibility path, reject it with a deterministic diagnostic, or
+   map it through a versioned migration rule; it must not reinterpret it
+   silently.
+6. Persist aliases and version migrations in the opcode registry, not in ad hoc
+   frontend code.
+7. Dumps should print the stable string ID and version, not just the numeric
+   table handle.
+8. Tests must cover lookup by current name, lookup by deprecated alias, unknown
+   name diagnostics, old-version handling, and enum append-only behavior.
+9. WHIRL `OPERATOR` and `OPCODE` enums remain unchanged in this stage.  DSL
+   opcode compatibility is maintained in `dsl_opcode.*` side tables and marker
+   metadata, preserving `ir_a2b` and `ir_b2a` behavior.
+
+### Example: Creating `common.add`
+
+The DSL opcode API should live in `osprey/common/com/dsl_opcode_core.h`,
+`osprey/common/com/dsl_opcode.h`, and `osprey/common/com/dsl_opcode.cxx`.
+This mirrors the existing `opcode_core.h`, `opcode.h`, and `opcode.cxx` split
+without changing WHIRL `OPERATOR` or `OPCODE`.
+
+```c++
+/* dsl_opcode_core.h */
+typedef mUINT32 DSL_OPCODE;
+
+enum DSL_OPCODE_CATEGORY {
+  DSL_OPC_EXECUTABLE = 0,
+  DSL_OPC_DECLARATION = 1,
+  DSL_OPC_CONTRACT = 2,
+  DSL_OPC_VERIFIER = 3,
+  DSL_OPC_LOWERING_POLICY = 4
+};
+
+enum DSL_OPCODE_LEVEL {
+  DSL_OPC_LEVEL_0_CORE = 0,
+  DSL_OPC_LEVEL_1_TENSOR = 1,
+  DSL_OPC_LEVEL_2_NUMERIC = 2,
+  DSL_OPC_LEVEL_3_NN_COMMON = 3,
+  DSL_OPC_LEVEL_4_RUNTIME = 4
+};
+
+enum DSL_SHAPE_RULE {
+  DSL_SHAPE_RULE_OPAQUE = 0,
+  DSL_SHAPE_RULE_BROADCAST = 1,
+  DSL_SHAPE_RULE_CONTRACTION = 2,
+  DSL_SHAPE_RULE_REDUCTION = 3,
+  DSL_SHAPE_RULE_VIEW = 4
+};
+
+enum DSL_EFFECT_MODEL {
+  DSL_EFFECT_PURE = 0,
+  DSL_EFFECT_VERIFIER_ONLY = 1,
+  DSL_EFFECT_DECLARATION_ONLY = 2,
+  DSL_EFFECT_LOWERING_POLICY = 3,
+  DSL_EFFECT_RUNTIME = 4
+};
+```
+
+```c++
+/* dsl_opcode.h */
+DSL_OPCODE DSL_Register_Opcode(const char *domain,
+                               const char *name,
+                               UINT16 version,
+                               DSL_OPCODE_CATEGORY category,
+                               DSL_OPCODE_LEVEL level,
+                               mINT16 nkids,
+                               DSL_SHAPE_RULE shape_rule,
+                               DSL_EFFECT_MODEL effect_model);
+
+DSL_OPCODE DSL_OPCODE_make_op(const char *domain,
+                              const char *name,
+                              UINT16 version);
+
+BOOL DSL_OPCODE_is_valid(DSL_OPCODE opc);
+const char *DSL_OPCODE_domain(DSL_OPCODE opc);
+const char *DSL_OPCODE_name(DSL_OPCODE opc);
+UINT16 DSL_OPCODE_version(DSL_OPCODE opc);
+mINT16 DSL_OPCODE_nkids(DSL_OPCODE opc);
+const char *DSL_OPCODE_kid_name(DSL_OPCODE opc, INT kid);
+```
+
+```c++
+/* common.v0 registry seed */
+DSL_OPCODE common_add =
+  DSL_Register_Opcode("common",
+                      "add",
+                      1,
+                      DSL_OPC_EXECUTABLE,
+                      DSL_OPC_LEVEL_2_NUMERIC,
+                      2,
+                      DSL_SHAPE_RULE_BROADCAST,
+                      DSL_EFFECT_PURE);
+
+/* Later lookup follows OPCODE_make_op style: assert if invalid. */
+DSL_OPCODE opc = DSL_OPCODE_make_op("common", "add", 1);
+
+Is_True(DSL_OPCODE_nkids(opc) == 2,
+        ("common.add must have kid0 and kid1"));
+Is_True(strcmp(DSL_OPCODE_kid_name(opc, 0), "kid0") == 0,
+        ("common.add kid0 name mismatch"));
+Is_True(strcmp(DSL_OPCODE_kid_name(opc, 1), "kid1") == 0,
+        ("common.add kid1 name mismatch"));
+```
+
+For `temp = add(a, b)`, the common substrate opcode descriptor owns the
+operation identity and static operation parameters:
+
+```text
+opcode: common.add version 1
+category: executable
+level: 2
+kids:
+  kid0: a
+  kid1: b
+output:
+  temp
+attributes:
+  broadcast_rule: broadcast
+  dtype_policy: same_or_declared_cast
+shape_rule:
+  broadcast
+effect_model:
+  pure
+```
+
+Tensor value state remains outside opcode attributes:
+
+```c++
+TensorDescriptorIR *a_desc = compiler.getTensorDescriptor(a);
+TensorDescriptorIR *b_desc = compiler.getTensorDescriptor(b);
+TensorDescriptorIR *temp_desc = compiler.getTensorDescriptor(temp);
+
+TensorTypeCore *temp_core = compiler.getTensorTypeCore(temp);
+TensorRepresentationDescriptor *temp_repr =
+  compiler.getTensorRepresentation(temp);
+TensorLineageMetadata *temp_lineage =
+  compiler.getTensorLineage(temp);
+```
+
+Static operation parameters such as `broadcast_rule` belong to
+`op.getAttribute(name)`.  Source context, diagnostic ownership, lowering hints,
+pass history, and profile data belong to `op.getMetadata(name)`.
+
+### Printing `common.add` Through `ir_b2a`
+
+The first printing goal is to make `ir_b2a` expose common-substrate opcode
+identity without requiring a WHIRL `OPERATOR` or binary IR image change.  The
+underlying WHIRL tree must remain legal and printable by the existing
+`ir_reader.cxx` path.  The DSL opcode printer should therefore augment the
+existing print stream with stable DSL annotation text rather than replacing
+`OPCODE_name(WN_opcode(wn))`.
+
+Current `ir_b2a` flow:
+
+```text
+osprey/ir_tools/ir_a2b.cxx
+  ir_b2a(...)
+    -> fdump_tree(...)
+       -> ir_put_stmt / ir_put_expr
+          -> ir_put_wn(...)
+             -> prints OPCODE_name(WN_opcode(wn))
+```
+
+For `temp = common.add(a, b)`, the compatible WHIRL fallback may still print as
+ordinary WHIRL:
+
+```text
+LDID <a>
+LDID <b>
+ADD
+STID <temp>
+```
+
+The augmented print should add a stable DSL line or inline comment that records
+the common-substrate descriptor:
+
+```text
+COMMENT "__WHIRL_DSL__:opcode:common.add:v1:kid0=a;kid1=b;attr.broadcast_rule=broadcast"
+LDID <a>
+LDID <b>
+ADD
+STID <temp>
+```
+
+or, for debug dumps that are not intended for `ir_a2b` round-trip:
+
+```text
+ADD  # dsl_opcode=common.add.v1 category=executable level=2 kids=(kid0,kid1)
+```
+
+Round-trip-safe output must prefer the `OPR_COMMENT` form because existing
+ASCII readers already understand comments.  Inline debug decoration may be
+enabled only under an explicit dump/debug option and must not become the
+default `ir_b2a` interchange format.
+
+Implementation plan:
+
+1. Keep `ir_put_wn` printing the original WHIRL opcode name exactly as it does
+   today for all non-DSL nodes.
+2. Add a helper in `dsl_opcode.h`, for example:
+
+```c++
+BOOL DSL_WN_Has_Opcode (const WN *wn);
+DSL_OPCODE DSL_WN_opcode(const WN *wn);
+void DSL_fprint_opcode_annotation (FILE *f, const WN *wn);
+```
+
+3. Store the DSL opcode association outside the WHIRL opcode field, using an
+   `OPR_COMMENT` marker, side table, or `WN_MAP` during staging.  Do not add
+   fields to `WN` for this stage.
+4. In `ir_reader.cxx`, add one guarded call near `ir_put_wn` output:
+
+```c++
+if (DSL_WN_Has_Opcode (wn))
+  DSL_fprint_opcode_annotation (ir_ofile, wn);
+```
+
+   The default round-trip mode should emit the annotation as a legal
+   `OPR_COMMENT` record before the marked statement or expression group.
+5. For `common.add`, the annotation must print stable string identity and
+   version, not the numeric `DSL_OPCODE` handle:
+
+```text
+__WHIRL_DSL__:opcode:common.add:v1:kid0;kid1;broadcast_rule=broadcast
+```
+
+6. `ir_a2b` must be able to read the printed file without knowing the DSL
+   opcode registry.  If the registry is available, a later validation pass can
+   resolve the comment back to `DSL_OPCODE_make_op("common", "add", 1)`.
+7. Add smoke tests:
+   - non-DSL WHIRL prints byte-for-byte the same as before,
+   - a `common.add` marker survives `ir_b2a -> ir_a2b -> ir_b2a`,
+   - unknown DSL opcode names remain printable as comments and produce
+     deterministic diagnostics only when a DSL validation pass runs,
+   - debug decoration mode never becomes the default interchange format.
+
+Coding changes:
+
+1. Add an opcode descriptor structure with fields for opcode name, category,
+   common level, owning domain ID, version, trait requirements, effect model,
+   shape model, verifier hook, lowering hook, and diagnostic prefix.
+2. Add registry APIs using existing Open64 global naming style, for example
+   `DSL_Register_Opcode`, `DSL_Find_Opcode`, `DSL_Opcode_Category`, and
+   `DSL_Opcode_Owner`.
+3. Seed the registry with the initial `common.*` substrate levels listed above.
+4. Add domain wrapper support so a domain opcode can reference a common opcode
+   while retaining domain metadata.
+5. Represent opcode references in DSL markers and tensor attributes using string
+   IDs first, without changing WHIRL operator enums.
+6. Add a dump/debug path that prints opcode category, owner, common level, and
+   wrapper target.
+7. Keep all common-core APIs global; optional C++ namespace facades may be
+   added later over the registry.
+
+Primary files:
+
+```text
+osprey/common/com/dsl_opcode.h
+osprey/common/com/dsl_opcode.cxx
+osprey/common/com/dsl_domain.h
+osprey/common/com/wn.h
+osprey/common/com/symtab.h
+doc/Open64_Domain_Specific_Compiler_IR_Design.md
+doc/WHIRL-DSL-INFRASTRUCTURE.md
+```
+
+Validation:
+
+1. `common.linear`, `common.residual_add`, `common.layout_cast`, and
+   `common.dispatch` can be registered and queried.
+2. Domain wrappers such as `cnn.linear` and `transformer.q_projection` can
+   point to `common.linear` without losing domain-specific metadata.
+3. Opcode categories distinguish executable ops from declaration, contract,
+   verifier, and lowering-policy ops.
+4. Unknown opcode IDs produce deterministic diagnostics.
+5. `ir_a2b` still sees legal WHIRL because opcode IDs are carried through
+   markers or side metadata at this stage.
+
+Exit criteria:
+
+1. The compiler has a concrete common opcode registry independent of C++
+   namespaces.
+2. Domain wrappers can preserve ABI and gatekeeper metadata while sharing common
+   op semantics.
+3. No WHIRL operator enum or binary IR image change is required for this stage.
+
+## Stage 6: Opcode Promotion Registry And Policy
+
+Goal: Implement Chapter 6 promotion policy so domain authors have an explicit
+path for deciding when an operation remains domain-specific, lowers partially,
+or becomes a common substrate opcode.
+
+Promotion criteria:
+
+1. Cross-domain evidence exists, or the construct is demonstrably
+   domain-neutral.
+2. Observable behavior can be specified without domain vocabulary.
+3. Required tensor traits are not tied to one domain ABI.
+4. Shape rules are expressible through common tensor shape descriptors and
+   shape constraints.
+5. Side effects are absent or expressible through common effect metadata.
+6. Lowering can be reused across multiple backends or target families.
+7. Domain-specific contracts can wrap the common op instead of redefining it.
+8. Promotion does not hide any compatibility check required by a domain
+   gatekeeper.
+
+Non-promotion criteria:
+
+1. The op carries domain-specific ABI meaning, such as
+   `cnn.preprocess_contract` or `transformer.tokenizer_contract`.
+2. Correctness depends on domain-specific runtime state, such as
+   `transformer.kv_cache_append` or `transformer.linear_state_update`.
+3. Shape formulas depend on domain interpretation, such as CNN
+   padding/stride/dilation or Transformer mask and position semantics.
+4. The op requires domain-specific conformance tests.
+5. Promotion would hide a required gatekeeper check.
+6. Implementation similarity does not imply semantic equivalence, such as CNN
+   group convolution versus Transformer MoE grouped execution.
+
+Partial promotion should be the default for semantically rich domain ops:
+
+```text
+cnn.conv2d
+  verify: padding, stride, dilation, image layout, groups
+  lower: common.windowed_contraction -> common.matmul_like/common.gemm
+
+transformer.attention
+  verify: mask, position encoding, head layout, runtime-state ABI
+  lower: common.matmul -> common.softmax -> common.matmul
+
+cnn.pool2d
+  verify: window, padding, ceil/floor behavior
+  lower: common.window_reduce
+
+transformer.rms_norm / transformer.layer_norm
+  verify: norm axis, epsilon, checkpoint mapping
+  lower: common.normalization_base
+```
+
+Coding changes:
+
+1. Add a promotion descriptor with fields for source domain op, promoted common
+   op, required common semantics, retained domain wrappers, required verifier
+   checks, version, and diagnostics.
+2. Add registry APIs such as `DSL_Register_Opcode_Promotion`,
+   `DSL_Find_Opcode_Promotion`, and `DSL_Check_Opcode_Promotion`.
+3. Add explicit promotion states:
+   `domain_only`, `wrapper_to_common`, `partial_promotion`, and
+   `common_native`.
+4. Add compatibility versioning so changes to `common.*` semantics do not
+   silently invalidate domain wrappers.
+5. Add stable promotion diagnostics:
+
+```text
+CPROM-001 PromotionCandidateMissingCrossDomainEvidence
+CPROM-002 DomainSpecificSemanticLeak
+CPROM-003 PromotedOpMissingShapeFormula
+CPROM-004 PromotedOpMissingEffectModel
+CPROM-005 DomainWrapperRequired
+CPROM-006 PromotionWouldHideGatekeeperCheck
+CPROM-007 LoweringConflictAcrossDomains
+CPROM-008 TraitMismatchAcrossPromotionSources
+CPROM-009 CommonOpVersionMismatch
+CPROM-010 DomainWrapperMissingAfterPromotion
+```
+
+6. Seed examples from CNN and Transformer:
+
+```text
+cnn.linear + transformer.q_projection:
+  promote common.linear
+  keep wrappers for classifier-head, checkpoint, and head-layout contracts
+
+cnn.residual_add + transformer.residual_add:
+  promote common.residual_add
+  preserve residual lineage and shape checks
+
+cnn.layout_cast + transformer.layout_cast:
+  promote common.layout_cast
+  preserve domain layout contracts
+
+cnn.conv2d + transformer.attention:
+  do not fully promote
+  lower partially after domain verification
+
+cnn.preprocess_contract + transformer.tokenizer_contract:
+  promote only the common contract mechanism
+  keep contract content domain-specific
+```
+
+Primary files:
+
+```text
+osprey/common/com/dsl_opcode.h
+osprey/common/com/dsl_opcode.cxx
+osprey/common/com/dsl_domain.h
+osprey/common/com/dsl_domain.cxx
+osprey/be/vho/*
+doc/Open64_Domain_Specific_Compiler_IR_Design.md
+```
+
+Validation:
+
+1. Promotion registry accepts common promotion examples such as
+   `cnn.residual_add` and `transformer.residual_add` to
+   `common.residual_add`.
+2. Promotion rejects `transformer.tokenizer_contract` as common contract
+   content while allowing reuse of the common contract mechanism.
+3. Partial promotion records required verifier checks before lowering.
+4. Version mismatch and missing wrapper cases produce CPROM diagnostics.
+5. Domain wrappers remain visible to the DSL lowering pass until gatekeeper
+   checks are complete.
+
+Exit criteria:
+
+1. The compiler can explain why an opcode is common, domain-only, wrapped, or
+   partially promoted.
+2. Promotion decisions are explicit, versioned, and testable.
+3. CNN and Transformer can share common opcodes without losing gatekeeper
+   semantics.
+
+## Stage 7: Tensor Type System Stabilization
+
+Goal: Settle the common tensor type contract before changing WHIRL binary IR
+image type records.
+
+Coding changes:
+
+1. Define the required tensor fields:
+   `element_ty`, `rank`, `shape`, `layout`, `strides`, `memory_space`,
+   `quantization`, and `sparsity`.
+2. Define which fields can remain symbolic or pending.
+3. Define type equivalence rules for tensor types.
+4. Define tensor attributes such as `layout`, `sharding`, `placement`,
+   `memory`, `quantization`, runtime state, semantic traits, and lineage; these
+   complete TensorDescriptorIR semantics.
+5. Define compiler metadata such as source context, diagnostics, pass owner,
+   lowering hints, and profile data; these attach to `ST_IDX` or use sites and
+   do not create new tensor types.
+6. Define diagnostics for unresolved required tensor attributes.
+
+Primary files:
+
+```text
+doc/Open64_Domain_Specific_Compiler_IR_Design.md
+doc/WHIRL-DSL-INFRASTRUCTURE.md
+osprey/common/com/symtab.h
+osprey/common/com/symtab.cxx
+```
+
+Validation:
+
+1. Tensor attributes have documented required and optional fields.
+2. Delayed fields have explicit binding points.
+3. Type equivalence rules are clear enough to implement and exclude ordinary
+   compiler metadata.
+
+Exit criteria:
+
+1. It is clear whether two tensor types are equivalent, compatible, or require
+   conversion.
+2. Lowering passes can trust the tensor attribute contract.
+
+### Tensor Descriptor Binary Image Compatibility Note
+
+The tensor compatibility contract is driven first by fields that participate in
+computation, verifier legality, lowering, memory interpretation, or ABI.  A
+free-form key-value table is useful for extensibility, but it is not a suitable
+primary representation for hot compatibility checks such as deciding whether
+two tensor operands can feed `common.add`, `common.matmul`,
+`common.residual_add`, or a domain wrapper.
+
+Architecturally, TensorDescriptorIR remains a layered model:
+
+```text
+TensorTypeCore
+  kind, element type, rank, logical shape
+
+TensorRepresentationDescriptor
+  layout, strides/contiguity, memory space, placement, sharding,
+  quantization, sparsity, runtime-state dependency
+
+TensorTraitSet
+  semantic role, domain traits, mutability/aliasing traits, lineage
+```
+
+### DSL result ownership and no-alias contract
+
+Every value-producing DSL operator assigns its result to a tensor-typed
+temporary symbol.  That result symbol has unique memory ownership and the
+semantic attribute `no_alias=true` before the computation is verified or
+lowered.  The storage denoted by one live result symbol therefore does not
+overlap storage denoted by another live tensor symbol.
+
+#### Special DSL tensor result temporary
+
+The left-hand side of the result assignment is a special compiler-created
+temporary with this required conjunction of properties:
+
+```text
+ST_class             CLASS_VAR
+ST_IS_TEMP_VAR        set
+ST_type               tensor TY_IDX
+symbol attribute      no_alias=true
+addressability        no LDA or address escape before lowering
+definition shape      STID result_temp <- OPR_DSL(...)
+use shape             LDID result_temp
+```
+
+This is a semantic specialization of the existing Open64 temporary symbol, not
+a new `ST_CLASS`, storage-class encoding, or symbol-table image layout.  The
+construction API is `DSL_Builder_Create_Tensor_Result_Symbol()`.  The builder
+must establish the complete conjunction when the result temporary is declared;
+passes must not infer it later merely from a generated name.
+
+The `no_alias=true` assertion means that the result temporary has unique
+ownership.  It is not permitted to overlap another live tensor result, and no
+address-bearing WHIRL operation may create an alias before representation
+lowering.  The gatekeeper verifies this assertion before DSL computation is
+lowered.
+
+The CUDA/PTX virtual-register model is the precedent: an instruction result is
+carried by a uniquely named, non-addressable temporary, while physical register
+allocation and spilling are deferred.  Likewise, a very-high-level DSL tensor
+result may be defined by `STID` and used by `LDID`, but `LDA`, passing by
+address, and other address escapes are illegal before lowering.  The DSL
+gatekeeper must enforce this rule.
+
+`no_alias` is value/symbol state.  It is not part of tensor type equivalence,
+because multiple symbols may share one tensor `TY_IDX` while having distinct
+ownership.  It is not an opcode attribute or compiler metadata.  Allocation
+and placement may remain deferred even though ownership is already complete.
+
+The very-high-level tensor symbol must not use baseline
+`ST_PT_TO_UNIQUE_MEM` directly.  Existing WSSA gives that flag a pointer-typed
+contract.  When lowering materializes a pointer representation, it must
+preserve the DSL `no_alias=true` fact and may translate it to
+`ST_PT_TO_UNIQUE_MEM` when the baseline pointer requirements are satisfied.
+
+### Logical operator names hide the physical escape
+
+The limited 8-bit WHIRL operator field is extended internally through one
+physical escape tag.  That storage mechanism is not part of the compiler-facing
+DSL model.  Compiler developers see and manipulate logical operators such as
+`OPR_DSLADD`; they do not see `OPR_DSL` followed by a record-ID lookup.
+
+The required abstraction is:
+
+```text
+public compiler view       OPR_DSLADD(kid0, kid1)
+logical API                DSL_WN_operator(), DSL_OPERATOR_name()
+private WN storage         escape tag plus logical node-record reference
+```
+
+The private row may contain the stable opcode identity, semantic version,
+attributes, and result metadata, but only common DSL accessors, the mapped-image
+boundary, and the low-level verifier decode it.  `ir_b2a`, ordinary internal
+traces, diagnostics, frontends, optimizers, and lowering passes print or consume
+the logical operator name directly.  They must never expose the physical escape
+tag or internal record index.
+
+This separation of concern is the reason for the DSL API: changing the physical
+encoding must not require changes to compiler passes or visible IR vocabulary.
+
+Physically, the binary IR image should store the hot compatibility state in one
+fixed-layout tensor descriptor table.  The three layers are logical views over
+one ordered record, not three unrelated binary tables.  This preserves Open64's
+TABLE discipline: direct indexing, fixed offsets for common checks, and no
+unordered key scan in verifier or lowering hot paths.
+
+The first descriptor record should be shaped like this conceptually:
+
+```c
+typedef struct {
+  TY_IDX element_ty;
+  UINT16 rank;
+  UINT16 flags;
+
+  TENSOR_SHAPE_ID shape;
+  TENSOR_LAYOUT_ID layout;
+  TENSOR_STRIDES_ID strides;
+  TENSOR_MEMORY_SPACE_ID memory_space;
+  TENSOR_PLACEMENT_ID placement;
+  TENSOR_SHARDING_ID sharding;
+  TENSOR_QUANT_ID quantization;
+  TENSOR_SPARSITY_ID sparsity;
+  TENSOR_RUNTIME_STATE_ID runtime_state;
+  TENSOR_TRAIT_SET_ID traits;
+  TENSOR_LINEAGE_ID lineage;
+} TENSOR_DESCRIPTOR_RECORD;
+```
+
+IDs inside the descriptor may point to auxiliary tables only when the payload is
+variable-sized or naturally interned, for example symbolic shape expressions,
+layout parameters, sharding meshes, quantization parameters, sparsity encodings,
+or large trait sets.  Those auxiliary tables are not a substitute for the
+fixed-layout descriptor; they are payload stores referenced by typed slots.
+
+The existing key-value tensor extension table remains as a compatibility and
+extension mechanism:
+
+1. Migration bridge for existing `TY_tensor_*attribute*` storage.
+2. Debug and dump representation.
+3. Experimental fields that are not yet part of the compatibility hot path.
+4. Compiler metadata that must not affect tensor type equivalence.
+
+It must not be required for core compatibility checks.  A verifier should be
+able to compare typed fields such as `element_ty`, `rank`, `shape`, `layout`,
+`sharding`, `quantization`, and `memory_space` without scanning string keys.
+
+Compatibility tiers:
+
+1. Type equivalent: same tensor kind, element type, rank, and logical shape.
+2. Representation compatible: type equivalent, and layout, strides, memory
+   space, placement, sharding, quantization, sparsity, and runtime state are
+   equal or have an explicit conversion.
+3. Lowering compatible: representation compatible, and every required field is
+   bound enough for target code generation.
+4. Domain compatible: lowering compatible, and domain-required semantics such
+   as residual lineage, mask meaning, image layout, classifier-head contracts,
+   or projection/head-layout contracts remain visible through attributes,
+   wrappers, or promotion records.
+
+Binary image compatibility rules:
+
+1. Existing non-tensor `TY_KIND` records remain readable without change.
+2. Current `KIND_STRUCT` tensor carriers remain the compatibility fallback until
+   `KIND_TENSOR` reader, writer, printer, verifier, and `ir_a2b` support land
+   together.
+3. A future tensor descriptor section must be versioned or guarded by section
+   table count so older readers fail deterministically instead of silently
+   misreading records.
+4. `ir_bread` must accept legacy images that have no tensor descriptor table.
+5. `ir_bwrite` must write tensor descriptors only when required computational
+   fields are representable.
+6. Before `KIND_TENSOR` lands, `ir_b2a -st` must print tensor information from
+   the descriptor-shaped side-table view.  After `KIND_TENSOR` lands, the same
+   fields must become canonical tensor type dump fields.
+7. `ir_a2b` must either reconstruct equivalent tensor descriptors from ASCII or
+   reject unsupported tensor records with a deterministic diagnostic.
+8. Compiler metadata such as source context, diagnostics, pass owner, lowering
+   hints, profiling, and pass-local ownership must not participate in tensor
+   type equivalence.
+
+### Tensor Descriptor Code Action List
+
+1. Add a source-level `TENSOR_DESCRIPTOR_RECORD` sketch in `symtab.h` or a new
+   common/com header, with typed fields only and no behavior change.
+2. Add enum or typedef placeholders for descriptor payload IDs:
+   `TENSOR_SHAPE_ID`, `TENSOR_LAYOUT_ID`, `TENSOR_STRIDES_ID`,
+   `TENSOR_MEMORY_SPACE_ID`, `TENSOR_PLACEMENT_ID`, `TENSOR_SHARDING_ID`,
+   `TENSOR_QUANT_ID`, `TENSOR_SPARSITY_ID`, `TENSOR_RUNTIME_STATE_ID`,
+   `TENSOR_TRAIT_SET_ID`, and `TENSOR_LINEAGE_ID`.
+3. Add accessor prototypes that expose logical views over the single physical
+   record:
+   `TY_tensor_type_core`, `TY_tensor_representation`, and
+   `TY_tensor_trait_set`.
+4. Keep the current key-value attribute table as the backing store until the
+   fixed descriptor table exists.  Do not change compiler behavior in this
+   step.
+5. Add compatibility-check API prototypes:
+   `TY_tensors_type_equivalent`, `TY_tensors_representation_compatible`, and
+   `TY_tensors_lowering_compatible`.
+6. Add diagnostics for missing fixed-slot fields before lowering.
+7. Extend `Print_tensor_dsl_symtab` to group existing key-value fields under the
+   future descriptor slots, making migration gaps visible.  This is the
+   pre-`KIND_TENSOR` `ir_b2a -st` path: the carrier may still be `KIND_STRUCT`,
+   but the dump is descriptor-shaped.
+8. Add side-table based descriptor-view accessors that read from the existing
+   key-value table and return typed-slot answers where fields are bound.  This
+   enables verifier experiments without changing the core `TY_KIND` enum.
+9. Run `dsl_ir_tools_smoke_test.sh` before and after any patch that reserves or
+   changes binary image tensor descriptor sections.
+10. Only after the source-level probe and descriptor-shaped dump are reviewed,
+    reserve the binary image section/table name for the single descriptor
+    table.
+11. Add `KIND_TENSOR` only when the type printer, `ir_b2a -st` canonical tensor
+    dump, binary reader, binary writer, ASCII reader/printer plan, verifier, and
+    `KIND_STRUCT` fallback behavior are implemented in the same staged change.
+
+## Stage 8: Promote Tensor To A First-Class WHIRL Type
+
+Goal: Move from staging carrier types to a first-class common tensor type.
+
+Coding changes:
+
+1. Add `KIND_TENSOR` to `TY_KIND`.
+2. Add tensor-aware accessors and verifier checks.
+3. Decide whether tensor attributes remain side-table based or become part of
+   the binary IR image type-extension records.
+4. Update type printing and dumps.
+5. Update type equivalence and IPA type merge logic.
+6. Update WHIRL reader/writer versioning if binary IR image records change.
+
+Primary files:
+
+```text
+osprey/common/com/symtab_defs.h
+osprey/common/com/symtab_access.h
+osprey/common/com/symtab.h
+osprey/common/com/symtab.cxx
+osprey/common/com/symtab_verify.cxx
+osprey/common/com/ir_bread.cxx
+osprey/common/com/ir_bwrite.cxx
+osprey/ir_tools/ir_a2b.cxx
+osprey/ipa/common/*type* or type merge files
+```
+
+Validation:
+
+1. Existing scalar, array, struct, pointer, and function type behavior is
+   unchanged.
+2. Tensor types dump and reload correctly.
+3. IPA merge either preserves tensor attributes or rejects incompatible tensor
+   types with a useful diagnostic.
+4. `ir_a2b` can read ASCII tensor type records and produce a binary IR image
+   containing tensor type records, and `ir_b2a` can print that image back to
+   ASCII, or this stage is not considered complete.
+
+Exit criteria:
+
+1. Tensor is represented by `TY_KIND = KIND_TENSOR`.
+2. The staging `KIND_STRUCT` carrier can be treated as compatibility fallback.
+3. ASCII reader/printer, binary image writer, binary image reader, dumper, and
+   verifier support for `KIND_TENSOR` land together.
+
+## Stage 9: DSL Lowering Pass
+
+Goal: Consume very-high WHIRL DSL markers and tensor attributes before
+standard optimization phases require canonical WHIRL.
+
+Coding changes:
+
+1. Add a VHO-adjacent DSL lowering pass.
+2. Scan function bodies for DSL markers.
+3. Validate required tensor attributes.
+4. Lower supported DSL features to canonical WHIRL, runtime calls, or target
+   intrinsics.
+5. Report unlowered required markers.
+6. Add a `-VHO:dsl_lower` or equivalent option.
+7. If the lowering implementation uses C++ namespaces internally, expose a
+   global driver entry point callable from existing VHO phase code.
+8. Lowering pass registration should consume domain IDs and contract IDs from
+   the registry before it depends on C++ namespace classes.
+
+Primary files:
+
+```text
+osprey/be/vho/*
+osprey/common/com/config_vho.h
+osprey/common/com/config_vho.cxx
+osprey/driver/OPTIONS
+```
+
+Validation:
+
+1. Required DSL markers are either consumed or diagnosed.
+2. Lowered functions no longer require DSL-only semantics.
+3. Existing VHO lowering still sees legal WHIRL.
+4. `ir_a2b` can still convert already-lowered WHIRL, and unlowered DSL marker
+   input has a deterministic policy: preserve as comments or reject with a
+   clear diagnostic.
+
+Exit criteria:
+
+1. A simple tensor operation can lower through the DSL pass.
+2. Unsupported tensor attributes produce a clear error before WOPT/LNO/CG.
+
+## Stage 10: Optional C++ Namespace Facade
+
+Goal: Introduce C++ namespace organization only after domain registry and
+contract metadata are stable.
+
+Coding changes:
+
+1. Add optional leaf-layer wrappers such as
+   `namespace ant::domain::transformer`.
+2. Keep common-core APIs global and stable.
+3. Provide adapters from namespaced C++ classes to global registration calls.
+4. Avoid moving existing `common/com` declarations into namespaces.
+5. Gate the facade behind build settings if needed.
+
+Primary files:
+
+```text
+osprey/dsl/*
+osprey/be/vho/*
+osprey/ir_tools/*
+```
+
+Validation:
+
+1. The compiler can build and run without the namespace facade.
+2. Namespaced adapters register the same domain IDs and contracts as the global
+   API path.
+3. No existing Open64 include path is forced to import a new namespace.
+
+Exit criteria:
+
+1. C++ namespaces become organizational sugar over stable registry data, not the
+   source of semantic truth.
+
+## Stage 11: Target-Specific Tensor Lowering
+
+Goal: Map common tensor semantics to target-specific hardware forms only after
+legality is known.
+
+Coding changes:
+
+1. Add target hooks for tensor lowering decisions.
+2. For NVIDIA, introduce a target-specific representation for Tensor Core
+   WMMA/MMA fragments if needed.
+3. Keep general `MTYPE_TENSOR` out of the common DSL/source level.
+4. Add target legality checks for shape, dtype, layout, and fragment size.
+5. Lower valid cases to intrinsics or target-specific IR.
+6. Lower invalid cases to runtime/library fallback or report diagnostics.
+
+Primary files:
+
+```text
+osprey/common/com/NVISA/*
+osprey/be/cg/*
+osprey/be/vho/*
+osprey/common/intr/*
+```
+
+Validation:
+
+1. Common tensor types do not imply target-specific fragments prematurely.
+2. NVIDIA Tensor Core fragments appear only after target lowering.
+3. CPU targets continue to lower tensor operations through aggregate, runtime,
+   or library paths.
+
+Exit criteria:
+
+1. One target-specific tensor kernel path is demonstrably separated from the
+   common tensor type system.
+
+## Stage 12: Tests And Diagnostics
+
+Goal: Make the feature maintainable and debuggable.
+
+Coding changes:
+
+1. Add unit-style tests for DSL marker APIs.
+2. Add tensor type extension tests.
+3. Add Python DSL ingestion and binary WHIRL builder boundary regression inputs
+   with DSL markers, first-class operators, tensor descriptors, opcode
+   attributes, contracts, and compiler metadata.
+4. Add dump output checks for tensor types and DSL markers.
+5. Add negative tests for missing required tensor attributes.
+6. Add domain registry and contract registry tests.
+7. Add opcode registry and promotion registry tests.
+8. Add tests proving domain IDs and opcode IDs do not require C++ namespaces.
+9. Add CPROM diagnostic tests for invalid or unsafe promotion.
+10. Add `ir_a2b`/`ir_b2a` smoke tests for non-DSL input, DSL-marker input, and,
+   once enabled, first-class tensor type records.
+
+Primary locations:
+
+```text
+test/
+osprey/ir_tools/
+doc/
+```
+
+Validation:
+
+1. Tests cover marker creation, type extension declaration, delayed binding,
+   lowering consumption, and diagnostics.
+2. Dumps explain tensor attributes clearly enough for compiler debugging.
+3. `ir_a2b` remains green for legacy WHIRL and has deterministic behavior for
+   DSL-marked WHIRL.
+
+Exit criteria:
+
+1. A developer can modify tensor attribute handling and catch regressions before
+   backend lowering.
+2. `ir_a2b` remains a required green check for every staged landing.
+
+## Migration Rules
+
+1. Do not replace `KIND_STRUCT` staging carriers until `KIND_TENSOR` binary IR
+   image layout, ASCII form, and equivalence are designed.
+2. Do not introduce common `MTYPE_TENSOR` for source-level DSL tensors.
+3. Target-specific tensor fragment `MTYPE`s are allowed only after lowering.
+4. Keep DSL metadata explicit and inspectable.
+5. Every stage must preserve legal WHIRL for components that are not yet
+   DSL-aware.
+6. Do not introduce namespaces into existing common-core headers as part of DSL
+   IR work; add namespaced code only behind global compatibility wrappers.
+7. Treat namespace hierarchy as semantic registry data first and C++ namespace
+   syntax second.
+8. Do not make the gatekeeper depend on C++ namespace availability.
+9. Do not land a staged change unless `osprey/ir_tools/ir_a2b.cxx` either keeps
+   working unchanged or is updated in the same stage with matching tests.
+10. Do not promote an opcode into `common.*` unless the promotion registry can
+    prove that domain-specific ABI and gatekeeper checks remain visible through
+    wrappers or partial-promotion rules.
+11. Do not lower semantically rich domain ops such as `cnn.conv2d` or
+    `transformer.attention` into common tensor contractions before domain
+    verification has certified their contracts.
+12. Treat Python as a source-language frontend only; the Open64 middle end must
+    consume a binary WHIRL artifact without depending on the original Python
+    interpreter.
+13. Do not use intrinsic ops, runtime calls, or target libraries as the primary
+    ingestion representation for domain/common operators.  They are products of
+    explicit lowering after gatekeeper verification and target-independent
+    optimization.
+14. Keep the binary artifact model aligned with Open64's mapped IR image design.
+    The V0.9 design name for the artifact boundary is
+    `WhirlMappedImageFinalizer`, reflecting direct mapped-image finalization.
+
+## Near-Term Coding Queue
+
+Completed:
+
+1. Add iteration APIs for `TY_IDX` tensor attributes and `ST_IDX` tensor
+   metadata, not just key lookup.
+   Implemented by commit `18491fc0` with `TY_tensor_attribute_count`,
+   `TY_tensor_attribute_at`, `ST_tensor_metadata_count`, and
+   `ST_tensor_metadata_at`.
+2. Add a small tensor schema enum for common keys.
+   Implemented by commit `ac7f0bf6` with `TY_TENSOR_SCHEMA_KEY`,
+   `TY_tensor_schema_key_name`, and enum-based tensor attribute / metadata
+   accessors.
+3. Add a first VHO scanner that reports unconsumed DSL markers.
+   Implemented by commit `57a4ebcd` with `VHO_Scan_Unconsumed_DSL_Markers`,
+   `VHO_Has_Unconsumed_DSL_Markers`, and
+   `VHO_fprint_unconsumed_DSL_markers`.
+4. Add diagnostics for unbound required tensor attributes.
+   Implemented by commit `1b9ff531` with
+   `TY_tensor_unbound_required_attribute_count`,
+   `TY_tensor_has_required_attributes`, and
+   `TY_tensor_fprint_unbound_required_attributes`.
+5. Add `dsl_domain.h` and `dsl_domain.cxx` with string-based domain registry
+   APIs.
+   Implemented by commit `10888e75` with `DSL_Domain_Register`,
+   `DSL_Domain_Find`,
+   `DSL_Domain_Get_Info`, `DSL_Domain_At`, and
+   `DSL_Domain_fprint_registry`.
+6. Add a small contract registry stub that models source domain, target domain,
+   required checks, and diagnostic codes.
+   Implemented by commit `97e5a842` with `DSL_Contract_Register`,
+   `DSL_Contract_Find`, `DSL_Contract_Get_Info`,
+   `DSL_Contract_Required_Check_At`, and
+   `DSL_Contract_Diagnostic_Code_At`.
+7. Add `dsl_opcode.h` and `dsl_opcode.cxx` with category, owner, level,
+   version, shape, effect, and lowering metadata.
+   Implemented by commit `291e88c2` with `DSL_Opcode_Register`,
+   `DSL_Opcode_Find`, `DSL_Opcode_Get_Info`, enum-name helpers, and
+   `DSL_Opcode_fprint_registry`.
+8. Seed the common opcode registry with Level 0 through Level 4 substrate
+   opcodes.
+   Implemented by commit `7a9fa050` with
+   `DSL_Opcode_Register_Common_Substrate`, which registers the planned
+   `common.*` operator descriptors under the runtime `common` domain.
+9. Add domain wrapper examples for `cnn.linear`,
+   `transformer.q_projection`, `cnn.residual_add`, and
+   `transformer.residual_add`.
+   Implemented by commit `607ddd02` with
+   `DSL_Opcode_Register_Domain_Wrapper`,
+   `DSL_Opcode_Register_Domain_Wrapper_Examples`, and wrapper target
+   metadata in `DSL_OPCODE_INFO`.
+10. Add the opcode promotion registry and CPROM diagnostics.
+    Implemented by commit `ce4c4728` with
+    `DSL_Opcode_Promotion_Register`,
+    `DSL_Opcode_Promotion_Register_Examples`,
+    `DSL_Opcode_Check_Promotion`, promotion-state names, and stable
+    `CPROM-001` through `CPROM-010` diagnostic codes.
+11. Add an `ir_a2b`/`ir_b2a` smoke test fixture before expanding binary IR
+    image type records.
+    Implemented by commit `d7378bd6` with
+    `osprey/common/com/tests/dsl_ir_tools_smoke_test.sh`, which generates a
+    fresh `.B` file, verifies `ir_b2a` output, and records the current
+    deterministic `ir_a2b` compatibility gate.
+12. Add a source-level tensor descriptor record probe without behavior change.
+    Implemented in the current working tree with typed placeholder IDs,
+    `TENSOR_DESCRIPTOR_RECORD`, `TENSOR_DESCRIPTOR_RECORD_Init`, and
+    `TY_get_tensor_descriptor_record`.  The record is a fixed-layout source
+    view over the existing tensor extension and key-value attribute backing
+    store; it does not add `KIND_TENSOR`, reserve a binary section, or change
+    binary reader/writer behavior.
+13. Add descriptor-shaped `ir_b2a -st` side-table dumping.
+    Implemented in the current working tree by extending
+    `Print_tensor_dsl_symtab` to show a `TensorDescriptorIR view` grouped into
+    `TensorTypeCore`, `TensorTraitSet`, `TensorRepresentationDescriptor`, and
+    `TensorLineageMetadata`.  The dump still uses the existing tensor extension
+    and key-value backing store, preserves the raw key-value view, makes missing
+    fixed slots visible as `<missing>`, and does not add `KIND_TENSOR`.
+14. Add native C++ ingestion-readiness fixtures before Python bindings.
+    Implemented in the current working tree with
+    `osprey/common/com/tests/dsl_ingestion_fixture.h`.  The fixture simulates
+    future Python builder calls from native C++ tests by creating staged tensor
+    types, symbols, tensor constants, `common.add`, and `common.matmul`, while
+    attaching opcode attributes as static operation parameters and source
+    context/lowering hints through compiler metadata.  It does not introduce
+    Python, pybind, packaging, driver integration, native WHIRL tensor opcodes,
+    `KIND_TENSOR`, or binary image sections.
+15. Sketch the minimal C++ builder-facing API without changing compiler
+    behavior.
+    Implemented in the current working tree with
+    `osprey/common/com/dsl_builder.h`.  The header defines the native builder
+    boundary for tensor type core creation, TensorDescriptorIR attachment,
+    symbol creation, first-class DSL operator creation, contract attachment,
+    compiler metadata attachment, and mapped image finalization.  It documents
+    possible future C++ facade names while keeping Open64-style API names as
+    the first public contract, and it explicitly keeps intrinsic creation out
+    of the frontend construction API.
+16. Add the smallest source-level binary image probe after the descriptor-shaped
+    dump is reviewed.
+    Implemented in the current working tree by reserving
+    `WT_DSL_TENSOR_DESCRIPTOR` / `.WHIRL.dsl_tensor_descriptor` in
+    `osprey/include/sys/elf_whirl.h` and adding
+    `osprey/common/com/dsl_ir_image.h` as a source-level description of the
+    future fixed-row tensor descriptor image.  This probe reserves only the
+    vocabulary for a future combined TensorDescriptorIR image section; it does
+    not add `KIND_TENSOR`, does not connect to `ir_bread.cxx` or
+    `ir_bwrite.cxx`, and does not change current binary reader/writer behavior.
+17. Add `KIND_TENSOR` as the first integrated type-system change.
+    Implemented in the current working tree by adding `KIND_TENSOR = 7` while
+    preserving all existing `TY_KIND` values and keeping `KIND_LAST = 8`.  The
+    native tensor TY path uses `TY_Create_Tensor_Type`, records element type,
+    rank, and TensorDescriptorIR slots in the existing tensor extension side
+    table, and leaves `TY_Create_Tensor_Extension_Type` available as the
+    `KIND_STRUCT` carrier fallback.  `Kind_Name`, `TY::Print`,
+    `ir_b2a -st`-visible descriptor dumping, verification, type hashing, and
+    type equivalence now understand native tensor TYs.  The binary table layout
+    is unchanged; existing reader/writer paths continue to move TY records and
+    side-table-backed staged tensor descriptors without adding a new emitted
+    tensor descriptor ELF section yet.
+18. Add the Chapter 7 Python DSL ingestion design note before coding the
+    frontend.
+    Implemented in this plan by adding the `Chapter 7 Ingestion Boundary Design
+    Note` under Stage 1.  The note defines `open64_dsc` as a thin Python
+    capture/interpreter package, assigns WHIRL node creation, symbol/type table
+    ownership, TensorDescriptorIR attachment, opcode attributes, contracts,
+    compiler metadata, and mapped image finalization to the native C++ builder
+    boundary, names `WhirlMappedImageFinalizer` as the artifact-finalization
+    component, preserves first-class operators through gatekeeper and
+    target-independent optimization, and states that `mpl2whirl` is not the
+    active DSL ingestion path.
+19. Define the first ResNet inference vertical-slice operator list in the
+    opcode registry plan.
+    Implemented in this plan by adding the `First ResNet Inference Vertical
+    Slice` section under Stage 1.  The slice includes `cnn.conv2d`,
+    `cnn.batch_norm_infer`, `common.relu`, `cnn.max_pool2d`,
+    `common.residual_add`, `cnn.global_avg_pool2d`, `common.flatten`,
+    `common.linear`, and `common.output_logits`.  It characterizes operand
+    policy, static opcode attributes, TensorDescriptorIR ownership, compiler
+    metadata ownership, and the rule that CNN-specific operators remain domain
+    operators until domain gatekeeper verification completes.
+20. Add the staged driver artifact boundary plan.
+    Implemented in this plan by adding the `Staged Driver Artifact Boundary`
+    section.  The first workflow is explicitly two-step:
+    `torch2whirl model.py -o model.B`, then `opencc -x whirl model.B ...`.
+    The combined `opencc -frontend=torch2whirl ...` mode is deferred until the
+    binary WHIRL artifact boundary is stable, inspectable with `ir_b2a -st`,
+    and consumable by Open64 without importing Python.
+
+Parked:
+
+1. Add a sample MPL tensor marker path once MPL tensor syntax is identified.
+   Status: precondition not met.  The current `mpl2whirl` path translates
+   Maple primitive, pointer, array, struct, union, and function types, but no
+   first-class MPL tensor syntax or tensor type kind has been identified in the
+   checked-in source.  Do not add speculative `mpl2whirl.cxx` marker hooks;
+   resume this item only after the MPL tensor source syntax and MIR type
+   representation are explicitly defined.
+
+Active queue:
+
+The current near-term planning queue is complete.  Start the next queue only
+after reviewing the completed plan items and choosing whether the next phase is
+opcode-registry implementation, native builder API implementation, binary image
+persistence, or Python frontend scaffolding.

--- a/doc/RESNET-NATIVE-WHIRL-PLAN.md
+++ b/doc/RESNET-NATIVE-WHIRL-PLAN.md
@@ -1,0 +1,428 @@
+# Native ResNet WHIRL Operator Plan
+
+## Purpose
+
+This is the main-agent plan for extending `common/com`, the native WHIRL
+builder, the DSL gatekeeper, binary image inspection, and VHO DSL lowering so a
+torch2whirl producer can emit a complete ResNet inference graph.
+
+The work proceeds concurrently with
+`osprey/torch2whirl/RESNET-INGESTION-PLAN.md`.  This document owns the compiler
+contract.  The torch2whirl plan consumes that contract through opaque builder
+handles and must not reproduce WHIRL internals in Python.
+
+## Certified Artifact
+
+A ResNet `.B` file is certified only when all of the following hold:
+
+1. The native torch2whirl backend writes the artifact through the existing
+   mapped-image and ELF WHIRL framework.
+2. A separate `ir_b2a -st` process reads the artifact and displays the complete
+   logical ResNet graph, symbol/type tables, tensor descriptors, opcode
+   attributes, value ownership, and all DSL image tables.
+3. The output exposes logical operator names and never exposes `OPR_DSL`,
+   `OPC_MDSL`, `MDSL`, or private record indices.
+4. `DSL_Gatekeeper_Verify_Program()` accepts every PU before output and again
+   before lowering.
+5. Every tensor result is a complete TensorDescriptorIR value carried by a
+   unique, non-addressable, `no_alias=true` temporary.
+6. Immutable parameters and BatchNorm state resolve through a checked external
+   tensor side-file manifest; model inputs are runtime values, not constants.
+7. `opencc -x whirl -O0` completes mandatory VHO DSL lowering and proves that
+   no executable native, EVAL, or XPRAGMA DSL carrier reaches standard VHO,
+   WOPT, LNO, or CG.  High-level `OPR_COMMENT` projections remain legal.
+8. Existing baseline WHIRL and older files without a DSL section remain
+   readable and unchanged.
+
+## Shared Native Contract
+
+All logical operator enum values and names are append-only compatibility
+contracts.  Static operation parameters are typed opcode attributes.  Tensor
+semantic state belongs in TensorDescriptorIR.  Source names, diagnostics,
+pass ownership, lowering hints, and profile information remain compiler
+metadata.
+
+The three released native operators retain version 1.  The ten ResNet names
+already had released marker-only version-1 descriptors, so their native
+contracts are appended as version 2 instead of changing version 1 in place.
+
+| Stable operator | Native version | Kids | Required attributes | Result rule | Initial `-O0` lowering |
+| --- | ---: | ---: | --- | --- | --- |
+| `common.model_input` | 2 | 0 | `attr.input_ordinal` | Declared input descriptor | Runtime input handle |
+| `common.tensor_const` | 1 | 0 | `value_kind`, `value` | Declared constant descriptor | Splat or external-data handle |
+| `cnn.conv2d` | 2 | 3 | kernel, stride, padding, dilation, groups, input/weight/output layout | Convolution formula | Versioned runtime call |
+| `cnn.batch_norm_infer` | 2 | 5 | epsilon, training=false, input layout, channel axis | Input shape/layout | Versioned runtime call |
+| `common.relu` | 2 | 1 | none | Input descriptor | Versioned runtime call |
+| `cnn.max_pool2d` | 2 | 1 | kernel, stride, padding, dilation, ceil mode | Pooling formula | Versioned runtime call |
+| `common.residual_add` | 2 | 2 | broadcast=none, shape_check=exact, residual_path=true | Exact operand descriptor | Verify, then lower to add |
+| `cnn.global_avg_pool2d` | 2 | 1 | output size, reduction axes | Spatial dimensions become one | Versioned runtime call |
+| `common.flatten` | 2 | 1 | start dimension, end dimension | Collapsed logical dimensions | Owning runtime result |
+| `common.linear` | 2 | 3 | bias, input/weight transpose, weight layout | Batch dimensions plus output features | Versioned linear call |
+| `common.output_logits` | 2 | 1 | semantic role | Input descriptor plus output role | Owning output handle |
+
+The physical WN representation remains private.  The existing value-oriented
+frontend APIs remain stable wherever possible:
+
+```text
+DSL_Builder_Create_Operator
+DSL_Builder_Append_PU_Value
+DSL_Builder_Count_PU_Values
+DSL_Builder_Get_PU_Value
+DSL_Builder_Finalize_Mapped_Image
+```
+
+## Main-Agent Ownership
+
+The main agent owns:
+
+1. Append-only logical operator IDs and table-driven descriptors.
+2. Native result-producing WN construction and direct operand kids.
+3. Result type inference and TensorDescriptorIR construction.
+4. No-alias result symbols and address-escape enforcement.
+5. Fixed-row opcode, node, attribute, value, and value-reference records.
+6. Binary mapped-image revision, writer, reader, and compatibility behavior.
+7. Logical tree and `ir_b2a -st` printing.
+8. Gatekeeper rules and stable diagnostics.
+9. Versioned runtime ABI declarations and VHO DSL lowering.
+10. Native C++ regression fixtures and baseline WHIRL protection.
+
+The main agent does not own PyTorch graph capture, Python module loading,
+safetensors file generation, or Python CLI behavior.
+
+## Implementation Queue
+
+### M0: Freeze Operator Contracts
+
+- [x] Append the logical enum values without renumbering released values.
+- [x] Add every operator to the authoritative seed with version, arity,
+  category, level, shape rule, effects, lowering model, attribute schema, and
+  diagnostic prefix.
+- [x] Add contract tests that lock enum values, stable names, and schemas.
+- [x] Publish the exact attribute spelling and defaults to the torch2whirl plan.
+
+Exit gate: torch2whirl can emit stable names and attributes without depending
+on unfinished physical construction.
+
+### M1: Model Inputs And External Parameters
+
+- [x] Make `common.model_input` a native value source with a complete declared
+  descriptor and runtime input ordinal.
+- [x] Extend `common.tensor_const` so `splat` and `external_data` are distinct,
+  verified value kinds.  Do not parse an external URI as a scalar.
+- [x] Define the version-1 external tensor reference: storage format, side-file
+  identity, tensor key, byte offset, byte length, checksum, dtype, shape, and
+  layout.
+- [x] Verify bounds, alignment, dtype, shape, and checksum metadata before
+  artifact finalization.
+- [x] Add runtime ABI entry points for input and external immutable handles.
+
+Exit gate: a native PU can consume a model input and immutable ResNet weights
+without compatibility carriers.
+
+G1 completed on 2026-07-12.  The builder and gatekeeper independently check
+input ordinals, structured external references, unsigned range overflow,
+dtype alignment, static shape byte size, checksum form, representation, and
+the URI projection consumed by the versioned runtime ABI.  The producer owns
+checking the actual side-file size and computing its digest before C++
+finalization; C++ owns validating that the supplied facts are mutually
+consistent in WHIRL.  The linked lowering fixture proves that both value
+sources pass the gatekeeper, lower to distinct runtime calls, and capture
+their returned handles in unique PREGs.  Duplicate input ordinals and tampered
+external metadata are rejected.
+
+### M2: Simple ResNet Values
+
+- [x] Add native `common.relu`.
+- [x] Add native `common.flatten` with checked dimension normalization.
+- [x] Add native `common.residual_add` with exact-shape verification.
+- [x] Add native `common.output_logits` and preserve its semantic output role.
+- [x] Populate all fixed-row image records from the same construction calls.
+- [x] Add logical dump, mapped-image roundtrip, malformed-input, and lowering
+  tests for each operator.
+
+Exit gate: a residual fragment can be built, verified, printed, reopened, and
+lowered without marker-only values.
+
+G2 completed on 2026-07-12.  The generic builder now creates all four logical
+version-2 operators as native result-producing expressions.  ReLU,
+residual-add, and output-logits preserve the input descriptor while producing
+distinct no-alias values.  Flatten normalizes negative or positive dimensions,
+checks a static shape, and creates a new descriptor with the collapsed shape
+and `common.flatten` lineage.  The gatekeeper independently verifies exact
+residual semantics, the logits role, and the flatten result formula.
+
+The producer-style fixture writes a real `.B`, and a separate `ir_b2a -st`
+process reopens it and displays all four logical names, typed attributes,
+direct value references, `[4]` flatten result, and `no_alias=true` symbols.
+The dump retains high-level comment projections, uses result symbol names for
+intermediate operands, and does not expose `OPR_DSL` or `MDSL`.  Mandatory
+lowering emits version-1 runtime ABI calls and captures all five returned
+handles, including the model input, in distinct pointer-sized PREGs.
+
+### M3: Linear Layer
+
+- [x] Add native `common.linear` with input, weight, and bias kids.
+- [x] Verify rank, feature compatibility, transpose flags, and weight layout.
+- [x] Infer the complete output descriptor.
+- [x] Keep linear visible through VHO optimization; do not decompose it during
+  ingestion.
+- [x] Add an `-O0` runtime-call lowering.  A later optional pass may select a
+  library call or decompose it to matmul and add.
+
+Exit gate: the ResNet classifier tail reaches an owning logits result.
+
+### M4: CNN Operators
+
+- [x] Add native `cnn.conv2d` with full static parameter verification and the
+  NCHW/OIHW native version-2 shape formula.
+- [x] Add native `cnn.batch_norm_infer`; reject training mode and missing
+  running statistics.
+- [x] Add native `cnn.max_pool2d` with floor/ceil shape semantics.
+- [x] Add native `cnn.global_avg_pool2d` with explicit spatial axes.
+- [x] Preserve CNN operators until their domain checks complete; do not promote
+  or fuse them during ingestion.
+- [x] Add versioned runtime calls as the mandatory `-O0` routes.
+
+Exit gate: a ResNet stem, basic block, downsample block, and pooling tail each
+pass native construction, gatekeeping, binary inspection, and lowering.
+
+### M5: Whole-Graph Gatekeeper
+
+- [x] Verify topological definitions and direct operand `LDID`s across the full
+  model.
+- [x] Verify every result descriptor, required typed attribute, domain contract,
+  and external tensor reference.
+- [x] Reject result address escape, duplicate definition, unsupported version,
+  missing operator, stale image row, and source-metadata/type confusion.
+- [ ] Check that result shapes observed by torch2whirl agree with the C++ shape
+  functions; C++ remains authoritative.
+
+Exit gate: finalization refuses malformed ResNet graphs and writes no partial
+artifact.
+
+### M6: Binary Inspection And Lowering
+
+- [x] Extend logical printing for every new operator and attribute schema.
+- [x] Confirm all new rows use the existing optional DSL ELF section and current
+  revision policy.
+- [x] Lower every verified result to a distinct pointer-sized PREG handle.
+- [x] Preserve source positions, compiler metadata, descriptor constants, and
+  requested comment projections.
+- [x] Run the canonical-boundary scan before standard language VHO.
+
+Exit gate: the complete model survives write/read in a separate process and
+`opencc -x whirl -O0` leaves no executable DSL carrier.
+
+### M7: Main-Agent Certification
+
+- [x] Build a C++ ResNet-shaped producer independent of Python.
+- [x] Write and reopen the complete `.B` image.
+- [x] Check `ir_b2a` and `ir_b2a -st` for every operator and DSL table.
+- [x] Run valid, malformed, unknown-version, address-escape, old-image, and
+  baseline tests.
+- [x] Run `opencc -x whirl -O0` through object generation.  Linking remains a
+  runtime implementation concern.
+- [x] Publish the exact build and validation commands for the torch2whirl
+  certification run.
+
+### M8A: Promote A Common WHIRL Region Substrate
+
+- [ ] Inventory region services into WN-structural and optimizer-RID groups;
+  document the ownership boundary before moving code.
+- [ ] Add a narrowly scoped `common/com` region API for construction, primary
+  and supporting pragmas, structural verification, source-position
+  propagation, region IDs, and safe body splicing.
+- [ ] Promote stable RID identity, hierarchy, and centrally managed WN-to-RID
+  lookup into `common/com`; retain the existing global map interface as a
+  compatibility wrapper during migration.
+- [ ] Bring up the reserved `WT_REGIONS` subsection as a fixed-row mapped-image
+  table containing stable region IDs, parent IDs, kinds, depths, and
+  PU-tree-relative WN offsets.  Never place `WN*` or `RID*` addresses in a row.
+- [ ] Add a repeatable region symbol-interface table with `ST_IDX`, ordinal,
+  compatibility flags, and provisional `INPUT`, `OUTPUT`, `INOUT`, and
+  `RESULT` role bits.  Keep its physical rows private behind common APIs.
+- [ ] Implement the common API as wrappers over the existing `OPR_REGION`,
+  `WN_CreateRegion`, and block utilities.  Do not change WN layout, region-kind
+  encodings, or existing public entry points.
+- [ ] Add common/com tests for empty and populated pragma regions, first-pragma
+  classification, parent/statement links, declared symbol interfaces,
+  mapped-image roundtrip, logical printing, and body splicing.
+- [ ] Migrate the CNN builder first so the new API is exercised without
+  changing LNO.
+- [ ] Migrate pure structural queries now pulled from `be/region` by
+  `common/com`; remove backend includes from common code where behavior can be
+  preserved exactly.
+- [ ] Convert one LNO automatic-parallelization construction path at a time,
+  retaining its dependence updates, derived boundary sets, and parentization
+  sequence while redirecting RID creation and lookup through common services.
+- [ ] Compare pre-migration and post-migration LNO WHIRL dumps and run
+  automatic-parallelization tests after every converted call site.
+- [ ] Keep optimizer levels, derived alias/preg boundary sets, region bounds,
+  and backend lowering in `be/region`; use them to check or refine the declared
+  common symbol interface rather than making them mapped-image contracts.
+
+Exit gate: frontend and backend clients share one common region and RID service,
+the mapped image preserves stable region and declared symbol-interface rows,
+LNO output is unchanged, and backend-derived boundary analysis remains intact.
+
+### M8B: Preserve CNN Block Structure With WHIRL Regions
+
+- [ ] Define an append-only logical pragma contract for CNN BasicBlock,
+  Bottleneck, input, result, shortcut kind, stage, and block ordinal.
+- [ ] Represent each structured CNN block as an `OPR_REGION` with
+  `REGION_KIND_PRAGMA`, an empty exits block, a CNN contract pragma block, and
+  an ordered operator body block.
+- [ ] Model construction after LNO automatic parallelization: make the first
+  pragma the classifier, propagate line numbers, assign a region ID, parentize
+  the completed region, and insert it into the enclosing statement block.
+- [ ] Have the native builder populate the managed common RID and region-symbol
+  tables.  Python continues to see only opaque value and region handles.
+- [ ] Keep convolution, normalization, activation, and residual operations as
+  first-class expression-level DSL nodes inside the region.
+- [ ] Have the enclosing region or PU create each complete tensor result symbol
+  with `no_alias=true`, declare it as an `OUTPUT|RESULT`, and let the inner
+  region store into that caller-owned location.  Do not treat `OPR_REGION` or
+  `OPR_BLOCK` as a tensor-valued expression.
+- [ ] Require every value defined in a region and consumed outside it to appear
+  in the declared output interface.  Defer conversion to SSA definitions,
+  block arguments, and merge values until the DSL middle-end SSA stage.
+- [ ] Have torch2whirl preserve source module hierarchy and propose BasicBlock,
+  Bottleneck, identity-shortcut, and projection-shortcut contracts.
+- [ ] Have the C++ CNN gatekeeper certify each proposed contract from region
+  topology, operand identity, operator attributes, and tensor descriptors.
+- [ ] Print the logical CNN region and its contract in `ir_b2a` while hiding
+  private pragma and DSL image indices.
+- [ ] Dissolve the region only after CNN gatekeeping and any whole-block VHO
+  optimization; reconnect its body using the established MP-region splicing
+  pattern, then promote eligible leaf operations to the common substrate.
+- [ ] Add mapped-image and lowering tests for identity BasicBlock, projection
+  BasicBlock, Bottleneck, malformed shortcut, mismatched result, and an older
+  ResNet image without structured regions.
+
+Exit gate: the binary VHO WHIRL image retains and exposes certified ResNet
+block and shortcut semantics without changing the expression-level contracts
+already used by the leaf operators.
+
+## Concurrent Handoff Gates
+
+| Gate | Main-agent deliverable | torch2whirl work unblocked |
+| --- | --- | --- |
+| G0 | Stable names, versions, arities, and attributes | Final Python mapping tables and negative tests |
+| G1 | Complete: native model-input and checked external-data values | Native parameters, inputs, and safetensors references |
+| G2 | Complete: ReLU, flatten, residual-add, output-logits | Native residual block and classifier boundary |
+| G3 | Complete: native linear | Complete classifier tail |
+| G4 | Complete: native CNN operators | Complete native ResNet graph |
+| G5 | Complete on the main side: whole-graph gatekeeper and image rows | Certified `.B` generation and `ir_b2a -st` test |
+| G6 | Complete: mandatory `-O0` lowering | `opencc -x whirl` certification |
+
+No gate permits torch2whirl to inspect WN fields, symbol tables, DSL image rows,
+or physical operator encodings.  A gate is complete only when its native C++
+contract tests pass.
+
+## Change Discipline
+
+1. Keep binary WHIRL compatibility and append-only public enums.
+2. Do not add tabs.
+3. Do not introduce backend or CG dependencies into torch2whirl.
+4. Describe binary handling only in terms of WHIRL mapped images and ELF
+   sections.
+5. Keep `OPR_COMMENT` projections until an explicit retirement decision.
+6. Keep MLIR out of the DSL compiler-development path.
+7. Update this plan after each gate, including the exact tests that passed.
+
+## Post-ResNet Semantic Priorities
+
+The next infrastructure work is ordered by semantic dependency rather than by
+the order in which framework APIs expose values:
+
+1. Canonicalize complete tensor descriptors in the `TY` domain. Equal frozen
+   descriptors must return one `TY_IDX`; descriptor hash and equivalence must
+   compare normalized contents rather than attribute counts.
+2. Preserve source position in the existing statement-WN `SRCPOS` slot for
+   stores, regions, pragmas, and barriers. Source names remain diagnostic
+   metadata and are not a substitute for `SRCPOS`.
+3. Classify apparent extra results one operator at a time. Tensor indexing is a
+   tensor-access abstraction modeled after High WHIRL `OPR_ARRAY`, not a
+   generic multiple-result operator.
+4. Define a VHO HSSA effect interface over virtual state with `MU`-like reads
+   and `CHI`-like modifications, then map it to existing WOPT alias and
+   points-to infrastructure.
+5. Reuse WHIRL forward/backward barriers for ordering and visibility. Keep
+   barrier semantics distinct from state effects even when an operation needs
+   both.
+6. Represent fusion and graph capture through a logical `FUSED` contract on
+   `OPR_REGION`. Treat CUDA Graph as a possible later implementation choice.
+7. Keep library and kernel dispatch contracts as a dedicated design workstream
+   covering capability, ABI, workspace, alias/effect, synchronization, error,
+   and version contracts.
+
+This ordering supersedes any earlier implication that a generic multi-result
+facility should be brought up before tensor access, state effects, and region
+interfaces have been classified.
+
+## Current Validation Record
+
+The G0/G1 implementation passed the following Linux/amd64 checks on
+2026-07-12:
+
+```text
+osprey/common/com/tests/dsl_native_syntax_test.sh
+dsl_common_add_print_test
+dsl_lower_contract_test
+make be
+```
+
+The syntax fixture includes the x8664, MIPS, MIPS little-endian, generic KEY,
+Loongson, and baseline physical-operator layout matrix.  The backend build
+emitted only pre-existing missing-return warnings outside the files changed
+for G0/G1.
+
+G2 additionally passed:
+
+```text
+dsl_builder_contract_test
+dsl_lower_contract_test
+ir_b2a -st simple_resnet_contract_test.B simple_resnet_contract_test.ir
+make ir_b2a
+make be
+```
+
+The G2 backend build emitted the same pre-existing missing-return warning in
+`be/com/comp_driver.h`; the changed G2 sources were warning-free.
+
+G3-G6 and main-agent M7 completed on 2026-07-13.  The independent C++ producer
+builds an 18-value ResNet-shaped graph with a model input, eight external
+parameter/state tensors, convolution, inference BatchNorm, ReLU, residual add,
+max pooling, global average pooling, flatten, linear, and logits.  The
+gatekeeper recomputes all operator result shapes, permits parameter placement
+to differ from activation placement, rejects a deliberately corrupted
+convolution result, and accepts the restored graph.  Mandatory lowering emits
+one versioned runtime call and one distinct pointer-sized result PREG per value.
+
+The builder now emits standard compile-unit and subprogram DST ownership for
+its PU, and `TY::Verify()` recognizes the append-only `KIND_TENSOR` structural
+contract.  The driver accepts explicit `-x whirl` as an alias for its existing
+`S_B` WHIRL input path.  Descriptor and scalar initializer symbols are marked
+initialized so code generation places their nonzero data outside `.bss`.
+
+The final Linux/amd64 validation lane was:
+
+```text
+bash osprey/common/com/tests/dsl_native_syntax_test.sh
+dsl_runtime_abi_contract_test
+OPEN64_DSL_RESNET_TEST_ARTIFACT=complete_resnet_contract_test.B dsl_lower_contract_test
+ir_b2a -st complete_resnet_contract_test.B complete_resnet_contract_test.ir
+opencc -run-build=/build -x whirl -O0 -c complete_resnet_contract_test.B -o complete_resnet_contract_test.o
+nm -u complete_resnet_contract_test.o
+```
+
+The retained `.B` and `-st` output expose every logical operator, typed
+attribute, tensor descriptor, external-data reference, direct value edge, and
+`no_alias=true` result without exposing the private physical escape tag.  The
+object contains unresolved references only to the expected version-1 DSL
+runtime entry points.  The build-tree `-run-build` option is validation setup,
+not part of the installed compiler interface.
+
+The only remaining M5 checkbox is the cross-producer comparison against shapes
+reported by torch2whirl.  It depends on the concurrent frontend producer and
+does not block the completed main-side contract.

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1,0 +1,1163 @@
+# Very High Level WHIRL DSL Infrastructure
+
+This note defines a conservative path for adding very-high-level WHIRL
+features for domain-specific languages and AI-assisted compiler front ends.
+The goal is to let a new front end preserve domain intent long enough for a
+dedicated lowering pass to consume it, without changing the stable WHIRL
+operator enum or breaking existing WHIRL readers.
+
+Architecture-independent optimization, parallelization, VHO-level Preopt/IPA,
+and compiler-library codesign are planned separately in
+`doc/VHO-DSL-OPTIMIZATION-PLAN.md`. This infrastructure plan owns the native
+representation, mapped binary image, inspection, gatekeeper, compatibility,
+and final VHO lowering boundary.
+
+## Design goals
+
+1. Keep existing WHIRL binary compatibility unless a feature explicitly needs a
+   new WHIRL version.
+2. Let DSL front ends create very-high-level WHIRL that keeps source-level
+   intent before the code is forced into scalar C/Fortran-like WHIRL.
+3. Make unhandled DSL intent visible and debuggable instead of silently losing
+   it.
+4. Lower all DSL markers before WOPT, LNO, CG, and other phases that expect
+   canonical WHIRL.
+
+## Extension marker
+
+DSL front ends can attach structured metadata with `OPR_COMMENT` nodes using
+the reserved prefix:
+
+```text
+__WHIRL_DSL__:<domain>:<feature>:<payload>
+```
+
+The common WHIRL API exposes helpers in `osprey/common/com/wn.h`:
+
+```c++
+WN *WN_Create_DSL_Comment (const char *domain,
+                        const char *feature,
+                        const char *payload);
+WN *WN_Create_DSL_Assert (const char *domain,
+                       const char *condition,
+                       const char *message);
+BOOL WN_Is_DSL_Comment (const WN *wn);
+BOOL WN_Is_DSL_Assert (const WN *wn);
+const char *WN_Get_DSL_Comment_Payload (const WN *wn);
+```
+
+Older components see the marker as a normal comment.  DSL-aware components
+should treat it as a required lowering contract.  The payload is intentionally
+opaque at this layer; a DSL-specific pass can use JSON, S-expression text, a
+symbol-table key, or another stable mini-format.  `WN_Get_DSL_Comment_Payload`
+returns the text after `<domain>:<feature>:`; passes that need the domain and
+feature can read the full comment string through `WN_GetComment`.
+
+## Non-Comment DSL Opcode Value Carrier
+
+The carrier for frontend-created DSL opcode values is no longer a physical
+`OPR_COMMENT`.  Carrier migration is intentionally per opcode.  Unmigrated
+builder operators still use the binary-compatible `OPR_EVAL` staging shape:
+
+```text
+OPR_EVAL
+  OPR_LDA string constant "__WHIRL_DSL__:opcode:<name>:v<version>:<payload>"
+```
+
+Operators with operands use an envelope that still preserves the fixed
+one-child shape:
+
+```text
+OPR_EVAL
+  OPR_COMMA
+    OPR_BLOCK
+      OPR_EVAL
+        OPR_LDA string constant "__WHIRL_DSL_OPERAND__:kid0:opcode=...:version=...:payload=..."
+      OPR_EVAL
+        OPR_LDA string constant "__WHIRL_DSL_OPERAND__:kid1:opcode=...:version=...:payload=..."
+    OPR_LDA string constant "__WHIRL_DSL__:opcode:<name>:v<version>:<payload>"
+```
+
+A non-comment, non-`OPR_EVAL` staging carrier is also available:
+
+```text
+OPR_XPRAGMA
+  OPR_COMMA
+    OPR_BLOCK
+      OPR_XPRAGMA
+        OPR_LDA string constant "__WHIRL_DSL_OPERAND__:kid0:opcode=...:version=...:payload=..."
+      OPR_XPRAGMA
+        OPR_LDA string constant "__WHIRL_DSL_OPERAND__:kid1:opcode=...:version=...:payload=..."
+    OPR_LDA string constant "__WHIRL_DSL__:opcode:<name>:v<version>:<payload>"
+```
+
+`DSL_WN_Create_Opcode_Xpragma` creates this non-eval carrier.  It uses
+`WN_PRAGMA_UNDEFINED` only as an internal staging tag; the authoritative DSL
+identity remains the `__WHIRL_DSL__:opcode:...` record.  This avoids adding a
+new WHIRL opcode, pragma enum, WN field, ELF section, or binary IR version in
+this stage.
+
+The first builder migration slice moved `common.tensor_const` and `common.add`
+to the XPRAGMA carrier.  The second slice moves `common.matmul`.  These common
+operators now use XPRAGMA for both their outer carrier and operand-evidence
+statements.  Carrier selection remains an implementation detail behind the
+opaque `DSL_BUILDER_VALUE` API.
+Operand-evidence statements follow their outer carrier: migrated XPRAGMA
+operators contain no EVAL nodes, while unmigrated EVAL operators retain their
+original EVAL evidence statements.  The decoder accepts both forms during the
+migration.  Compatibility tests construct the legacy EVAL form explicitly
+through `DSL_WN_Create_Opcode_With_Operands`; production common operators no
+longer need to remain on EVAL solely to exercise that input path.
+
+The operand helper records are inspection evidence for the staged carrier.
+They do not use the `__WHIRL_DSL__:` opcode prefix and therefore are not
+counted as independent unlowered DSL opcodes by the VHO scanner.
+DSL-aware verifier and lowering code should inspect them through
+`DSL_WN_Decode_Opcode_Operand_Record`, not by parsing `fdump_tree` output.
+Before lowering a non-comment DSL node, passes should call
+`DSL_WN_Verify_Opcode_Carrier` to reject malformed carrier shapes and
+malformed operand records.
+The VHO unconsumed-DSL scanner also reports malformed carrier counts, so
+pre-lowering diagnostics can distinguish "valid but unlowered" DSL values from
+broken staged carriers.
+
+The carrier node is the opaque `DSL_BUILDER_VALUE` seen by Python and other
+frontends.  The string record preserves stable opcode name, version, operands,
+attributes, and payload/result metadata in the same parseable format as the
+legacy marker.
+
+Binary reader/writer behavior is intentionally unchanged for this stage.  The
+carriers remain ordinary `OPR_EVAL`, `OPR_XPRAGMA`, `OPR_COMMA`, `OPR_BLOCK`,
+and `OPR_LDA` tree entries, and their records remain ordinary constant/string
+table entries in the mapped WHIRL image.  They do not add a WHIRL `OPERATOR`,
+opcode enum value, WN field, ELF section, or new binary IR image table.
+
+Compatibility input remains explicit.  `DSL_WN_Create_Opcode_Marker` creates
+the old annotated `OPR_COMMENT` marker, and `DSL_WN_Get_Opcode_Annotation`
+accepts both carriers during migration.  Dumps distinguish them with stable
+carrier text:
+
+```text
+dsl_node=common.add.v1 dsl_carrier=eval_lda_string dsl_operand_count=2
+dsl_node=common.add.v1 dsl_carrier=xpragma_lda_string dsl_operand_count=2
+dsl_opcode=common.add.v1 dsl_carrier=comment_marker
+```
+
+Frontend code must continue to treat `DSL_BUILDER_VALUE` as opaque.  Both the
+current `OPR_EVAL` and `OPR_XPRAGMA` carriers are binary-compatible staging
+representations, not promises about the final native WHIRL DSL opcode layout.
+
+## Compatibility Migration Policy
+
+`DSL_WN_Get_Logical_Opcode()` is the carrier-independent semantic entry point.
+It accepts native nodes and legacy `OPR_COMMENT`, `OPR_EVAL`, and
+`OPR_XPRAGMA` records, then returns the logical operator, source version,
+effective version, payload, carrier classification, and version disposition.
+Compiler code that needs executable DSL semantics should use this accessor
+instead of branching on the physical carrier.
+
+Version handling is deterministic and conservative.  An exact registered
+version is accepted.  Older versions, newer versions, and unknown stable names
+receive distinct rejection dispositions.  No version is silently upgraded.
+`DSL_OPCODE_VERSION_MIGRATED` is reserved for a future operator-specific
+migration routine that validates and rewrites the old schema; merely changing
+the version number will never constitute migration.
+
+`DSL_WN_Create_Logical_Opcode()` provides explicit output modes for native,
+legacy EVAL, legacy XPRAGMA, and comment-projection output.  EVAL and XPRAGMA
+retain legacy operand records.  COMMENT remains a high-level projection and
+does not carry operand records.  A producer targeting an older tool must choose
+the compatibility form during construction.  It must not remove `.WHIRL.dsl`,
+rewrite the revision string, or otherwise relabel an artifact that still
+contains native DSL nodes as baseline `WHIRL::0.33`.
+
+## Compatibility Comment Projection
+
+The `OPR_COMMENT` view remains a required compatibility and inspection
+projection until the project explicitly retires it.  Even after a native WHIRL
+DSL node is introduced, `ir_b2a` should continue to expose a high-level comment
+record such as:
+
+```text
+COMMENT "__WHIRL_DSL__:opcode:common.add:v1:kid0=...;kid1=...;attr.broadcast_rule=none"
+```
+
+This comment projection is not the authoritative long-term carrier.  It is a
+stable human-readable and tool-friendly summary of the DSL operator.  It lets
+older tools, reviewers, DSL authors, and `ir_a2b` / `ir_b2a` round-trip tests
+inspect high-level intent while the native DSL node representation matures.
+
+Retiring this projection requires an explicit design decision.  Until then,
+new native DSL node work must preserve enough information to regenerate the
+comment projection from the same logical DSL node record used by the native
+carrier.
+
+## Logical DSL Node Record
+
+All physical carriers must decode to the same logical `DSL_WHIRL_NODE_RECORD`.
+This record is the compatibility contract between the current staging carrier,
+the compatibility comment projection, and a future native WHIRL DSL node.
+
+The record contains:
+
+1. Stable opcode name.
+2. Opcode version.
+3. Payload string carrying operands, attributes, and result metadata.
+4. Carrier kind for diagnostics and migration visibility.
+
+The current APIs are:
+
+```c++
+BOOL DSL_WN_Decode_Opcode_Record(const WN *wn,
+                                 DSL_WHIRL_NODE_RECORD *record);
+WN *DSL_WN_Create_Opcode_From_Record(const DSL_WHIRL_NODE_RECORD *record);
+WN *DSL_WN_Create_Opcode_With_Operands(const char *name,
+                                       UINT32 version,
+                                       const char *payload,
+                                       WN **operands,
+                                       UINT32 operand_count);
+WN *DSL_WN_Create_Opcode_Xpragma(const char *name,
+                                 UINT32 version,
+                                 const char *payload,
+                                 WN **operands,
+                                 UINT32 operand_count);
+WN *DSL_WN_Create_Opcode_Marker_From_Record(
+        const DSL_WHIRL_NODE_RECORD *record);
+WN *DSL_WN_Create_Opcode_Comment_Projection(const WN *wn);
+UINT32 DSL_WN_Opcode_Operand_Count(const WN *wn);
+BOOL DSL_WN_Decode_Opcode_Operand_Record(
+        const WN *wn,
+        UINT32 operand_index,
+        DSL_WHIRL_OPERAND_RECORD *record);
+BOOL DSL_WN_Verify_Opcode_Carrier(const WN *wn, FILE *diagnostic);
+BOOL DSL_WN_Opcode_Records_Equivalent(
+        const DSL_WHIRL_NODE_RECORD *record0,
+        const DSL_WHIRL_NODE_RECORD *record1);
+void DSL_fprint_opcode_comment_projection(FILE *f, const WN *wn);
+```
+
+The builder boundary exposes equivalent operand inspection without exposing WN
+layout to frontends:
+
+```c++
+UINT32 DSL_Builder_Count_Value_Operands(DSL_BUILDER_VALUE value);
+BOOL DSL_Builder_Get_Value_Operand(DSL_BUILDER_VALUE value,
+                                   UINT32 operand_index,
+                                   DSL_BUILDER_VALUE_INFO *info);
+```
+
+Before replacing the `OPR_EVAL` transition with a native WHIRL DSL node, tests
+must prove:
+
+1. The `OPR_EVAL` carrier decodes to the record.
+2. The `OPR_COMMENT` compatibility marker decodes to an equivalent record.
+3. A native DSL node created from the same record decodes to an equivalent
+   record.
+4. `ir_b2a` can still print stable DSL node evidence and the compatibility
+   comment projection.
+
+## DSL Framework Usability Goal
+
+The DSL WHIRL framework should make adding a new DSL operator and, later, a
+native WHIRL DSL node smooth, repeatable, and well documented.  The goal is for
+new DSL authors to extend Open64 through this framework without reverse
+engineering scattered compiler conventions or depending on an external IR
+stack.
+
+The design documents, `AGENTS.md`, and future `SKILL.md` guidance are part of
+the implementation strategy.  They should capture the repeatable steps,
+compatibility rules, required tests, printing expectations, and migration
+points clearly enough that new DSL work can follow the same path.
+
+The long-term project direction is to make DSL WHIRL the primary Open64 DSL
+path for AI-era compiler construction, without any dependence on MLIR for DSL
+compiler development.  That requires preserving Open64 binary compatibility
+while making the DSL extension workflow easier to use, easier to validate, and
+better integrated with Open64 tools.
+
+`WN_Create_DSL_Assert` is a convenience wrapper for simple pre-lowering
+assertions.  It creates a DSL marker with feature `assert`, not a canonical
+`OPR_ASSERT` node.  A DSL-aware validation or lowering pass must consume the
+marker before canonical optimization.  This lets a frontend state facts that
+must hold before lowering, such as resolved tensor shape, compatible operand
+types, or concrete stack storage size.
+
+## Recommended lowering pipeline
+
+1. A DSL or AI frontend builds very-high-level WHIRL by combining legal High
+   WHIRL executable fallback nodes with DSL markers next to the WHIRL region,
+   statement, or expression group they describe.  The frontend must set
+   `PU_HAS_VERY_HIGH_WHIRL` on any PU that contains these markers.
+2. A VHO-adjacent DSL lowering pass scans for DSL opcode values with
+   `DSL_WN_Has_Opcode` and for generic DSL comments with `WN_Is_DSL_Comment`.
+3. The pass validates the `<domain>` and `<feature>` fields and either:
+   - replaces the marked region with canonical WHIRL,
+   - rewrites it to target intrinsics/runtime calls, or
+   - reports a fatal diagnostic if the marker is required but unsupported.
+4. After successful lowering, the pass removes or rewrites consumed DSL markers
+   to ordinary debug comments.
+5. Standard VHO lowering runs on canonical WHIRL.
+
+## Encoding examples
+
+Tensor DSL:
+
+```text
+__WHIRL_DSL__:tensor:fused_op:{"op":"matmul_bias_relu","layout":"nhwc"}
+__WHIRL_DSL__:tensor:assert:shape(temp_var)==shape(a):tensor add result shape must be resolved
+```
+
+Scheduling DSL:
+
+```text
+__WHIRL_DSL__:schedule:tile:{"i":64,"j":32,"vectorize":"j"}
+```
+
+AI compiler search hint:
+
+```text
+__WHIRL_DSL__:ai:search_space:{"unroll":[1,2,4,8],"cost":"latency"}
+```
+
+## MPL Reference Boundary
+
+MPL is not a Very High Level WHIRL ingestion path and does not provide an
+equivalent Very High Level WHIRL feature set.  MPL-related sources may be used
+only as reference material for porting another IR roughly equivalent to Middle
+Level WHIRL.  They should not guide the DSL frontend, Python ingestion, or
+non-comment DSL node design.
+
+## Tensor Type Extensions
+
+Tensor is represented first as a DSL type extension attached to an existing
+`TY_IDX`, not as a new WHIRL operator or a new binary IR image `TY_KIND`.  This
+keeps the core symbol-table layout stable while the tensor type system is still
+being designed.  The current carrier type uses `TY_KIND = KIND_STRUCT` with
+`MTYPE_M`; tensor identity and delayed attributes live in the tensor extension
+side table.
+
+Tensor extension records should follow the existing WHIRL table discipline:
+fixed-size records indexed by integer handles.  Do not place nested STL
+containers such as `std::vector` or `std::map` inside a table record that may
+later need to be dumped, reloaded, compared, or moved into a binary IR image.
+Variable attributes and metadata should live in separate key/value table
+entries and be linked from their owning records through table indices,
+mirroring the way WHIRL uses companion tables such as `TY`, `FLD`, `ARB`, and
+`TYLIST`.
+
+Tensor attributes and compiler metadata intentionally have different owners.
+Attributes are TensorDescriptorIR-completing facts associated with `TY_IDX`:
+they describe semantic tensor value state such as TensorTypeCore, TensorTraitSet,
+TensorRepresentationDescriptor, and TensorLineageMetadata.  Required attributes
+must be complete before tensor computation, verification, or lowering can rely
+on the tensor descriptor.  Metadata is compiler context associated with `ST_IDX`
+or a use site: source context, diagnostics, pass ownership, lowering hints, and
+profile data.  Adding or changing compiler metadata must not create a new tensor
+type and must not participate in tensor type equivalence unless a later schema
+explicitly promotes the fact into tensor attributes.
+
+The `TY_tensor_*` and `ST_tensor_*` APIs are intentionally global
+`common/com` entry points, grouped by Open64-style prefixes rather than by a
+new C++ namespace.  This keeps the symbol-table and type-table additions
+callable from older Open64 code without forcing a namespace migration through
+frontends, IPA, backends, and IR tools.  A future C++ namespace facade may be
+added in a leaf DSL component, but it should wrap these stable global APIs
+rather than replace them.
+
+The agreed long-term direction is to promote tensor into the core WHIRL type
+system as `TY_KIND = KIND_TENSOR`, because tensor is common across many DSLs and
+domains.  That common tensor type should carry semantic information such as
+element type, rank, shape, layout, and strides.  It should not require a
+general `MTYPE_TENSOR` at the source/DSL level, because `MTYPE` is normally tied
+to target-machine values.
+
+Target-specific tensor machine types are still legitimate after lowering.  For
+example, NVIDIA Tensor Core lowering may introduce a target-specific `MTYPE`
+for a WMMA/MMA matrix fragment or accumulator fragment.  That target type is
+not the same thing as the common DSL tensor type; it is the hardware-level
+representation selected after shape, layout, and target legality are known.
+
+```mermaid
+flowchart TB
+    subgraph Existing["Existing WHIRL Type System"]
+        A["Source Type<br/>C / Fortran / Java / MPL"] --> B["TY_IDX"]
+        B --> C["TY record"]
+        C --> C1["TY_KIND<br/>scalar / array / struct / pointer / function"]
+        C --> C2["MTYPE<br/>I4 / F8 / M / pointer"]
+        C --> C3["Size / align"]
+        C --> C4["ARB / FLD / TYLIST"]
+        C --> D["WHIRL nodes use TY_IDX"]
+        D --> E["Lowering / optimization / codegen"]
+    end
+
+    subgraph Tensor["DSL Tensor Type Extension"]
+        T0["DSL Tensor Type<br/>tensor<float>[N,H,W,C]"] --> T1["Base TY_IDX<br/>stable WHIRL-compatible type"]
+        T1 --> T1A["Current staging carrier<br/>TYPE_KIND / TY_KIND = KIND_STRUCT<br/>MTYPE = M"]
+        T1A --> T1B["Opaque tensor carrier<br/>no binary IR image TY_KIND change yet"]
+        T1 --> T1C["Target core design<br/>TY_KIND = KIND_TENSOR<br/>semantic tensor type"]
+        T1C --> T2["Tensor attributes<br/>owned by TY_IDX"]
+        T2 --> T3["Element type<br/>float / int8 / bf16 / custom"]
+        T2 --> T4["Rank<br/>known / symbolic / pending"]
+        T2 --> T5["Attributes<br/>shape, layout, strides, dtype"]
+        T5 --> T7["Delayed binding"]
+        T7 --> T8["Resolved by DSL analysis / AI compiler search"]
+        T8 --> T9["Later lowering decision"]
+        T9 --> T10["aggregate WHIRL"]
+        T9 --> T11["descriptor / runtime handle"]
+        T9 --> T12["intrinsic sequence"]
+        T9 --> T13["target-specific object"]
+        T9 --> T14["NVIDIA Tensor Core fragment<br/>target-specific MTYPE after lowering"]
+    end
+
+    subgraph SymbolMetadata["Tensor Symbol Metadata"]
+        S0["Tensor object symbol"] --> S1["ST_IDX"]
+        S1 --> S2["Metadata owned by ST_IDX"]
+        S2 --> S3["source context, diagnostics,<br/>pass owner, lowering hints"]
+    end
+
+    T1 -. "Still valid TY_IDX" .-> D
+    T2 -. "Extra semantic layer" .-> T9
+    S2 -. "Per-symbol usage / placement" .-> T9
+```
+
+The type-system interface is declared in `osprey/common/com/symtab.h`:
+
+```c++
+TY_IDX TY_Create_Tensor_Extension_Type(const char *name,
+                                       TY_IDX element_ty,
+                                       INT32 rank);
+void TY_Mark_Tensor_Extension(TY_IDX ty, TY_IDX element_ty, INT32 rank);
+BOOL TY_is_tensor_extension(TY_IDX ty);
+BOOL TY_Get_Tensor_Extension_Info(TY_IDX ty,
+                                  TY_TENSOR_EXTENSION_INFO *info);
+TY_IDX TY_tensor_element_ty(TY_IDX ty);
+INT32 TY_tensor_rank(TY_IDX ty);
+```
+
+Type attributes can be declared before final values are known, then bound later
+by type inference, DSL analysis, or an AI compiler search stage:
+
+```c++
+TY_tensor_declare_attribute(tensor_ty, "shape");
+TY_tensor_declare_attribute(tensor_ty, "layout");
+
+/* Later, after DSL type analysis has resolved the facts. */
+TY_tensor_bind_attribute(tensor_ty, "shape", "[1,224,224,3]");
+TY_tensor_bind_attribute(tensor_ty, "layout", "NHWC");
+```
+
+Suggested attribute keys include `shape`, `rank`, `layout`, `dtype`,
+`strides`, `sparsity`, `quantization`, and `memory_space`.
+
+Compiler metadata uses a separate `ST_IDX` API:
+
+```c++
+ST_tensor_declare_metadata(tensor_st, "source_layer_name");
+ST_tensor_declare_metadata(tensor_st, "lowering_hint");
+
+/* Later, after source import or pass planning has resolved the facts. */
+ST_tensor_bind_metadata(tensor_st, "source_layer_name", "encoder.block0.add");
+ST_tensor_bind_metadata(tensor_st, "lowering_hint", "prefer_vector");
+```
+
+Suggested metadata keys include `source_context`, `source_layer_name`,
+`diagnostic_owner`, `pass_owner`, `lowering_hint`, and `profile_data`.  These
+names are conventions at this layer; a later tensor schema can standardize them
+without changing the storage interface.
+
+WHIRL generation should remain delayed.  A frontend can create or mark tensor
+types and bind attributes incrementally, while VHO or a future DSL lowering pass
+decides later whether a tensor becomes an aggregate, descriptor, runtime handle,
+intrinsic call sequence, or target-specific object.
+
+## When to add real WHIRL operators
+
+Use these markers for early infrastructure, experiments, source intent, and
+features that can be lowered before canonical optimization.  Add real WHIRL
+operators only when the feature must participate directly in common
+optimizers, dependence analysis, alias analysis, or code generation.  In that
+case update the operator enum, opcode table, ASCII reader/printer, binary IR
+image reader/writer, dumps, simplifier tables, WHIRL-to-source tools, and every
+phase that asserts operator coverage.
+
+## Native DSL WHIRL bring-up plan
+
+Status convention:
+
+- `[x]` completed and validated.
+- `[ ] (active)` current implementation item.
+- `[ ]` queued in dependency order.
+
+The production builder still emits compatibility carriers.  Native construction
+is an exercised vertical slice, not yet the default artifact path.
+
+### Design contracts
+
+### Logical DSL operator abstraction
+
+Compiler developers work with logical operators such as `OPR_DSLADD`,
+`OPR_DSLMATMUL`, and `OPR_DSLTENSORCONST`.  Construction, inspection,
+verification, lowering, ASCII dumps, and traces go through the logical APIs:
+
+```c++
+WN *DSL_WN_Create_Native(DSL_OPERATOR dsl_operator,
+                         UINT32 version,
+                         const char *payload,
+                         WN **operands,
+                         UINT32 operand_count);
+DSL_OPERATOR DSL_WN_operator(const WN *wn);
+const char *DSL_OPERATOR_name(DSL_OPERATOR dsl_operator);
+```
+
+For example, a pass tests `DSL_WN_operator(wn) == OPR_DSLADD`.  It must not
+test the physical escape tag and then decode `WN_offset` itself.  `ir_b2a` and
+internal traces print `OPR_DSLADD`, its semantic version, operands, attributes,
+and result information.  They do not print `OPR_DSL`, `OPC_MDSL`, or the
+internal record index.
+
+This separation is an API contract.  Adding a logical DSL operator extends the
+logical registry and its printer mapping without consuming another physical WN
+operator slot or spreading decoding logic through compiler passes.
+
+### Private physical escape contract
+
+At the low-level WN storage boundary only, one generic, variable-arity
+`OPR_DSL` expression acts as an escape tag.  Every DSL operator produces a
+value.  Its physical layout is private to the logical accessor, mapped-image
+reader/writer, and low-level verifier:
+
+```text
+WN_operator       OPR_DSL
+WN_rtype          MTYPE_M
+WN_desc           MTYPE_V
+WN_kid_count      exact number of operand-reference kids
+WN_offset         private DSL record reference
+WN_kid(i)         operand-reference WHIRL tree
+```
+
+The node-record ID resolves an opcode-descriptor record containing the stable
+opcode name and semantic version, plus the node attributes and result metadata.
+The 14-bit `kid_count` field is used only as a count.  Its high bits must not be
+reused for flags, versions, or table IDs because generic WHIRL allocation,
+copying, traversal, and mapped-image logic consume the complete count.
+
+No DSL pass, frontend, diagnostic, ASCII dump, or ordinary trace may expose or
+depend on this physical layout.
+
+The native DSL expression does not own a result symbol or decide storage
+allocation.  An enclosing assignment names the temporary result:
+
+```text
+STID temp
+  OPR_DSLADD kid0, kid1
+```
+
+The temporary symbol has the tensor `TY_IDX`, associated tensor descriptor, and
+the semantic symbol attribute `no_alias=true`.  DSL operator results have
+unique memory ownership: the storage denoted by a live result symbol does not
+overlap storage denoted by another live tensor symbol.  Allocation and physical
+placement remain deferred until lowering, but ownership is complete before
+computation and is available to DSL verification and optimization.
+
+The special DSL tensor result temporary is represented without a new symbol
+class.  It is a `CLASS_VAR` with `ST_IS_TEMP_VAR` set, a tensor `TY_IDX`, and
+`no_alias=true`.  `DSL_Builder_Create_Tensor_Result_Symbol()` must establish all
+four properties when declaring the left-hand side of the `STID`.  The result
+role must never be inferred from its symbol name.
+
+Like a CUDA/PTX virtual-register temporary, a very-high-level DSL result
+temporary is non-addressable before lowering.  It may be defined by `STID` and
+used by `LDID`, but it must not appear in `LDA`, be passed by address, or escape
+through an address-bearing operation.  The DSL gatekeeper must reject such an
+escape.  This makes `no_alias=true` a structural value contract rather than an
+optimization hint.
+
+Do not set baseline `ST_PT_TO_UNIQUE_MEM` directly on a `KIND_TENSOR` symbol.
+Existing WSSA logic defines that flag for pointer-typed symbols and asserts the
+pointer-type requirement.  When lowering materializes a pointer representation,
+it must preserve `no_alias=true` and may translate it to
+`ST_PT_TO_UNIQUE_MEM` under the existing pointer contract.
+
+`OPR_DSL` is not executable canonical WHIRL.  The DSL gatekeeper and VHO
+lowering must consume it before WOPT, LNO, or CG.  Compatibility comment
+projection remains required until an explicit decision retires it.
+
+### First executable tensor representation
+
+The first target-independent lowering route is a versioned opaque runtime
+handle ABI.  This is a lowering decision, not an ingestion representation.
+Very-high-level WHIRL continues to carry first-class logical operators and
+tensor descriptors through gatekeeper and target-independent DSL analysis.
+Only the VHO-adjacent DSL lowering pass introduces runtime calls.
+
+Each verified tensor result maps to a distinct pointer-sized PREG containing an
+`OPEN64_DSL_TENSOR_HANDLE`.  The PREG is non-addressable and therefore retains
+the virtual-register behavior of the very-high-level result temporary.  The
+runtime call contract promises a distinct owning handle for every successful
+result, preserving `no_alias=true`; a null handle denotes runtime failure.  The
+compiler does not allocate tensor data or select physical placement in this
+first route.  Runtime allocation, placement, and reclamation remain runtime
+policy.
+
+`osprey/include/open64_dsl_runtime_abi.h` defines ABI version 1.  Its tensor
+descriptor has a fixed 64-byte header followed by optional signed 64-bit shape
+and stride arrays.  Array locations are relative byte offsets from the start of
+the descriptor blob, not process-local pointers.  Numeric dtype, layout,
+memory, broadcast, matmul flag, and ownership values are append-only contracts;
+zero means unspecified where applicable.  Sharding, placement, quantization,
+and runtime-state fields remain numeric schema IDs and must be zero until their
+registries are defined.
+
+The first call surface is:
+
+```c
+__open64_dsl_tensor_const_v1(result_descriptor, scalar_value)
+__open64_dsl_add_v1(kid0, kid1, result_descriptor, broadcast_rule)
+__open64_dsl_matmul_v1(kid0, kid1, result_descriptor, matmul_flags)
+```
+
+These functions return opaque handles.  No frontend or Python API exposes
+them, and no backend code enters torch2whirl.  A release/lifetime ABI is
+intentionally deferred until graph output ownership and liveness policy are
+defined; lowering must not insert speculative releases.
+
+The checked-in opcode tables contain legacy target operators that the current
+`opcode_gen` script does not reproduce.  The first native slice assigns
+`OPR_DSL` the common value 148 on every target and leaves reserved gaps after
+the existing target-specific ranges.  Before full opcode-table regeneration,
+reconcile those existing target additions with the generator and prove that all
+previously assigned operator values remain unchanged.
+
+### Fixed-row mapped-image table contract
+
+The source-level DSL image model uses append-only, 1-based table IDs.  ID zero
+is invalid; the tables do not reserve empty rows or encode optional state with
+holes.  Rows contain only explicitly sized scalars, table IDs, `TY_IDX`,
+`ST_IDX`, and `STR_IDX`.  They contain no pointers, STL containers, ownership,
+or process-local object references.
+
+The first table set is:
+
+- `DSL_IR_IMAGE_HEADER`, 48 bytes: version, capabilities, flags, and row counts.
+- `DSL_IR_OPCODE_DESCRIPTOR_RECORD`, 72 bytes: logical operator identity,
+  semantic version, operand contract, semantic models, and schema string IDs.
+- `DSL_IR_NODE_RECORD`, 40 bytes: opcode descriptor, contiguous operand and
+  attribute ranges, result value, flags, and compatibility payload string ID.
+- `DSL_IR_ATTRIBUTE_RECORD`, 32 bytes: owner node, typed value kind, name and
+  value string IDs, and flags.
+- `DSL_IR_VALUE_RECORD`, 48 bytes: value role, tensor descriptor, producer,
+  type, symbol, name, metadata string ID, and flags.
+- `DSL_IR_VALUE_REFERENCE_RECORD`, 24 bytes: owner node, operand ordinal, and
+  referenced value ID.
+
+Construction appends rows and then finalizes a node's contiguous operand,
+attribute, and result links through `DSL_IR_Image_Set_Node_Links()`.  Link
+finalization validates table bounds, operand order, owner identity, logical
+arity, and result provenance.  The next stage connects these rows to the
+  existing ELF WHIRL mapped-image path.
+
+### Optional ELF DSL image section
+
+All fixed-row DSL tables occupy one optional `SHT_MIPS_WHIRL` section named
+`.WHIRL.dsl` with `sh_info=WT_DSL_IR_IMAGE`.  The section contains the 48-byte
+header followed by opcode descriptor, node, attribute, value, and value
+reference rows in that order.  Every boundary is naturally 8-byte aligned and
+the reader computes the exact expected section size from checked row counts.
+
+The writer omits `.WHIRL.dsl` when every DSL table is empty, preserving legacy
+output.  For `0.33` compatibility artifacts, existing readers ignore the
+unknown optional section.  A DSL-aware
+reader treats section absence as an empty image, but a present section must
+have the supported version and capability set, exact size, valid string-table
+IDs, sequential row IDs, valid ranges, matching owners and ordinals, supported
+logical descriptors, and correct result provenance.  Validation completes
+before mapped rows replace live tables.  Input cleanup detaches mapped rows
+before the ELF mapping is released.
+
+Legacy artifacts without native DSL nodes retain `WHIRL::0.33`.  An artifact
+containing native DSL node rows uses `WHIRL::0.34` and must contain a valid,
+nonempty `.WHIRL.dsl` section.  The DSL-aware reader accepts both revisions;
+an older reader rejects `0.34` at the revision gate before it can traverse an
+unknown physical operator.  This explicit revision boundary prevents native
+`OPR_DSL` trees from being mislabeled as baseline binary WHIRL.
+
+### Completed foundation
+
+- [x] Add the append-only physical escape operator at value 148 without
+  renumbering existing x86-64 WHIRL operators.
+- [x] Define the native carrier as a variable-arity, value-producing `MTYPE_M`
+  expression with direct operand kids.
+- [x] Add the first logical operator names: `OPR_DSLTENSORCONST`,
+  `OPR_DSLADD`, and `OPR_DSLMATMUL`.
+- [x] Add logical construction and inspection APIs that hide the physical
+  escape tag and private record reference.
+- [x] Make native ASCII dumps and internal image traces show the logical
+  operator rather than `OPR_DSL`, `OPC_MDSL`, or the private record index.
+- [x] Define the special tensor result temporary as `CLASS_VAR` plus
+  `ST_IS_TEMP_VAR`, tensor `TY_IDX`, and `no_alias=true`.
+- [x] Preserve annotated `OPR_COMMENT`, `OPR_EVAL`, and `OPR_XPRAGMA` as
+  compatibility inputs while the native path is brought up.
+- [x] Add a native contract test for logical `OPR_DSLADD`, direct kids,
+  expression classification, result `STID`, no-alias ownership, and hidden
+  physical dump evidence.
+- [x] Consolidate the first logical operator descriptors in the append-only
+  common opcode seed.  `common.tensor_const`, `common.add`, and
+  `common.matmul` now obtain their logical enum/name, stable name, semantic
+  version, operand contract, attribute schema, shape rule, effect model,
+  lowering model, and diagnostic prefix from one table-driven source.
+- [x] Audit the historical `opcode_gen` boundary and add a physical operator
+  compatibility matrix.  The matrix compiles both enum assertions and the
+  real `OPERATOR_info` table for x86-64, MIPS, MIPS-SL, generic KEY, Loongson,
+  and baseline configurations; it locks the existing extension slots,
+  `OPR_DSL=148`, `OPERATOR_LAST=148`, and `OPC_MDSL`.
+- [x] Define fixed-row DSL image tables for capability/header, logical opcode
+  descriptors, logical nodes, typed operation attributes, values, and ordered
+  value references.  Lock row sizes at compile time, use string-table and
+  table IDs only, validate forward-link finalization, and establish the table
+  contract before its ELF integration.
+- [x] Connect the fixed rows to one optional `.WHIRL.dsl` section through the
+  existing ELF WHIRL mapped-image writer and reader.  Omit empty images, load
+  legacy files as empty tables, reject malformed or unsupported sections, and
+  detach mapped rows before input cleanup.  Cover both section absence and a
+  populated `common.add` write/open/map/read round trip.
+- [x] Migrate the production builder's first vertical slice.  Native
+  `common.tensor_const`, `common.add`, and `common.matmul` values are defining
+  `STID` statements for no-alias tensor temporaries.  Their expression kids are
+  logical DSL nodes and binary operands are direct `LDID` references.  The
+  builder populates opcode, node, typed-attribute, value, and value-reference
+  rows from the same construction call.  Non-migrated operators receive fresh
+  compatibility projections when consuming native values, and all public
+  dumps retain the high-level `OPR_COMMENT` projection.
+- [x] Complete logical inspection in `ir_b2a` and `ir_b2a -st`.  Standard tree
+  output names native expressions as `OPR_DSLTENSORCONST`, `OPR_DSLADD`, and
+  `OPR_DSLMATMUL` with semantic versions, direct operands, payload, and comment
+  projection.  The `-st` path prints the DSL image header plus opcode
+  descriptor, node, typed attribute, value, and ordered value-reference tables.
+  Value rows include tensor descriptor facts, result symbols, and `no_alias`
+  ownership.  Neither form exposes `OPR_DSL`, `MDSL`, `OPC_MDSL`, nor the
+  private WN record reference.
+- [x] Add the first native DSL gatekeeper.  Common/com verifies the fixed image
+  and native WN tree together before builder output, and VHO invokes the same
+  verifier before F90 or VH lowering.  The gate rejects unsupported logical
+  versions, operand-count or direct-`LDID` violations, missing typed static
+  attributes, incomplete tensor cores, incompatible tensor operands or results,
+  malformed result `STID` temporaries, missing `no_alias=true`, stale image
+  nodes, duplicate definitions, and result-symbol use through `LDA` or a
+  non-DSL `LDID`.  Rank-2 matmul construction and verification enforce
+  `[M,K] x [K,N] -> [M,N]`.  A differently named builder PU starts a fresh DSL
+  program/image so multiple compilations in one frontend process cannot leak
+  records into each other.
+- [x] Complete the first compatibility migration policy.  Native,
+  `OPR_COMMENT`, `OPR_EVAL`, and `OPR_XPRAGMA` carriers resolve through
+  `DSL_WN_Get_Logical_Opcode()`.  Exact versions are accepted; older, newer,
+  and unknown versions receive stable rejection dispositions, with no implicit
+  schema upgrade.  `DSL_WN_Create_Logical_Opcode()` selects native, legacy
+  EVAL, legacy XPRAGMA, or comment-projection output explicitly.  Compatibility
+  output is a construction decision; native `0.34` artifacts are never
+  relabeled as baseline `0.33`.
+
+### Active queue
+
+10. [x] Add VHO native DSL lowering.
+
+   Lower verified tensor-constant, add, and matmul nodes before canonical
+   optimization while preserving tensor semantics, unique ownership,
+   no-alias facts, source context, and version-specific behavior.
+
+   - [x] Establish the dedicated `VHO_DSL_Lower_Driver()` as the DSL-specific
+     peer of the existing language-oriented `VHO_Lower_Driver()`. It runs the
+     DSL gatekeeper, the fixed-order optional DSL optimization pipeline, a
+     post-optimization gatekeeper check, and the verified DSL lowering engine
+     before F90/standard VHO lowering. It traverses
+     native nodes through logical APIs only, leaves baseline WHIRL untouched,
+     reports stable operator/version/lowering-model diagnostics, and prevents
+     unsupported native nodes from leaking into canonical phases.
+   - [x] Select and document a versioned opaque runtime-handle ABI as the first
+     executable tensor representation.  Results map to distinct pointer-sized
+     PREGs, descriptor blobs use a fixed 64-byte pointer-free header plus
+     relative shape/stride offsets, and allocation/placement remain runtime
+     policy.  The ABI choice is independent of the private WN carrier.
+   - [x] Change `common.tensor_const`, `common.add`, and `common.matmul` from
+     `marker_only` to `runtime_call` after defining the selected handle ABI.
+     Their stable names, logical enum values, semantic versions, operand
+     contracts, and physical WHIRL encoding remain unchanged.
+   - [x] Implement topological rewrites for `common.tensor_const`,
+     `common.add`, and `common.matmul`, preserving descriptor facts and mapping
+     each unique no-alias result temporary into the selected representation.
+     The first implementation emits versioned runtime calls in source order,
+     captures each owning handle in a distinct pointer-sized PREG, and requires
+     every operand to resolve to an earlier result PREG.  It materializes the
+     fixed descriptor header, relative shape vector, and tensor-constant scalar
+     as read-only WHIRL symbols.  Known representation fields are mapped to
+     append-only runtime enums; nonempty unsupported values are rejected rather
+     than discarded.  Source positions and literal `OPR_COMMENT` projections
+     remain beside the lowered calls, while the original tensor symbol/type and
+     compiler metadata tables remain available for diagnostics.
+   - [x] Prove native and compatibility inputs produce equivalent lowered
+     WHIRL, and prove no native DSL node reaches standard VHO, WOPT, LNO, or CG.
+     The compatibility proof covers the representable version-1 subset for
+     tensor constants and one-level add/matmul graphs.  Validated XPRAGMA, EVAL,
+     and comment carriers are normalized from their stable payload identities
+     and immediately use the native lowering engine.  Ambiguous chained legacy
+     results, incomplete tensor cores, unknown versions, and unsupported
+     operators are rejected rather than assigned inferred semantics.  A linked
+     producer-style test compares normalized call names, parameter roles,
+     dependency ordinals, static arguments, and retained-comment counts for
+     native and mixed compatibility inputs.  The DSL driver performs a final
+     canonical-boundary scan before standard VHO: native DSL expressions and
+     executable EVAL/XPRAGMA carriers are forbidden, while the requested
+     high-level `OPR_COMMENT` projections remain available for inspection.
+
+### Completed regression matrix
+
+11. [x] Complete the regression matrix.
+
+   Cover mapped-image write/read, old-image readability, logical dumps,
+   `-st` tables, malformed records, unknown versions, address-escape failures,
+   equivalent native/compatibility lowering, and unchanged baseline WHIRL.
+
+   - [x] Fixed-row and ELF mapped-image tests cover populated write/open/map/read
+     round trips, optional-section absence in legacy images, revision selection,
+     invalid rows and ranges, malformed headers, and unknown image versions.
+   - [x] Logical printer tests and a retained native builder artifact cover
+     standard tree output and the real `ir_b2a -st` path.  The output contains
+     logical tensor-constant, add, and matmul names; symbol and type tables; all
+     five DSL image tables; tensor descriptor facts; and `no_alias=true`.  It
+     contains no physical `OPR_DSL`, `OPC_MDSL`, or `MDSL` evidence.  Set
+     `OPEN64_DSL_TEST_ARTIFACT` when running `dsl_builder_contract_test` to keep
+     the otherwise temporary binary artifact for this inspection.
+   - [x] Carrier, gatekeeper, and lowering tests reject malformed operand
+     records, missing typed attributes, unsupported old/new opcode versions,
+     unknown operators, incomplete compatibility payloads, incompatible tensor
+     operands, and tensor-result address escapes.
+   - [x] The linked lowering test proves equivalent normalized call structure
+     for native and mixed comment/EVAL/XPRAGMA inputs and proves the canonical
+     boundary rejects every executable DSL carrier while retaining comments.
+   - [x] Baseline tests pass an empty WHIRL tree unchanged and run a compiled C
+     function through the real `ir_b2a` and `ir_b2a -st` paths.  The documented
+     newer-symbol-table `ir_a2b` limitation remains the expected compatibility
+     gate rather than being mistaken for DSL image failure.
+
+The original native DSL WHIRL bring-up sequence has no remaining implementation
+item.  The torch2whirl semantic-ingestion upgrade below is the next promoted
+dependent feature.
+
+### Torch2whirl semantic-ingestion API
+
+Torch2whirl must continue to see opaque handles.  It must not receive a raw
+`WN*`, `ST_IDX`, `TY_IDX`, `RID*`, `SRCPOS` bit pattern, DSL image row, WOPT
+`AUX_ID`, or physical `OPR_DSL` record.  The native bridge translates Python
+data into the following common builder operations and keeps all WHIRL
+construction and ownership in C++.
+
+The names below define the required capability boundary.  Items 12-14 now have
+their common/com implementation; the torch2whirl bridge migration consumes
+these APIs without exposing their WHIRL types to Python.
+
+#### Canonical tensor types
+
+1. Add `DSL_Builder_Intern_Tensor_Type(name, element_ty, descriptor)`.
+   It accepts one complete descriptor, normalizes its identity fields, seals
+   it, and returns the canonical `TY_IDX`.  Equal complete descriptors return
+   the same `TY_IDX`; the diagnostic name does not create type inequality.
+   Before implementation, classify every current descriptor field as
+   identity-bearing, immutable value semantics, or mutable abstract state.
+   Mutable runtime state belongs in the HSSA effect model and must not prevent
+   otherwise equal tensor types from sharing a `TY_IDX`.  Per-value lineage or
+   transformation history that would defeat type sharing requires a separate
+   semantic value-lineage attachment rather than compiler metadata.
+   The implemented canonical identity includes kind, dtype, rank, logical
+   shape, traits, layout, sharding, placement, memory, and quantization.
+   Mutable runtime state and per-value lineage are deliberately excluded.
+2. Add `DSL_Builder_Get_Tensor_Descriptor(ty, descriptor)` for gatekeeper,
+   printer, lowering, and tests.  This is a C++ compiler API, not a Python
+   layout-inspection API.
+3. Add `DSL_Builder_Tensor_Type_Is_Canonical(ty)` and reject mutation of a
+   sealed descriptor.
+4. Keep `DSL_Builder_Create_Tensor_Type_Core` and
+   `DSL_Builder_Attach_Tensor_Descriptor` as compatibility wrappers during
+   migration.  They must eventually build a temporary descriptor and intern it
+   before the type is used by a value; they must not mutate a hashed canonical
+   type.
+5. Replace the torch2whirl `create_tensor_type` plus
+   `attach_tensor_descriptor` sequence with one opaque
+   `intern_tensor_type(descriptor)` binding.
+
+The implementation seals canonical types with a reserved attribute in the
+existing tensor-extension KV table.  It changes neither the fixed mapped row
+layout nor the ELF section contract.  A tensor-specific sealed-type scan uses
+complete, insertion-order-independent equivalence and ignores diagnostic `TY`
+names; the generic Open64 type hash remains unchanged.
+
+#### Typed inputs, constants, operators, and value context
+
+1. Expose the existing `DSL_Builder_Create_Model_Input` through an opaque
+   `create_model_input(name, tensor_type, ordinal)` bridge binding.
+2. Expose the existing `DSL_Builder_Create_External_Tensor_Constant` through
+   `create_external_tensor_constant(name, tensor_type, reference)`.  Stop
+   reconstructing an external-data value through a generic constant URI plus a
+   separately created symbol.
+3. Add `DSL_Builder_Create_Operator_With_Result`.  It receives the logical
+   opcode, version, direct operand handles, static opcode attributes, result
+   name, and canonical result `TY_IDX`.  The gatekeeper independently derives
+   or checks the expected result.  Keep `DSL_Builder_Create_Operator` as the
+   inference-based compatibility wrapper.
+4. Add `DSL_Builder_Attach_Value_Metadata(value, metadata)`.  It resolves the
+   value's actual result symbol internally and attaches compiler metadata to
+   that symbol.  Torch2whirl must not create a parallel symbol solely to carry
+   source context.
+5. Add `DSL_Builder_Attach_Value_Lineage(value, lineage)` if the field
+   classification above determines that transformation history is value state
+   rather than canonical tensor-type identity.  Keep it distinct from compiler
+   metadata.
+6. Add `DSL_Builder_Get_Value_Type(value)` and
+   `DSL_Builder_Get_Value_Result_Symbol(value)` for common compiler clients.
+   The Python bridge may use these internally but must continue returning only
+   opaque handles.
+7. Keep static operation parameters in the operator creation request.  Keep
+   source names, diagnostic ownership, lowering hints, and profile context in
+   value metadata.  Neither category may be used to complete a tensor type.
+
+#### Source position
+
+1. Add a pointer-free `DSL_BUILDER_SOURCE_POSITION` input structure containing
+   source-file identity, line, column, and statement-boundary flags.  It is an
+   API request structure, not a mapped-image record.
+2. Add `DSL_Builder_Register_Source_File(pu, path)` so the native builder owns
+   file-number and DST correspondence.
+3. Add `DSL_Builder_Set_Value_Source_Position(value, source_position)`.  The
+   builder writes the resulting `SRCPOS` into the value's statement-level
+   result `STID` through the standard WN source-position interface.
+4. Add equivalent internal wrappers for region, pragma, and barrier statements.
+   Expressions do not gain an independent source-position field.
+
+#### Program lifecycle and verification
+
+1. Add explicit `DSL_Builder_Begin_Program`, `DSL_Builder_Abort_Program`, and
+   successful-finalization cleanup.  A failed Python capture or finalization
+   must not contaminate the next model compiled in the same process.
+2. Add `DSL_Builder_Verify_Program` with a structured diagnostic sink suitable
+   for translation into a Python exception.  Finalization continues to invoke
+   the same gatekeeper and remains the final authority.
+3. Generalize `DSL_Builder_Create_Minimal_PU` only when multiple functions or
+   explicit signatures are required.  Preserve the current single-entry API as
+   the first compatibility wrapper.
+
+`DSL_Builder_Finalize_Mapped_Image` retains its established post-call state for
+producer compatibility.  A frontend calls `DSL_Builder_Begin_Program` before
+each model, including the model following successful finalization, and calls
+`DSL_Builder_Abort_Program` after capture or construction failure.
+
+#### Structured regions
+
+1. Add opaque `DSL_BUILDER_REGION` and region-classifier handles.
+2. Add `DSL_Builder_Create_Region`, `DSL_Builder_Append_Region_Value`, and
+   `DSL_Builder_Append_PU_Region`.  C++ owns the `OPR_REGION`, body, pragma and
+   exit blocks, statement links, parentization, RID, and insertion sequence.
+3. Add `DSL_Builder_Declare_Region_Value(region, value, role, ordinal)` with
+   append-only `INPUT`, `OUTPUT`, `INOUT`, and `RESULT` role bits.  The builder
+   resolves the value's real result symbol; Python does not pass an `ST_IDX`.
+4. Add `DSL_Builder_Attach_Region_Contract` for versioned BasicBlock,
+   Bottleneck, shortcut, and later `FUSED` classifiers.  The native gatekeeper
+   certifies the proposed contract from region topology and values.
+5. Add `DSL_Builder_Set_Region_Source_Position` as a wrapper over the common
+   statement source-position service.
+
+#### Tensor access
+
+1. Add scalar/index value construction before exposing tensor access.
+2. Add `DSL_Builder_Create_Tensor_Access` with a tensor base, ordered index
+   values, access kind, and canonical result type.  Its semantics follow High
+   WHIRL `OPR_ARRAY`; indices are operands rather than additional results.
+3. Define element access, subtensor/slice access, load, and store separately.
+   Do not overload one API until their result, bounds, alias, and ownership
+   contracts are specified.
+
+#### Abstract state effects and ordering
+
+1. Add opaque `DSL_BUILDER_STATE` and
+   `DSL_Builder_Declare_State_Object(pu, name, kind)` for random state, mutable
+   buffers, runtime status, communication state, and similar virtual memory.
+2. Add `DSL_Builder_Add_State_Effect(value, state, effect_kind)` with
+   append-only `READ`, `MODIFY`, and any later reviewed effect kinds.  `READ`
+   lowers to a `MU`-like use; `MODIFY` lowers to a `CHI`-like old/new state edge
+   when VHO HSSA is built.  Do not expose WOPT node classes to torch2whirl.
+3. Add `DSL_BUILDER_BARRIER_DIRECTION` and
+   `DSL_Builder_Create_Barrier(direction, affected_values, count)`.  It creates
+   the existing WHIRL forward/backward barrier form and remains distinct from
+   state effects.
+4. Allow barriers to be appended to a PU or region through statement-oriented
+   builder APIs and assign their `SRCPOS` through the common source-position
+   service.
+
+#### Fused regions and dispatch
+
+1. Represent fusion and graph capture with the generic region API plus a
+   logical, versioned `FUSED` contract.  A convenience
+   `DSL_Builder_Create_Fused_Region` may wrap that combination after the
+   generic contract is stable.
+2. Do not expose CUDA Graph as a common builder node.  It is a later
+   implementation choice for a verified `FUSED` region.
+3. Keep library and kernel dispatch out of this first API increment.  Open a
+   dedicated contract covering capability matching, ABI, workspace,
+   asynchronous completion, effects, barriers, errors, and versioning before
+   adding dispatch-builder APIs.
+
+### Active infrastructure action queue
+
+12. [x] Canonicalize `TensorDescriptorIR` in the `TY` domain.
+
+   First classify identity fields, value lineage, and mutable abstract state.
+   Then implement complete normalized equivalence, build-seal-intern APIs,
+   mutation rejection, compatibility wrappers, and duplicate/nonduplicate
+   tests.  The implementation preserves the mapped row layout, stores the seal
+   in the existing KV table, and excludes runtime state and value lineage from
+   type identity.  Existing mapped-image and `ir_b2a -st` tests remain the
+   binary and inspection gates.
+
+13. [x] Upgrade the common value-oriented ingestion boundary.
+
+   Add explicit-result operator creation, value metadata, value type/result
+   queries, and direct model-input/external-tensor bridge bindings.  Migrate
+   `DSL_Builder_Attach_Value_Lineage` keeps semantic lineage separate from
+   compiler metadata.  Torch2whirl migration away from generic external-data
+   URIs and separately created metadata symbols is the dependent frontend
+   work and may proceed concurrently with item 15.
+
+14. [x] Add source-position and lifecycle services.
+
+   Register source files, construct `SRCPOS` in C++, annotate statement-level
+   values, reset failed programs, and provide structured gatekeeper diagnostics.
+   Source registration uses standard DST directory/file entries and value
+   positions use the statement-level `STID` `SRCPOS`.  Explicit begin/abort
+   isolate builder-owned state, and verification returns counts plus a bounded
+   diagnostic buffer suitable for translation to a Python exception.
+
+15. [ ] Complete the common region substrate.
+
+   Implement the M8A RID, `WT_REGIONS`, declared value-interface, construction,
+   verification, logical printing, body-splicing, and LNO compatibility work
+   before exposing opaque region bindings to torch2whirl.
+
+   The initial source audit establishes the promotion boundary.  Common/com
+   already owns `OPR_REGION`, `WN_CreateRegion`, the three region blocks, region
+   IDs in WN, and the `WT_REGIONS` PU subsection.  The historical `RID` in
+   `be/region` also contains backend-only points-to, live-range, CG, and lowering
+   pointers, so it must not be moved wholesale.  M8A will first introduce a
+   pointer-free common region descriptor table plus a centrally managed
+   region-WN mapping.  A staged `be/region` adapter will materialize or consume
+   the historical RID tree so LNO, WOPT, EH, and CG behavior remains unchanged.
+
+16. [ ] Ingest and certify ResNet structured regions.
+
+   Implement M8B BasicBlock, Bottleneck, identity shortcut, and projection
+   shortcut contracts; preserve source positions and outer-owned no-alias
+   results; add mapped-image and malformed-contract tests.
+
+17. [ ] Define tensor access from the High WHIRL array model.
+
+   Design scalar indices, element and slice results, bounds, load/store,
+   descriptor propagation, and alias behavior.  Add the builder API only after
+   these cases are separated.
+
+18. [ ] Add HSSA-style abstract-state effects.
+
+   Define virtual-state and effect rows, fixed mapped-image representations,
+   gatekeeper rules, logical dumps, and lowering to WOPT `MU`/`CHI` semantics.
+   Test runtime status, random state, and a mutable-buffer case.
+
+19. [ ] Add barrier ingestion and optimization checks.
+
+   Wrap existing forward/backward WHIRL barriers, preserve affected-value and
+   source-position information, and prove WOPT/LNO ordering behavior remains
+   unchanged.
+
+20. [ ] Add the first logical `FUSED` region.
+
+   Gate fusion legality with region interfaces, canonical tensor types,
+   abstract-state effects, and barriers.  Keep CUDA Graph and kernel dispatch
+   as later implementation-selection concerns.
+
+21. [ ] Run the cross-boundary regression matrix for every promoted item.
+
+   Cover C++ builder tests, Python mock/native parity, failed-capture cleanup,
+   mapped-image write/reopen, old-image readability, `ir_b2a -st`, gatekeeper
+   diagnostics, `-O0` lowering, no-tab checks, and frontend/backend isolation.
+   Existing APIs remain compatibility wrappers until torch2whirl and retained
+   binary fixtures have migrated.
+
+### Deferred work TODO
+
+Deferred work remains tracked but does not block the active native DSL bring-up
+unless a dependency below explicitly promotes it back into the active queue.
+
+- [ ] Modernize the historical `opcode_gen` Perl script.
+
+  The script stops at the pre-extension operator set and cannot reproduce the
+  checked-in operator-centric tables.  Keep `opcode_gen_core.h`,
+  `opcode_gen_core.cxx`, and `wn_simp_ftable.h` authoritative in the meantime.
+  Completion requires byte-for-byte reproducible generated tables and a
+  passing `dsl_operator_layout_test.sh` target matrix with no released operator
+  value changes.
+
+- [ ] Restore logical ASCII input after the newer symbol-table limitation in
+  `ir_a2b` is resolved.
+
+  Native logical names should reconstruct private physical records only
+  through common DSL APIs.  Do not treat ASCII input as a compatibility gate
+  before the symbol-table path is reliable.
+
+- [ ] Retire compatibility carriers only after an explicit design decision.
+
+  Keep annotated `OPR_COMMENT` output as the high-level projection and continue
+  accepting legacy `OPR_COMMENT`, `OPR_EVAL`, and `OPR_XPRAGMA` input until
+  migration coverage and external-tool requirements justify retirement.
+
+- [ ] Add combined-driver Python frontend integration.
+
+  Defer `opencc` driver integration until the standalone frontend writes an
+  inspectable binary WHIRL artifact and the native gatekeeper boundary is
+  stable.  Python and torch2whirl must remain free of backend dependencies.
+  The completion interface is `openpy -keep model.py`, where `openpy` is a
+  symbolic link to the standard Open64 driver, analogous to `opencc`, but its
+  executable name selects the Python DSL frontend pipeline.  The completed
+  command retains the certified frontend artifact as `model.B` and writes
+  `model.t` as the logical WHIRL dump immediately after
+  `VHO_DSL_Lower_Driver()` and before `VHO_Lower_Driver()`.  Add the symbolic
+  link only with the corresponding language selection, phase orchestration,
+  naming behavior, and end-to-end tests.
+
+- [ ] Open coordinated native-infrastructure and torch2whirl pull requests.
+
+  Submit both branches after a ResNet `model.py` passes the standalone native
+  artifact gates and the combined `openpy -keep` driver cycle.  Cross-reference
+  the pull requests, document their merge order, and include `model.B`,
+  `ir_b2a -st`, `model.t`, and downstream `opencc -x whirl` evidence.
+
+- [ ] Publish the DSL WHIRL appendix for `WHIRL.pdf`.
+
+  First stabilize the binary image, logical printer, verifier, compatibility
+  behavior, and lowering contract.  The appendix should document the logical
+  abstraction without exposing the private physical escape representation.
+
+### Dependency gates
+
+- The production builder does not default to native nodes until logical
+  descriptor consolidation and items 3-4 are complete, and the logical node
+  record survives the binary WHIRL boundary.
+- Native nodes do not enter WOPT, LNO, or CG until item 7 is complete.
+- VHO lowering does not become a default pipeline step until item 10 has
+  semantic-equivalence tests.
+- Python and torch2whirl continue to use opaque `DSL_BUILDER_VALUE` handles and
+  gain no backend dependency during these stages.
+- MPL remains reference material only and is not a Very High Level WHIRL
+  ingestion path.
+
+### Completion criteria
+
+Native DSL WHIRL bring-up is complete when a producer can create
+`common.tensor_const`, `common.add`, and `common.matmul`; write a binary WHIRL
+artifact; read it in a separate compiler process; inspect only logical operator
+names and DSL tables with `ir_b2a`; reject malformed or escaping tensor results
+in the gatekeeper; and lower the verified graph before canonical optimization,
+while existing non-DSL WHIRL behavior and old-image readability remain intact.


### PR DESCRIPTION
## Summary

- add the staged Open64 DSL IR architecture and infrastructure plans
- define the common/com versus backend ownership boundary for `OPR_REGION` and RID data
- specify pointer-free `WT_REGIONS` rows and declared region value interfaces
- define CNN BasicBlock, shortcut, result-symbol, source-position, and gatekeeper contracts
- require retained `.B`, `.T`, phase traces, payloads, and diagnostics for human review
- make `ir_b2a -st -src` the standard review command

## Scope

This is the architecture and execution contract for REGION work. It intentionally does **not** claim that M8A RID/`WT_REGIONS` support is implemented. The plan keeps item 15 open until construction, mapped-image handling, printing, verification, body splicing, and LNO compatibility tests all land together.

## Compatibility

- preserves current WN layout and existing `REGION_KIND` encodings
- requires the historical backend RID interface to remain available through compatibility wrappers during migration
- keeps optimizer-derived alias, live-range, CG, and lowering state in `be/region`

## Validation

- documentation whitespace checks passed
- no tab characters are present in the added Markdown files
- references updated to `DSC_Master_Design_Doc_v0.10.docx`