### PR TITLE
Migrate torch2whirl to the canonical source-aware builder

### DIFF
--- a/osprey/torch2whirl/AGENTS.md
+++ b/osprey/torch2whirl/AGENTS.md
@@ -15,7 +15,7 @@ Keep work scoped to `torch2whirl` source, its configured build entry under
   `save_as_whirl`.
 - Keep the native builder API narrow. Do not turn it into a generic
   Python-owned WHIRL construction API before the artifact path is inspectable
-  through `ir_b2a -st`.
+  through `ir_b2a -st -src`.
 - Do not use tab characters in files touched under this directory, except
   Makefiles where tabs are required by standard make syntax.
 

--- a/osprey/torch2whirl/Makefile.gbase
+++ b/osprey/torch2whirl/Makefile.gbase
@@ -79,9 +79,9 @@ OPEN64_DSC_NATIVE_IR_TOOL_OBJS = \
   $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/config_elf_targ.o) \
   $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/const.o) \
   $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/dsl_builder.o) \
+  $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/dsl_gatekeeper.o) \
   $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/dsl_contract.o) \
   $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/dsl_domain.o) \
-  $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/dsl_gatekeeper.o) \
   $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/dsl_ir_image.o) \
   $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/dsl_opcode.o) \
   $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/dwarf_DST.o) \
@@ -117,6 +117,7 @@ OPEN64_DSC_NATIVE_REQUIRED_FILES ?= $(strip $(OPEN64_DSC_NATIVE_OBJS))
 OPEN64_DSC_NATIVE_LDLIBS ?=
 OPEN64_IR_B2A ?= $(if $(OPEN64_DSC_NATIVE_OBJDIR),$(OPEN64_DSC_NATIVE_OBJDIR)/ir_b2a)
 OPEN64_OPENCC ?=
+OPEN64_DSL_TEST_ARTIFACT_DIR ?= $(CURDIR)/test-artifacts
 PYTHON_NATIVE_TARGET = $(PYTHON_NATIVE_PACKAGE_DIR)/_whirl$(PYTHON_EXT_SUFFIX)
 PYTHON_NATIVE_OBJECTS = \
   _whirl_module.native.o \
@@ -172,6 +173,7 @@ driver_native_ir_tools_smoke: $(TARGETS) python_native_extension \
   python_native_ir_tools_deps
 	PYTHONDONTWRITEBYTECODE=1 \
 	    OPEN64_IR_B2A="$(OPEN64_IR_B2A)" \
+	    OPEN64_DSL_TEST_ARTIFACT_DIR="$(OPEN64_DSL_TEST_ARTIFACT_DIR)/driver-native" \
 	    PYTHONPATH=$(TORCH2WHIRL_PYTHONPATH) \
 	    TORCH2WHIRL_DRIVER=$(TORCH2WHIRL_DRIVER) \
 	    $(PYTHON) $(BUILD_BASE)/python/tests/driver_native_ir_tools_smoke.py
@@ -297,6 +299,7 @@ python_native_test: python_native_extension
 python_native_ir_tools_smoke: python_native_extension python_native_ir_tools_deps
 	PYTHONDONTWRITEBYTECODE=1 \
 	    OPEN64_IR_B2A="$(OPEN64_IR_B2A)" \
+	    OPEN64_DSL_TEST_ARTIFACT_DIR="$(OPEN64_DSL_TEST_ARTIFACT_DIR)/python-native" \
 	    PYTHONPATH=$(PYTHON_BUILD_ROOT):$(BUILD_BASE)/python \
 	    $(PYTHON) $(BUILD_BASE)/python/tests/native_ir_tools_smoke.py
 

--- a/osprey/torch2whirl/README.md
+++ b/osprey/torch2whirl/README.md
@@ -79,13 +79,17 @@ Use `make python_native_test` from that directory to run the optional native
 Python finalization test after installing the matching Python development
 headers in the test environment.
 Use `make python_native_ir_tools_smoke` from the same directory to generate a
-native Python WHIRL artifact and inspect it with `ir_b2a -st`.  In a configured
+native Python WHIRL artifact and inspect it with `ir_b2a -st -src`.  In a configured
 `--enable-torch2whirl-only` build, this target first builds the additional
 tool-side `libjsoncpp.a` and `ir_b2a`/`ir_a2b` pieces needed for inspection.
 Those reader/WSSA objects are not linked into the `_whirl` frontend extension.
+The `.B`, `.safetensors`, and `.T` files are retained under
+`$(OPEN64_DSL_TEST_ARTIFACT_DIR)/python-native`.  The target removes the prior
+files in that artifact family before each run.
 Use `make driver_native_ir_tools_smoke` from a torch-enabled configured build
 to run the same native artifact inspection through the C++ `torch2whirl`
-executable.
+executable.  Its files are retained under
+`$(OPEN64_DSL_TEST_ARTIFACT_DIR)/driver-native` and refreshed before each run.
 Use `make driver_opencc_smoke` from a full-toolchain environment to run the
 C++ driver with `--backend native` and verify that `opencc -x whirl -c`
 consumes the generated artifact. This target skips cleanly when `opencc` is not
@@ -159,6 +163,12 @@ version, build directory, or Docker builder mode is needed. Set
 `OPEN64_TORCH2WHIRL_REBUILD_IMAGE=1` to refresh an existing torch image. The
 script defaults `OPEN64_TORCH2WHIRL_DOCKER_BUILDKIT=0` so local-only Open64
 base images are not resolved through a remote registry.
+The script mounts the host directory
+`$OPEN64_TORCH2WHIRL_ARTIFACT_DIR` at `/artifacts`, cleans it at startup, runs
+both native `ir_b2a -st -src` smoke lanes, and leaves the resulting artifacts after
+Docker exits.  It defaults to
+`$OPEN64_TORCH2WHIRL_BUILD_DIR/test-artifacts`.  Set
+`OPEN64_TORCH2WHIRL_RUN_IR_TOOLS=0` only when running the shorter PyTorch lane.
 
 For Linux Docker native extension validation from a configured build tree:
 
@@ -170,13 +180,13 @@ docker run --rm -v /path/to/open64:/src \
   sh -c 'apt-get update && apt-get install -y python3.8-dev && make python_native_test'
 ```
 
-For optional `ir_b2a -st` inspection of the native Python artifact:
+For optional `ir_b2a -st -src` inspection of the native Python artifact:
 
 ```sh
 make python_native_ir_tools_smoke
 ```
 
-For optional `ir_b2a -st` inspection of a native artifact produced through the
+For optional `ir_b2a -st -src` inspection of a native artifact produced through the
 C++ driver:
 
 ```sh

--- a/osprey/torch2whirl/python/native/_whirl_module.cxx
+++ b/osprey/torch2whirl/python/native/_whirl_module.cxx
@@ -155,6 +155,24 @@ Open64_DSC_Create_Tensor_Type(PyObject *self, PyObject *args)
 }
 
 static PyObject *
+Open64_DSC_Intern_Tensor_Type(PyObject *self, PyObject *args)
+{
+    const char *name;
+    PyObject *descriptor_obj;
+    Open64_DSC_Tensor_Descriptor descriptor;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "sO!:intern_tensor_type", &name,
+                          &PyDict_Type, &descriptor_obj))
+        return NULL;
+    if (!Open64_DSC_Read_Tensor_Descriptor(descriptor_obj, &descriptor))
+        return NULL;
+    return Open64_DSC_Handle_Result
+               (Open64_DSC_Intern_Tensor_Type(name, &descriptor),
+                "intern tensor type");
+}
+
+static PyObject *
 Open64_DSC_Attach_Tensor_Descriptor(PyObject *self, PyObject *args)
 {
     Open64_DSC_Handle tensor_type;
@@ -342,6 +360,36 @@ Open64_DSC_Create_Operator(PyObject *self, PyObject *args)
 }
 
 static PyObject *
+Open64_DSC_Create_Operator_With_Result(PyObject *self, PyObject *args)
+{
+    const char *opcode_name;
+    unsigned int version;
+    PyObject *kids_obj;
+    PyObject *attrs_obj;
+    const char *result_name;
+    Open64_DSC_Handle result_type;
+    std::vector<Open64_DSC_Handle> kids;
+    std::vector<Open64_DSC_Attribute> attrs;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "sIOOsK:create_operator_with_result",
+                          &opcode_name, &version, &kids_obj, &attrs_obj,
+                          &result_name, &result_type))
+        return NULL;
+    if (!Open64_DSC_Read_Handle_Sequence(kids_obj, &kids) ||
+        !Open64_DSC_Read_Attributes(attrs_obj, &attrs))
+        return NULL;
+    return Open64_DSC_Handle_Result
+               (Open64_DSC_Create_Operator_With_Result
+                    (opcode_name, version,
+                     kids.empty() ? NULL : &kids[0],
+                     (unsigned int) kids.size(),
+                     attrs.empty() ? NULL : &attrs[0],
+                     (unsigned int) attrs.size(), result_name, result_type),
+                "create operator with result");
+}
+
+static PyObject *
 Open64_DSC_Create_Symbol(PyObject *self, PyObject *args)
 {
     const char *name;
@@ -382,6 +430,83 @@ Open64_DSC_Attach_Symbol_Metadata(PyObject *self, PyObject *args)
 }
 
 static PyObject *
+Open64_DSC_Attach_Value_Metadata(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle value;
+    PyObject *metadata_obj;
+    std::vector<Open64_DSC_Attribute> metadata;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "KO!:attach_value_metadata", &value,
+                          &PyDict_Type, &metadata_obj))
+        return NULL;
+    if (!Open64_DSC_Read_Attributes(metadata_obj, &metadata))
+        return NULL;
+    return Open64_DSC_Bool_Result
+               (Open64_DSC_Attach_Value_Metadata
+                    (value, metadata.empty() ? NULL : &metadata[0],
+                     (unsigned int) metadata.size()),
+                "attach value metadata");
+}
+
+static PyObject *
+Open64_DSC_Attach_Value_Lineage(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle value;
+    const char *lineage;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "Ks:attach_value_lineage", &value, &lineage))
+        return NULL;
+    return Open64_DSC_Bool_Result
+               (Open64_DSC_Attach_Value_Lineage(value, lineage),
+                "attach value lineage");
+}
+
+static PyObject *
+Open64_DSC_Get_Value_Type(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle value;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "K:get_value_type", &value))
+        return NULL;
+    return Open64_DSC_Handle_Result(Open64_DSC_Get_Value_Type(value),
+                                    "get value type");
+}
+
+static PyObject *
+Open64_DSC_Get_Value_Result_Symbol(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle value;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "K:get_value_result_symbol", &value))
+        return NULL;
+    return Open64_DSC_Handle_Result
+               (Open64_DSC_Get_Value_Result_Symbol(value),
+                "get value result symbol");
+}
+
+static PyObject *
+Open64_DSC_Begin(PyObject *self, PyObject *args)
+{
+    (void) self;
+    (void) args;
+    return Open64_DSC_Bool_Result(Open64_DSC_Begin_Program(),
+                                  "begin program");
+}
+
+static PyObject *
+Open64_DSC_Abort(PyObject *self, PyObject *args)
+{
+    (void) self;
+    (void) args;
+    Open64_DSC_Abort_Program();
+    Py_RETURN_NONE;
+}
+
+static PyObject *
 Open64_DSC_Create_Minimal_Program_Unit(PyObject *self, PyObject *args)
 {
     const char *name;
@@ -394,6 +519,81 @@ Open64_DSC_Create_Minimal_Program_Unit(PyObject *self, PyObject *args)
 
     handle = Open64_DSC_Create_Minimal_Program_Unit(name);
     return Open64_DSC_Handle_Result(handle, "create minimal program unit");
+}
+
+static PyObject *
+Open64_DSC_Register_Source_File(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle program_unit;
+    const char *path;
+    unsigned int file_id;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "Ks:register_source_file", &program_unit,
+                          &path))
+        return NULL;
+    file_id = Open64_DSC_Register_Source_File(program_unit, path);
+    if (file_id == 0) {
+        PyErr_SetString(PyExc_RuntimeError, "failed to register source file");
+        return NULL;
+    }
+    return PyLong_FromUnsignedLong(file_id);
+}
+
+static PyObject *
+Open64_DSC_Set_Value_Source_Position(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle value;
+    unsigned int file_id;
+    int line;
+    unsigned int column;
+    int statement_begin;
+    int basic_block_begin;
+    Open64_DSC_Source_Position position;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "KIiIpp:set_value_source_position", &value,
+                          &file_id, &line, &column, &statement_begin,
+                          &basic_block_begin))
+        return NULL;
+    if (column > 65535) {
+        PyErr_SetString(PyExc_ValueError, "source column is out of range");
+        return NULL;
+    }
+    position.file_id = file_id;
+    position.line = line;
+    position.column = (unsigned short) column;
+    position.statement_begin = statement_begin != 0;
+    position.basic_block_begin = basic_block_begin != 0;
+    return Open64_DSC_Bool_Result
+               (Open64_DSC_Set_Value_Source_Position(value, &position),
+                "set value source position");
+}
+
+static PyObject *
+Open64_DSC_Verify(PyObject *self, PyObject *args)
+{
+    char diagnostic[4096];
+    Open64_DSC_Verify_Result result;
+    int valid;
+    PyObject *record;
+
+    (void) self;
+    (void) args;
+    result.native_node_count = 0;
+    result.result_symbol_count = 0;
+    result.error_count = 0;
+    result.diagnostic = diagnostic;
+    result.diagnostic_capacity = sizeof(diagnostic);
+    valid = Open64_DSC_Verify_Program(&result);
+    record = Py_BuildValue
+                 ("{s:O,s:I,s:I,s:I,s:s}",
+                  "valid", valid ? Py_True : Py_False,
+                  "native_node_count", result.native_node_count,
+                  "result_symbol_count", result.result_symbol_count,
+                  "error_count", result.error_count,
+                  "diagnostic", diagnostic);
+    return record;
 }
 
 static PyObject *
@@ -605,6 +805,12 @@ static PyMethodDef Open64_DSC_Methods[] = {
         "Create a native tensor type and return an opaque handle."
     },
     {
+        "intern_tensor_type",
+        Open64_DSC_Intern_Tensor_Type,
+        METH_VARARGS,
+        "Intern a canonical native tensor descriptor and return its handle."
+    },
+    {
         "attach_tensor_descriptor",
         Open64_DSC_Attach_Tensor_Descriptor,
         METH_VARARGS,
@@ -635,6 +841,12 @@ static PyMethodDef Open64_DSC_Methods[] = {
         "Create a native DSL operator and return an opaque handle."
     },
     {
+        "create_operator_with_result",
+        Open64_DSC_Create_Operator_With_Result,
+        METH_VARARGS,
+        "Create a native DSL operator with an explicit result type."
+    },
+    {
         "create_symbol",
         Open64_DSC_Create_Symbol,
         METH_VARARGS,
@@ -647,10 +859,64 @@ static PyMethodDef Open64_DSC_Methods[] = {
         "Attach compiler metadata to a native symbol."
     },
     {
+        "attach_value_metadata",
+        Open64_DSC_Attach_Value_Metadata,
+        METH_VARARGS,
+        "Attach compiler metadata to a native value result."
+    },
+    {
+        "attach_value_lineage",
+        Open64_DSC_Attach_Value_Lineage,
+        METH_VARARGS,
+        "Attach semantic lineage to a native value result."
+    },
+    {
+        "get_value_type",
+        Open64_DSC_Get_Value_Type,
+        METH_VARARGS,
+        "Get the opaque canonical tensor type for a value."
+    },
+    {
+        "get_value_result_symbol",
+        Open64_DSC_Get_Value_Result_Symbol,
+        METH_VARARGS,
+        "Get the opaque result symbol for a value."
+    },
+    {
+        "begin_program",
+        Open64_DSC_Begin,
+        METH_NOARGS,
+        "Begin an isolated native builder program."
+    },
+    {
+        "abort_program",
+        Open64_DSC_Abort,
+        METH_NOARGS,
+        "Discard the current native builder program."
+    },
+    {
         "create_minimal_program_unit",
         Open64_DSC_Create_Minimal_Program_Unit,
         METH_VARARGS,
         "Create a minimal native PU tree entry and return an opaque handle."
+    },
+    {
+        "register_source_file",
+        Open64_DSC_Register_Source_File,
+        METH_VARARGS,
+        "Register a source file for a native program unit."
+    },
+    {
+        "set_value_source_position",
+        Open64_DSC_Set_Value_Source_Position,
+        METH_VARARGS,
+        "Attach a source position to a native value definition."
+    },
+    {
+        "verify_program",
+        Open64_DSC_Verify,
+        METH_NOARGS,
+        "Run structured native DSL gatekeeper verification."
     },
     {
         "append_program_unit_value",

--- a/osprey/torch2whirl/python/native/open64_dsc_native_bridge.cxx
+++ b/osprey/torch2whirl/python/native/open64_dsc_native_bridge.cxx
@@ -16,6 +16,8 @@
 #include "erglob.h"
 #include "errors.h"
 #include "err_host.tab"
+#include "config.h"
+#include "config_targ_opt.h"
 #include "stab.h"
 #include "dsl_builder.h"
 #include "open64_dsc_native_bridge.h"
@@ -87,35 +89,75 @@ Open64_DSC_Initialize_Context(void)
     Open64_DSC_Context_Initialized = TRUE;
 }
 
+static BOOL
+Open64_DSC_Copy_Tensor_Descriptor
+        (const Open64_DSC_Tensor_Descriptor *descriptor,
+         DSL_BUILDER_TENSOR_DESCRIPTOR *builder_descriptor)
+{
+    if (descriptor == NULL || builder_descriptor == NULL ||
+        descriptor->dtype == NULL || descriptor->dtype[0] == '\0' ||
+        descriptor->rank < 0 || descriptor->logical_shape == NULL ||
+        descriptor->logical_shape[0] == '\0')
+        return FALSE;
+
+    memset(builder_descriptor, 0, sizeof(*builder_descriptor));
+    builder_descriptor->type_core.kind =
+        descriptor->kind == NULL ? "tensor" : descriptor->kind;
+    builder_descriptor->type_core.dtype = descriptor->dtype;
+    builder_descriptor->type_core.rank = descriptor->rank;
+    builder_descriptor->type_core.logical_shape = descriptor->logical_shape;
+    builder_descriptor->traits.traits = descriptor->traits;
+    builder_descriptor->representation.layout = descriptor->layout;
+    builder_descriptor->representation.sharding = descriptor->sharding;
+    builder_descriptor->representation.placement = descriptor->placement;
+    builder_descriptor->representation.memory = descriptor->memory;
+    builder_descriptor->representation.quantization = descriptor->quantization;
+    builder_descriptor->representation.runtime_state = descriptor->runtime_state;
+    builder_descriptor->lineage.lineage = descriptor->lineage;
+    return TRUE;
+}
+
+Open64_DSC_Handle
+Open64_DSC_Intern_Tensor_Type
+        (const char *name,
+         const Open64_DSC_Tensor_Descriptor *descriptor)
+{
+    DSL_BUILDER_TENSOR_DESCRIPTOR builder_descriptor;
+    TY_IDX element_ty;
+
+    if (name == NULL || name[0] == '\0' ||
+        !Open64_DSC_Copy_Tensor_Descriptor(descriptor, &builder_descriptor))
+        return 0;
+
+    Open64_DSC_Initialize_Context();
+    element_ty = Open64_DSC_Dtype_To_TY(descriptor->dtype);
+    if (element_ty == TY_IDX_ZERO)
+        return 0;
+    TY_IDX tensor_ty = DSL_Builder_Intern_Tensor_Type
+                           (name, element_ty, &builder_descriptor);
+    return DSL_Builder_Tensor_Type_Is_Canonical(tensor_ty) ?
+           (Open64_DSC_Handle) tensor_ty : 0;
+}
+
 Open64_DSC_Handle
 Open64_DSC_Create_Tensor_Type(const char *name,
                               const char *dtype,
                               int rank,
                               const char *logical_shape)
 {
-    DSL_BUILDER_TENSOR_TYPE_CORE type_core;
-    TY_IDX element_ty;
-    TY_IDX tensor_ty;
+    Open64_DSC_Tensor_Descriptor descriptor;
 
     if (name == NULL || name[0] == '\0' ||
         dtype == NULL || dtype[0] == '\0' ||
         rank < 0)
         return 0;
 
-    Open64_DSC_Initialize_Context();
-
-    element_ty = Open64_DSC_Dtype_To_TY(dtype);
-    if (element_ty == TY_IDX_ZERO)
-        return 0;
-
-    type_core.kind = "tensor";
-    type_core.dtype = dtype;
-    type_core.rank = rank;
-    type_core.logical_shape = logical_shape;
-
-    tensor_ty = DSL_Builder_Create_Tensor_Type_Core(name, element_ty,
-                                                    &type_core);
-    return (Open64_DSC_Handle) tensor_ty;
+    memset(&descriptor, 0, sizeof(descriptor));
+    descriptor.kind = "tensor";
+    descriptor.dtype = dtype;
+    descriptor.rank = rank;
+    descriptor.logical_shape = logical_shape;
+    return Open64_DSC_Intern_Tensor_Type(name, &descriptor);
 }
 
 int
@@ -132,21 +174,8 @@ Open64_DSC_Attach_Tensor_Descriptor
 
     Open64_DSC_Initialize_Context();
 
-    memset(&builder_descriptor, 0, sizeof(builder_descriptor));
-    builder_descriptor.type_core.kind =
-        descriptor->kind == NULL ? "tensor" : descriptor->kind;
-    builder_descriptor.type_core.dtype = descriptor->dtype;
-    builder_descriptor.type_core.rank = descriptor->rank;
-    builder_descriptor.type_core.logical_shape = descriptor->logical_shape;
-    builder_descriptor.traits.traits = descriptor->traits;
-    builder_descriptor.representation.layout = descriptor->layout;
-    builder_descriptor.representation.sharding = descriptor->sharding;
-    builder_descriptor.representation.placement = descriptor->placement;
-    builder_descriptor.representation.memory = descriptor->memory;
-    builder_descriptor.representation.quantization = descriptor->quantization;
-    builder_descriptor.representation.runtime_state =
-        descriptor->runtime_state;
-    builder_descriptor.lineage.lineage = descriptor->lineage;
+    if (!Open64_DSC_Copy_Tensor_Descriptor(descriptor, &builder_descriptor))
+        return 0;
 
     return DSL_Builder_Attach_Tensor_Descriptor
                ((TY_IDX) tensor_type, &builder_descriptor) ? 1 : 0;
@@ -160,10 +189,9 @@ Open64_DSC_Create_Tensor_Constant(const char *name,
                                   const char *value_kind,
                                   const char *value)
 {
-    DSL_BUILDER_TENSOR_TYPE_CORE type_core;
-    TY_IDX element_ty;
+    Open64_DSC_Tensor_Descriptor descriptor;
     TY_IDX tensor_ty;
-    DSL_BUILDER_VALUE value_wn;
+    DSL_BUILDER_VALUE result;
 
     if (name == NULL || name[0] == '\0' ||
         dtype == NULL || dtype[0] == '\0' ||
@@ -172,25 +200,17 @@ Open64_DSC_Create_Tensor_Constant(const char *name,
 
     Open64_DSC_Initialize_Context();
 
-    element_ty = Open64_DSC_Dtype_To_TY(dtype);
-    if (element_ty == TY_IDX_ZERO)
-        return 0;
-
-    type_core.kind = "tensor";
-    type_core.dtype = dtype;
-    type_core.rank = (INT32) rank;
-    type_core.logical_shape = logical_shape;
-    tensor_ty = DSL_Builder_Create_Tensor_Type_Core(name, element_ty,
-                                                    &type_core);
-    if (tensor_ty == TY_IDX_ZERO)
-        return 0;
-
-    value_wn = DSL_Builder_Create_Tensor_Constant(name, tensor_ty, dtype,
-                                                  rank, logical_shape,
-                                                  value_kind, value);
-    return (Open64_DSC_Handle) value_wn;
+    memset(&descriptor, 0, sizeof(descriptor));
+    descriptor.kind = "tensor";
+    descriptor.dtype = dtype;
+    descriptor.rank = rank;
+    descriptor.logical_shape = logical_shape;
+    tensor_ty = (TY_IDX) Open64_DSC_Intern_Tensor_Type(name, &descriptor);
+    result = DSL_Builder_Create_Tensor_Constant
+                 (name, tensor_ty, dtype, rank, logical_shape,
+                  value_kind, value);
+    return (Open64_DSC_Handle) result;
 }
-
 Open64_DSC_Handle
 Open64_DSC_Create_Model_Input(const char *name,
                               Open64_DSC_Handle tensor_type,
@@ -305,6 +325,57 @@ Open64_DSC_Create_Operator(const char *opcode_name,
 }
 
 Open64_DSC_Handle
+Open64_DSC_Create_Operator_With_Result
+        (const char *opcode_name,
+         unsigned int version,
+         const Open64_DSC_Handle *kids,
+         unsigned int kid_count,
+         const Open64_DSC_Attribute *attrs,
+         unsigned int attr_count,
+         const char *result_name,
+         Open64_DSC_Handle result_type)
+{
+    DSL_DOMAIN_ID domain_id;
+    DSL_OPCODE_ID opcode_id;
+    DSL_BUILDER_VALUE *builder_kids = NULL;
+    DSL_BUILDER_OPERATOR_ATTRIBUTE *builder_attrs = NULL;
+    DSL_BUILDER_OPERATOR op;
+    unsigned int i;
+
+    if (opcode_name == NULL || version == 0 || result_name == NULL ||
+        result_name[0] == '\0' || result_type == 0 ||
+        (kid_count != 0 && kids == NULL) ||
+        (attr_count != 0 && attrs == NULL))
+        return 0;
+    Open64_DSC_Initialize_Context();
+    domain_id = Open64_DSC_Domain_For_Opcode(opcode_name);
+    if (domain_id == DSL_DOMAIN_INVALID_ID)
+        return 0;
+    opcode_id = DSL_Opcode_Find(domain_id, opcode_name, (UINT16) version);
+    if (opcode_id == DSL_OPCODE_INVALID_ID)
+        return 0;
+
+    if (kid_count != 0) {
+        builder_kids = new DSL_BUILDER_VALUE[kid_count];
+        for (i = 0; i < kid_count; ++i)
+            builder_kids[i] = (DSL_BUILDER_VALUE) kids[i];
+    }
+    if (attr_count != 0) {
+        builder_attrs = new DSL_BUILDER_OPERATOR_ATTRIBUTE[attr_count];
+        for (i = 0; i < attr_count; ++i) {
+            builder_attrs[i].name = attrs[i].name;
+            builder_attrs[i].value = attrs[i].value;
+        }
+    }
+    op = DSL_Builder_Create_Operator_With_Result
+             (opcode_id, (UINT16) version, builder_kids, kid_count,
+              builder_attrs, attr_count, result_name, (TY_IDX) result_type);
+    delete [] builder_kids;
+    delete [] builder_attrs;
+    return (Open64_DSC_Handle) op;
+}
+
+Open64_DSC_Handle
 Open64_DSC_Create_Symbol(const char *name, Open64_DSC_Handle tensor_type)
 {
     ST_IDX st;
@@ -352,6 +423,69 @@ Open64_DSC_Attach_Symbol_Metadata(Open64_DSC_Handle symbol,
     return ok ? 1 : 0;
 }
 
+int
+Open64_DSC_Attach_Value_Metadata(Open64_DSC_Handle value,
+                                 const Open64_DSC_Attribute *metadata,
+                                 unsigned int metadata_count)
+{
+    DSL_BUILDER_COMPILER_METADATA *builder_metadata = NULL;
+    unsigned int i;
+    BOOL ok;
+
+    Open64_DSC_Initialize_Context();
+    if (metadata_count != 0 && metadata == NULL)
+        return 0;
+    if (metadata_count != 0) {
+        builder_metadata = new DSL_BUILDER_COMPILER_METADATA[metadata_count];
+        for (i = 0; i < metadata_count; ++i) {
+            builder_metadata[i].name = metadata[i].name;
+            builder_metadata[i].value = metadata[i].value;
+        }
+    }
+    ok = DSL_Builder_Attach_Value_Metadata
+             ((DSL_BUILDER_VALUE) value, builder_metadata, metadata_count);
+    delete [] builder_metadata;
+    return ok ? 1 : 0;
+}
+
+int
+Open64_DSC_Attach_Value_Lineage(Open64_DSC_Handle value, const char *lineage)
+{
+    Open64_DSC_Initialize_Context();
+    return DSL_Builder_Attach_Value_Lineage
+               ((DSL_BUILDER_VALUE) value, lineage) ? 1 : 0;
+}
+
+Open64_DSC_Handle
+Open64_DSC_Get_Value_Type(Open64_DSC_Handle value)
+{
+    Open64_DSC_Initialize_Context();
+    return (Open64_DSC_Handle) DSL_Builder_Get_Value_Type
+               ((DSL_BUILDER_VALUE) value);
+}
+
+Open64_DSC_Handle
+Open64_DSC_Get_Value_Result_Symbol(Open64_DSC_Handle value)
+{
+    Open64_DSC_Initialize_Context();
+    return (Open64_DSC_Handle) DSL_Builder_Get_Value_Result_Symbol
+               ((DSL_BUILDER_VALUE) value);
+}
+
+int
+Open64_DSC_Begin_Program(void)
+{
+    Open64_DSC_Initialize_Context();
+    return DSL_Builder_Begin_Program() ? 1 : 0;
+}
+
+void
+Open64_DSC_Abort_Program(void)
+{
+    Open64_DSC_Initialize_Context();
+    DSL_Builder_Abort_Program();
+}
+
 Open64_DSC_Handle
 Open64_DSC_Create_Minimal_Program_Unit(const char *name)
 {
@@ -364,6 +498,54 @@ Open64_DSC_Create_Minimal_Program_Unit(const char *name)
 
     pu = DSL_Builder_Create_Minimal_PU(name);
     return (Open64_DSC_Handle) pu;
+}
+
+unsigned int
+Open64_DSC_Register_Source_File(Open64_DSC_Handle program_unit,
+                                const char *path)
+{
+    Open64_DSC_Initialize_Context();
+    return DSL_Builder_Register_Source_File
+               ((DSL_BUILDER_PROGRAM_UNIT) program_unit, path);
+}
+
+int
+Open64_DSC_Set_Value_Source_Position
+        (Open64_DSC_Handle value,
+         const Open64_DSC_Source_Position *position)
+{
+    DSL_BUILDER_SOURCE_POSITION builder_position;
+
+    if (position == NULL)
+        return 0;
+    Open64_DSC_Initialize_Context();
+    builder_position.file_id = position->file_id;
+    builder_position.line = position->line;
+    builder_position.column = position->column;
+    builder_position.statement_begin = position->statement_begin;
+    builder_position.basic_block_begin = position->basic_block_begin;
+    return DSL_Builder_Set_Value_Source_Position
+               ((DSL_BUILDER_VALUE) value, &builder_position) ? 1 : 0;
+}
+
+int
+Open64_DSC_Verify_Program(Open64_DSC_Verify_Result *result)
+{
+    DSL_BUILDER_VERIFY_RESULT builder_result;
+    BOOL valid;
+
+    if (result == NULL)
+        return 0;
+    builder_result.native_node_count = 0;
+    builder_result.result_symbol_count = 0;
+    builder_result.error_count = 0;
+    builder_result.diagnostic = result->diagnostic;
+    builder_result.diagnostic_capacity = result->diagnostic_capacity;
+    valid = DSL_Builder_Verify_Program(&builder_result);
+    result->native_node_count = builder_result.native_node_count;
+    result->result_symbol_count = builder_result.result_symbol_count;
+    result->error_count = builder_result.error_count;
+    return valid ? 1 : 0;
 }
 
 int

--- a/osprey/torch2whirl/python/native/open64_dsc_native_bridge.h
+++ b/osprey/torch2whirl/python/native/open64_dsc_native_bridge.h
@@ -65,15 +65,6 @@ typedef struct {
 
 typedef Open64_DSC_Marker_Info Open64_DSC_Value_Info;
 
-typedef struct {
-    const char *storage_format;
-    const char *side_file;
-    const char *tensor_key;
-    unsigned long long byte_offset;
-    unsigned long long byte_length;
-    const char *checksum;
-} Open64_DSC_External_Tensor_Reference;
-
 extern Open64_DSC_Handle Open64_DSC_Create_Tensor_Type
                                 (const char *name,
                                  const char *dtype,

--- a/osprey/torch2whirl/python/native/open64_dsc_native_bridge.h
+++ b/osprey/torch2whirl/python/native/open64_dsc_native_bridge.h
@@ -32,6 +32,31 @@ typedef struct {
 } Open64_DSC_Tensor_Descriptor;
 
 typedef struct {
+    const char *storage_format;
+    const char *side_file;
+    const char *tensor_key;
+    unsigned long long byte_offset;
+    unsigned long long byte_length;
+    const char *checksum;
+} Open64_DSC_External_Tensor_Reference;
+
+typedef struct {
+    unsigned int file_id;
+    int line;
+    unsigned short column;
+    unsigned char statement_begin;
+    unsigned char basic_block_begin;
+} Open64_DSC_Source_Position;
+
+typedef struct {
+    unsigned int native_node_count;
+    unsigned int result_symbol_count;
+    unsigned int error_count;
+    char *diagnostic;
+    unsigned int diagnostic_capacity;
+} Open64_DSC_Verify_Result;
+
+typedef struct {
     const char *opcode_name;
     unsigned int opcode_name_len;
     unsigned int version;
@@ -54,6 +79,9 @@ extern Open64_DSC_Handle Open64_DSC_Create_Tensor_Type
                                  const char *dtype,
                                  int rank,
                                  const char *logical_shape);
+extern Open64_DSC_Handle Open64_DSC_Intern_Tensor_Type
+                                (const char *name,
+                                 const Open64_DSC_Tensor_Descriptor *descriptor);
 extern int Open64_DSC_Attach_Tensor_Descriptor
                                 (Open64_DSC_Handle tensor_type,
                                  const Open64_DSC_Tensor_Descriptor *descriptor);
@@ -80,6 +108,15 @@ extern Open64_DSC_Handle Open64_DSC_Create_Operator
                                  unsigned int kid_count,
                                  const Open64_DSC_Attribute *attrs,
                                  unsigned int attr_count);
+extern Open64_DSC_Handle Open64_DSC_Create_Operator_With_Result
+                                (const char *opcode_name,
+                                 unsigned int version,
+                                 const Open64_DSC_Handle *kids,
+                                 unsigned int kid_count,
+                                 const Open64_DSC_Attribute *attrs,
+                                 unsigned int attr_count,
+                                 const char *result_name,
+                                 Open64_DSC_Handle result_type);
 extern Open64_DSC_Handle Open64_DSC_Create_Symbol
                                 (const char *name,
                                  Open64_DSC_Handle tensor_type);
@@ -87,8 +124,28 @@ extern int Open64_DSC_Attach_Symbol_Metadata
                                 (Open64_DSC_Handle symbol,
                                  const Open64_DSC_Attribute *metadata,
                                  unsigned int metadata_count);
+extern int Open64_DSC_Attach_Value_Metadata
+                                (Open64_DSC_Handle value,
+                                 const Open64_DSC_Attribute *metadata,
+                                 unsigned int metadata_count);
+extern int Open64_DSC_Attach_Value_Lineage
+                                (Open64_DSC_Handle value,
+                                 const char *lineage);
+extern Open64_DSC_Handle Open64_DSC_Get_Value_Type
+                                (Open64_DSC_Handle value);
+extern Open64_DSC_Handle Open64_DSC_Get_Value_Result_Symbol
+                                (Open64_DSC_Handle value);
+extern int Open64_DSC_Begin_Program(void);
+extern void Open64_DSC_Abort_Program(void);
 extern Open64_DSC_Handle Open64_DSC_Create_Minimal_Program_Unit
-                                (const char *name);
+                                 (const char *name);
+extern unsigned int Open64_DSC_Register_Source_File
+                                (Open64_DSC_Handle program_unit,
+                                 const char *path);
+extern int Open64_DSC_Set_Value_Source_Position
+                                (Open64_DSC_Handle value,
+                                 const Open64_DSC_Source_Position *position);
+extern int Open64_DSC_Verify_Program(Open64_DSC_Verify_Result *result);
 extern int Open64_DSC_Append_Program_Unit_Value
                                 (Open64_DSC_Handle program_unit,
                                  Open64_DSC_Handle value);

--- a/osprey/torch2whirl/python/open64_dsc/_mock_whirl.py
+++ b/osprey/torch2whirl/python/open64_dsc/_mock_whirl.py
@@ -9,6 +9,7 @@ from typing import Dict, Mapping, Sequence
 
 _handle_counter = count(1)
 _objects: Dict[int, Mapping[str, object]] = {}
+_canonical_types: Dict[tuple[tuple[str, str], ...], int] = {}
 
 
 def backend_name() -> str:
@@ -43,6 +44,28 @@ def create_tensor_type(
             "logical_shape": logical_shape,
         }
     )
+
+
+def intern_tensor_type(name: str, descriptor: Mapping[str, object]) -> int:
+    canonical = {
+        str(key): str(value)
+        for key, value in descriptor.items()
+        if key not in {"runtime_state", "lineage"} and value is not None
+    }
+    if not canonical.get("dtype") or int(canonical.get("rank", -1)) < 0:
+        raise RuntimeError("failed to intern tensor type")
+    key = tuple(sorted(canonical.items()))
+    existing = _canonical_types.get(key)
+    if existing is not None:
+        return existing
+    handle = _new_handle({
+        "name": name,
+        "descriptor": canonical,
+        **canonical,
+        "kind": "tensor_type",
+    })
+    _canonical_types[key] = handle
+    return handle
 
 
 def attach_tensor_descriptor(
@@ -176,6 +199,22 @@ def create_operator(
     )
 
 
+def create_operator_with_result(
+    opcode_name: str,
+    version: int,
+    kids: Sequence[int],
+    attrs: Mapping[str, str],
+    result_name: str,
+    result_type: int,
+) -> int:
+    handle = create_operator(opcode_name, version, kids, attrs)
+    record = dict(_objects[handle])
+    record["name"] = result_name
+    record["result_type"] = result_type
+    _objects[handle] = record
+    return handle
+
+
 def create_symbol(name: str, tensor_type: int) -> int:
     if not name:
         raise RuntimeError("failed to create symbol")
@@ -208,6 +247,51 @@ def attach_symbol_metadata(
     return True
 
 
+def attach_value_metadata(value: int, metadata: Mapping[str, str]) -> bool:
+    if value not in _objects:
+        raise RuntimeError("failed to attach value metadata")
+    record = dict(_objects[value])
+    record["metadata"] = dict(metadata)
+    _objects[value] = record
+    return True
+
+
+def attach_value_lineage(value: int, lineage: str) -> bool:
+    if value not in _objects or not lineage:
+        raise RuntimeError("failed to attach value lineage")
+    record = dict(_objects[value])
+    record["lineage"] = lineage
+    _objects[value] = record
+    return True
+
+
+def get_value_type(value: int) -> int:
+    return int(_objects[value].get("result_type", _objects[value].get("tensor_type", 0)))
+
+
+def get_value_result_symbol(value: int) -> int:
+    if value not in _objects:
+        raise RuntimeError("failed to get value result symbol")
+    record = dict(_objects[value])
+    symbol = int(record.get("result_symbol", 0))
+    if symbol == 0:
+        symbol = _new_handle({"kind": "symbol", "name": record.get("name", "")})
+        record["result_symbol"] = symbol
+        _objects[value] = record
+    return symbol
+
+
+def begin_program() -> bool:
+    _objects.clear()
+    _canonical_types.clear()
+    return True
+
+
+def abort_program() -> None:
+    _objects.clear()
+    _canonical_types.clear()
+
+
 def create_minimal_program_unit(name: str) -> int:
     if not name:
         raise RuntimeError("failed to create minimal program unit")
@@ -219,6 +303,60 @@ def create_minimal_program_unit(name: str) -> int:
             "body_markers": [],
         }
     )
+
+
+def register_source_file(program_unit: int, path: str) -> int:
+    if program_unit not in _objects or not path:
+        raise RuntimeError("failed to register source file")
+    record = dict(_objects[program_unit])
+    files = list(record.get("source_files", ()))
+    if path not in files:
+        files.append(path)
+    record["source_files"] = files
+    _objects[program_unit] = record
+    return files.index(path) + 1
+
+
+def set_value_source_position(
+    value: int,
+    file_id: int,
+    line: int,
+    column: int,
+    statement_begin: bool,
+    basic_block_begin: bool,
+) -> bool:
+    if value not in _objects or file_id <= 0 or line < 0:
+        raise RuntimeError("failed to set value source position")
+    record = dict(_objects[value])
+    record["source_position"] = (
+        file_id, line, column, statement_begin, basic_block_begin
+    )
+    _objects[value] = record
+    return True
+
+
+def verify_program() -> Mapping[str, object]:
+    program_units = [
+        record for record in _objects.values()
+        if record.get("kind") == "program_unit"
+    ]
+    valid = bool(program_units)
+    values = [
+        record for record in _objects.values()
+        if record.get("kind") in {
+            "operator",
+            "tensor_constant",
+            "model_input",
+            "external_tensor_constant",
+        }
+    ]
+    return {
+        "valid": valid,
+        "native_node_count": len(values),
+        "result_symbol_count": len(values),
+        "error_count": 0 if valid else 1,
+        "diagnostic": "" if valid else "no program unit",
+    }
 
 
 def _marker_name(marker: int) -> str:

--- a/osprey/torch2whirl/python/open64_dsc/backend.py
+++ b/osprey/torch2whirl/python/open64_dsc/backend.py
@@ -20,6 +20,13 @@ class WhirlBackend(Protocol):
     ) -> int:
         ...
 
+    def intern_tensor_type(
+        self,
+        name: str,
+        descriptor: Mapping[str, object],
+    ) -> int:
+        ...
+
     def attach_tensor_descriptor(
         self,
         tensor_type: int,
@@ -63,6 +70,17 @@ class WhirlBackend(Protocol):
     ) -> int:
         ...
 
+    def create_operator_with_result(
+        self,
+        opcode_name: str,
+        version: int,
+        kids: Sequence[int],
+        attrs: Mapping[str, str],
+        result_name: str,
+        result_type: int,
+    ) -> int:
+        ...
+
     def create_symbol(
         self,
         name: str,
@@ -77,10 +95,49 @@ class WhirlBackend(Protocol):
     ) -> bool:
         ...
 
+    def attach_value_metadata(
+        self,
+        value: int,
+        metadata: Mapping[str, str],
+    ) -> bool:
+        ...
+
+    def attach_value_lineage(self, value: int, lineage: str) -> bool:
+        ...
+
+    def get_value_type(self, value: int) -> int:
+        ...
+
+    def get_value_result_symbol(self, value: int) -> int:
+        ...
+
+    def begin_program(self) -> bool:
+        ...
+
+    def abort_program(self) -> None:
+        ...
+
     def create_minimal_program_unit(
         self,
         name: str,
     ) -> int:
+        ...
+
+    def register_source_file(self, program_unit: int, path: str) -> int:
+        ...
+
+    def set_value_source_position(
+        self,
+        value: int,
+        file_id: int,
+        line: int,
+        column: int,
+        statement_begin: bool,
+        basic_block_begin: bool,
+    ) -> bool:
+        ...
+
+    def verify_program(self) -> Mapping[str, object]:
         ...
 
     def append_program_unit_marker(

--- a/osprey/torch2whirl/python/open64_dsc/builder.py
+++ b/osprey/torch2whirl/python/open64_dsc/builder.py
@@ -10,6 +10,11 @@ from .mapping import cnn, common
 from .mapping.contract import operator_version
 
 
+_TYPE_DESCRIPTORS: dict[str, dict[int, dict[str, object]]] = {}
+_VALUE_TYPES: dict[str, dict[int, "TensorTypeHandle"]] = {}
+_RESULT_ORDINALS: dict[str, int] = {}
+
+
 @dataclass(frozen=True)
 class OpaqueHandle:
     value: int
@@ -55,6 +60,10 @@ class ProgramUnitHandle(OpaqueHandle):
 class WhirlBuilder:
     def __init__(self, backend: WhirlBackend):
         self._backend = backend
+        backend_name = backend.backend_name()
+        self._backend_key = backend_name
+        self._type_descriptors = _TYPE_DESCRIPTORS.setdefault(backend_name, {})
+        self._value_types = _VALUE_TYPES.setdefault(backend_name, {})
 
     def backend_name(self) -> str:
         return self._backend.backend_name()
@@ -65,26 +74,55 @@ class WhirlBuilder:
         dtype: str,
         rank: int,
         logical_shape: str,
+        descriptor: Optional[Mapping[str, object]] = None,
     ) -> TensorTypeHandle:
-        return TensorTypeHandle(
-            self._backend.create_tensor_type(
-                name,
-                dtype,
-                rank,
-                logical_shape,
-            )
+        canonical = dict(descriptor or {})
+        canonical.update({
+            "kind": str(canonical.get("kind", "tensor")),
+            "dtype": dtype,
+            "rank": rank,
+            "logical_shape": logical_shape,
+        })
+        canonical.pop("runtime_state", None)
+        canonical.pop("lineage", None)
+        tensor_type = TensorTypeHandle(
+            self._backend.intern_tensor_type(name, canonical)
         )
+        self._type_descriptors[tensor_type.value] = canonical
+        return tensor_type
 
     def attach_tensor_descriptor(
         self,
         tensor_type: TensorTypeHandle,
         descriptor: Mapping[str, object],
     ) -> None:
-        if not self._backend.attach_tensor_descriptor(
-            tensor_type.value,
-            descriptor,
+        canonical = dict(descriptor)
+        canonical.pop("runtime_state", None)
+        canonical.pop("lineage", None)
+        current = self._type_descriptors.get(tensor_type.value)
+        if current is None or any(
+            current.get(key) != value for key, value in canonical.items()
         ):
-            raise RuntimeError("failed to attach tensor descriptor")
+            raise RuntimeError("canonical tensor descriptor cannot be mutated")
+
+    def begin_program(self) -> None:
+        if not self._backend.begin_program():
+            raise RuntimeError("failed to begin native builder program")
+        self._value_types.clear()
+        _RESULT_ORDINALS[self._backend_key] = 0
+
+    def abort_program(self) -> None:
+        self._backend.abort_program()
+        self._value_types.clear()
+
+    def verify_program(self) -> Mapping[str, object]:
+        result = self._backend.verify_program()
+        if not bool(result.get("valid", False)):
+            diagnostic = str(result.get("diagnostic", ""))
+            raise RuntimeError(
+                diagnostic or "native DSL program verification failed"
+            )
+        return result
 
     def symbol(
         self,
@@ -113,6 +151,54 @@ class WhirlBuilder:
         return ProgramUnitHandle(
             self._backend.create_minimal_program_unit(name)
         )
+
+    def register_source_file(
+        self,
+        program_unit: ProgramUnitHandle,
+        path: str,
+    ) -> int:
+        return self._backend.register_source_file(program_unit.value, path)
+
+    def set_value_source_position(
+        self,
+        value: ValueHandle,
+        file_id: int,
+        line: int,
+        column: int = 0,
+        statement_begin: bool = True,
+        basic_block_begin: bool = False,
+    ) -> None:
+        if not self._backend.set_value_source_position(
+            value.value,
+            file_id,
+            line,
+            column,
+            statement_begin,
+            basic_block_begin,
+        ):
+            raise RuntimeError("failed to set value source position")
+
+    def attach_value_metadata(
+        self,
+        value: ValueHandle,
+        metadata: Mapping[str, str],
+    ) -> None:
+        if not self._backend.attach_value_metadata(value.value, metadata):
+            raise RuntimeError("failed to attach value metadata")
+
+    def attach_value_lineage(self, value: ValueHandle, lineage: str) -> None:
+        if not self._backend.attach_value_lineage(value.value, lineage):
+            raise RuntimeError("failed to attach value lineage")
+
+    def value_result_symbol(self, value: ValueHandle) -> SymbolHandle:
+        return SymbolHandle(self._backend.get_value_result_symbol(value.value))
+
+    def value_type(self, value: ValueHandle) -> TensorTypeHandle:
+        tensor_type = self._value_types.get(value.value)
+        if tensor_type is None:
+            tensor_type = TensorTypeHandle(self._backend.get_value_type(value.value))
+            self._value_types[value.value] = tensor_type
+        return tensor_type
 
     def append_program_unit_marker(
         self,
@@ -163,7 +249,10 @@ class WhirlBuilder:
         value_kind: str,
         value: str,
     ) -> ValueHandle:
-        return ValueHandle(
+        tensor_type = self.tensor_type(
+            f"{name}_type", dtype, rank, logical_shape
+        )
+        value_handle = ValueHandle(
             self._backend.create_tensor_constant(
                 name,
                 dtype,
@@ -173,6 +262,8 @@ class WhirlBuilder:
                 value,
             )
         )
+        self._value_types[value_handle.value] = tensor_type
+        return value_handle
 
     def model_input(
         self,
@@ -204,7 +295,9 @@ class WhirlBuilder:
                 common.MODEL_INPUT,
                 operator_version(common.MODEL_INPUT),
             )
-        return ValueHandle(handle)
+        value = ValueHandle(handle)
+        self._value_types[value.value] = tensor_type
+        return value
 
     def external_tensor_constant(
         self,
@@ -246,12 +339,6 @@ class WhirlBuilder:
         ):
             raise ValueError("external tensor checksum must be 64 hex characters")
 
-        tensor_type = self.tensor_type(
-            f"{name}_type",
-            dtype,
-            rank,
-            logical_shape,
-        )
         descriptor = {
             "kind": "tensor",
             "dtype": dtype,
@@ -263,11 +350,14 @@ class WhirlBuilder:
             "placement": "side_file",
             "memory": "external_data",
             "quantization": "none",
-            "runtime_state": "static",
-            "lineage": name,
         }
-        self.attach_tensor_descriptor(tensor_type, descriptor)
-        symbol = self.symbol(name, tensor_type)
+        tensor_type = self.tensor_type(
+            f"{name}_type",
+            dtype,
+            rank,
+            logical_shape,
+            descriptor,
+        )
         metadata = {
             "source_layer_name": name,
             "lowering_hint": "external_tensor_constant",
@@ -282,8 +372,6 @@ class WhirlBuilder:
             "storage_byte_length": str(byte_length),
             "storage_checksum": checksum,
         }
-        self.attach_symbol_metadata(symbol, metadata)
-
         create_external = getattr(
             self._backend,
             "create_external_tensor_constant",
@@ -319,10 +407,14 @@ class WhirlBuilder:
                 "external_data",
             )
         value = ValueHandle(value_handle)
+        self._value_types[value.value] = tensor_type
+        self.attach_value_metadata(value, metadata)
+        self.attach_value_lineage(value, name)
+        symbol = int(self._backend.get_value_result_symbol(value.value))
         return TensorConstantHandle(
             value.value,
             tensor_type.value,
-            symbol.value,
+            symbol,
             metadata,
             descriptor,
         )
@@ -377,19 +469,39 @@ class WhirlBuilder:
         version: int,
         kids: Sequence[ValueHandle],
         attrs: Mapping[str, str],
+        result_name: Optional[str] = None,
+        result_type: Optional[TensorTypeHandle] = None,
     ) -> OperatorHandle:
+        if not kids:
+            raise ValueError("DSL operator requires at least one operand")
+        create_with_result = getattr(
+            self._backend, "create_operator_with_result", None
+        )
+        if create_with_result is None:
+            raise self._operator_capability_error(opcode_name, version)
+        if result_name is None:
+            result_name = self._next_result_name(opcode_name)
+        if result_type is None:
+            result_type = self._infer_result_type(
+                result_name, opcode_name, kids, attrs
+            )
         try:
-            handle = self._backend.create_operator(
+            handle = create_with_result(
                 opcode_name,
                 version,
                 [kid.value for kid in kids],
                 attrs,
+                result_name,
+                result_type.value,
             )
         except RuntimeError as exc:
             raise self._operator_capability_error(opcode_name, version) from exc
         if handle <= 0:
             raise self._operator_capability_error(opcode_name, version)
-        return OperatorHandle(handle)
+        result = OperatorHandle(handle)
+        self._value_types[result.value] = result_type
+        self.attach_value_lineage(result, opcode_name)
+        return result
 
     def _operator_capability_error(
         self,
@@ -400,6 +512,109 @@ class WhirlBuilder:
             f"{self.backend_name()} backend does not support "
             f"{opcode_name}.v{version}"
         )
+
+    def _next_result_name(self, opcode_name: str) -> str:
+        ordinal = _RESULT_ORDINALS.get(self._backend_key, 0) + 1
+        _RESULT_ORDINALS[self._backend_key] = ordinal
+        return f"{opcode_name.replace('.', '_')}_{ordinal}"
+
+    def _infer_result_type(
+        self,
+        result_name: str,
+        opcode_name: str,
+        kids: Sequence[ValueHandle],
+        attrs: Mapping[str, str],
+    ) -> TensorTypeHandle:
+        input_type = self._value_types.get(kids[0].value)
+        if input_type is None:
+            raise RuntimeError("operator operand has no registered tensor type")
+        descriptor = dict(self._type_descriptors[input_type.value])
+        shape = self._parse_shape(str(descriptor["logical_shape"]))
+
+        if opcode_name == "common.matmul" and len(kids) > 1:
+            rhs_type = self._value_types[kids[1].value]
+            rhs_shape = self._parse_shape(
+                str(self._type_descriptors[rhs_type.value]["logical_shape"])
+            )
+            shape = (shape[0], rhs_shape[1])
+        elif opcode_name == "common.flatten":
+            start = int(attrs.get("attr.start_dim", "1"))
+            end = int(attrs.get("attr.end_dim", "-1"))
+            if end < 0:
+                end += len(shape)
+            flattened = 1
+            for dimension in shape[start:end + 1]:
+                flattened *= dimension
+            shape = shape[:start] + (flattened,) + shape[end + 1:]
+        elif opcode_name in {"cnn.conv2d", "cnn.max_pool2d"}:
+            if len(shape) != 4:
+                return input_type
+            kernel = self._parse_pair(attrs["attr.kernel_shape"])
+            stride = self._parse_pair(attrs["attr.stride"])
+            padding = self._parse_pair(attrs["attr.padding"])
+            dilation = self._parse_pair(attrs["attr.dilation"])
+            channels = shape[1]
+            if opcode_name == "cnn.conv2d":
+                weight_type = self._value_types[kids[1].value]
+                weight_shape = self._parse_shape(
+                    str(self._type_descriptors[weight_type.value]["logical_shape"])
+                )
+                channels = weight_shape[0]
+                kernel = (weight_shape[2], weight_shape[3])
+            shape = (
+                shape[0],
+                channels,
+                self._conv_dim(shape[2], kernel[0], stride[0],
+                               padding[0], dilation[0]),
+                self._conv_dim(shape[3], kernel[1], stride[1],
+                               padding[1], dilation[1]),
+            )
+        elif opcode_name == "cnn.global_avg_pool2d":
+            if len(shape) != 4:
+                return input_type
+            output = self._parse_pair(attrs.get("attr.output_size", "1,1"))
+            shape = (shape[0], shape[1], output[0], output[1])
+        elif opcode_name == "common.linear" and len(kids) > 1:
+            weight_type = self._value_types[kids[1].value]
+            weight_shape = self._parse_shape(
+                str(self._type_descriptors[weight_type.value]["logical_shape"])
+            )
+            shape = (shape[0], weight_shape[0])
+
+        descriptor["rank"] = len(shape)
+        descriptor["logical_shape"] = self._format_shape(shape)
+        return self.tensor_type(
+            f"{result_name}_type",
+            str(descriptor["dtype"]),
+            len(shape),
+            str(descriptor["logical_shape"]),
+            descriptor,
+        )
+
+    @staticmethod
+    def _parse_shape(shape: str) -> tuple[int, ...]:
+        body = shape.strip()[1:-1]
+        return tuple(int(value) for value in body.split(",")) if body else ()
+
+    @staticmethod
+    def _format_shape(shape: Sequence[int]) -> str:
+        return "[" + ",".join(str(value) for value in shape) + "]"
+
+    @staticmethod
+    def _parse_pair(value: str) -> tuple[int, int]:
+        parts = tuple(int(item) for item in value.split(","))
+        return (parts[0], parts[0]) if len(parts) == 1 else (parts[0], parts[1])
+
+    @staticmethod
+    def _conv_dim(
+        value: int,
+        kernel: int,
+        stride: int,
+        padding: int,
+        dilation: int,
+    ) -> int:
+        return ((value + 2 * padding - dilation * (kernel - 1) - 1)
+                // stride + 1)
 
     def common_add(
         self,

--- a/osprey/torch2whirl/python/open64_dsc/cli.py
+++ b/osprey/torch2whirl/python/open64_dsc/cli.py
@@ -61,7 +61,12 @@ def _load_python_module(path: Path) -> ModuleType:
         raise ImportError(f"failed to load model file: {path}")
 
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(module_name, None)
+        raise
     return module
 
 

--- a/osprey/torch2whirl/python/open64_dsc/export.py
+++ b/osprey/torch2whirl/python/open64_dsc/export.py
@@ -36,6 +36,14 @@ def save_as_whirl(module: WhirlModule, path: str) -> None:
     temp_path: Optional[Path] = None
     backend = load_backend(module.options.backend)
     try:
+        verify_program = getattr(backend, "verify_program", None)
+        if verify_program is not None:
+            native_result = verify_program()
+            if not bool(native_result.get("valid", False)):
+                diagnostic = str(native_result.get("diagnostic", ""))
+                raise RuntimeError(
+                    diagnostic or "native DSL program verification failed"
+                )
         output_dir.mkdir(parents=True, exist_ok=True)
         with tempfile.NamedTemporaryFile(
             prefix=f".{output_path.name}.",
@@ -50,6 +58,9 @@ def save_as_whirl(module: WhirlModule, path: str) -> None:
         os.replace(temp_path, output_path)
         temp_path = None
     except Exception:
+        abort_program = getattr(backend, "abort_program", None)
+        if abort_program is not None:
+            abort_program()
         raise
     finally:
         if temp_path is not None:

--- a/osprey/torch2whirl/python/open64_dsc/interpreter.py
+++ b/osprey/torch2whirl/python/open64_dsc/interpreter.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import hashlib
+import inspect
+import os
 import operator
+import traceback
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
-from .builder import ValueHandle, WhirlBuilder, load_builder
+from .builder import ProgramUnitHandle, ValueHandle, WhirlBuilder, load_builder
 from .mapping import cnn, common
 from .mapping.contract import operator_arity
 from .module import (
@@ -45,6 +48,22 @@ class WhirlExportInterpreter:
         return self._builder
 
     def export(self, model: Any, example_inputs: Iterable[Any]) -> WhirlModule:
+        builder = self.builder()
+        builder.begin_program()
+        try:
+            module = self._export_program(model, example_inputs)
+            self._bind_model_source_positions(model, module)
+            builder.verify_program()
+            return module
+        except Exception:
+            builder.abort_program()
+            raise
+
+    def _export_program(
+        self,
+        model: Any,
+        example_inputs: Iterable[Any],
+    ) -> WhirlModule:
         inputs = list(example_inputs)
         model_name = self._model_name(model)
         entry_pu = self.builder().minimal_program_unit(self._options.entry)
@@ -108,6 +127,42 @@ class WhirlExportInterpreter:
             tensor_payloads=tensor_payloads,
             graph_operators=graph_operators,
         )
+
+    def _bind_model_source_positions(
+        self,
+        model: Any,
+        module: WhirlModule,
+    ) -> None:
+        try:
+            path = inspect.getsourcefile(type(model))
+            line = inspect.getsourcelines(type(model))[1]
+        except (OSError, TypeError):
+            return
+        if not path:
+            return
+        program_unit = ProgramUnitHandle(module.entry_function.handle)
+        file_id = self.builder().register_source_file(program_unit, path)
+        handles = [value.handle for value in module.values]
+        if module.graph_source != "torch.fx":
+            handles.extend(operator.handle for operator in module.graph_operators)
+        for handle in handles:
+            self.builder().set_value_source_position(
+                ValueHandle(handle), file_id, line
+            )
+
+    def _bind_fx_source_position(
+        self,
+        program_unit: ProgramUnitHandle,
+        node: Any,
+        value: ValueHandle,
+    ) -> None:
+        metadata = getattr(node, "meta", {})
+        path = metadata.get("open64_source_path")
+        line = metadata.get("open64_source_line")
+        if not isinstance(path, str) or not isinstance(line, int) or line <= 0:
+            return
+        file_id = self.builder().register_source_file(program_unit, path)
+        self.builder().set_value_source_position(value, file_id, line)
 
     def _emit_captured_graph(
         self,
@@ -197,6 +252,7 @@ class WhirlExportInterpreter:
             )
             env[id(node)] = _GraphValue(handle, operator_plan.name)
             self.builder().append_program_unit_value(entry_pu, handle)
+            self._bind_fx_source_position(entry_pu, node, handle)
             operators.append(operator_plan.name)
             body_markers.append(operator_plan.name)
             graph_operators.append(
@@ -223,6 +279,7 @@ class WhirlExportInterpreter:
             {"attr.semantic": "logits"},
         )
         self.builder().append_program_unit_value(entry_pu, handle)
+        self._bind_fx_source_position(entry_pu, output_source_node, handle)
         operators.append(common.OUTPUT_LOGITS)
         body_markers.append(common.OUTPUT_LOGITS)
         graph_operators.append(
@@ -643,81 +700,64 @@ class WhirlExportInterpreter:
                 if value.name == name:
                     return _GraphValue(ValueHandle(value.handle), value.name)
 
-        if target.endswith(".bias") and (role or self._parameter_role(target)) == "bias":
+        parameter_role = role or self._parameter_role(target)
+        dtype = "float32"
+        rank = 0
+        logical_shape = "[]"
+        value_kind = "absent_parameter"
+        value_text = "none"
+        if target.endswith(".bias") and parameter_role == "bias":
             weight_target = target[:-4] + "weight"
             weight = self._resolve_attr(traced_module, weight_target)
             if weight is not None:
                 shape = self._input_shape(weight)
                 if shape:
                     dtype = self._input_dtype(weight)
+                    rank = 1
                     logical_shape = self._format_shape((shape[0],))
-                    tensor_type_name = f"{name}_type"
-                    descriptor = {
-                        "kind": "tensor",
-                        "dtype": dtype,
-                        "rank": 1,
-                        "logical_shape": logical_shape,
-                        "traits": role or self._parameter_role(target),
-                        "layout": "C",
-                        "sharding": "replicated",
-                        "placement": "inline_constant",
-                        "memory": "static",
-                        "quantization": "none",
-                        "runtime_state": "static",
-                        "lineage": name,
-                    }
-                    handle = self.builder().tensor_constant(
-                        name,
-                        dtype,
-                        1,
-                        logical_shape,
-                        "implicit_zero",
-                        "0",
-                    )
-                    tensor_types.append(
-                        WhirlTensorTypeRecord(
-                            name=tensor_type_name,
-                            handle=handle.value,
-                            dtype=dtype,
-                            rank=1,
-                            logical_shape=logical_shape,
-                            descriptor=descriptor,
-                        )
-                    )
-                    values.append(
-                        WhirlValueRecord(
-                            name=name,
-                            handle=handle.value,
-                            type_name=tensor_type_name,
-                            value_kind="implicit_zero",
-                            metadata={
-                                "source_layer_name": name,
-                                "lowering_hint": "module_parameter_absent",
-                                "tensor_role": role or self._parameter_role(target),
-                                "storage_shape": logical_shape,
-                            },
-                        )
-                    )
-                    return _GraphValue(handle, name)
+                    value_kind = "implicit_zero"
+                    value_text = "0"
 
         handle = self.builder().tensor_constant(
             name,
-            "float32",
-            0,
-            "[]",
-            "absent_parameter",
-            "none",
+            dtype,
+            rank,
+            logical_shape,
+            value_kind,
+            value_text,
+        )
+        type_name = f"{name}_type"
+        tensor_type = self.builder().value_type(handle)
+        descriptor = {
+            "kind": "tensor",
+            "dtype": dtype,
+            "rank": rank,
+            "logical_shape": logical_shape,
+        }
+        tensor_types.append(
+            WhirlTensorTypeRecord(
+                name=type_name,
+                handle=tensor_type.value,
+                dtype=dtype,
+                rank=rank,
+                logical_shape=logical_shape,
+                descriptor=descriptor,
+            )
         )
         values.append(
             WhirlValueRecord(
                 name=name,
                 handle=handle.value,
-                type_name="",
-                value_kind="absent_parameter",
+                type_name=type_name,
+                value_kind=value_kind,
                 metadata={
                     "source_layer_name": name,
-                    "lowering_hint": "module_parameter_absent",
-                    "tensor_role": role or self._parameter_role(target),
+                    "lowering_hint": (
+                        "implicit_zero_parameter"
+                        if value_kind == "implicit_zero"
+                        else "module_parameter_absent"
+                    ),
+                    "tensor_role": parameter_role,
                 },
             )
         )
@@ -896,16 +936,34 @@ class WhirlExportInterpreter:
 
     def _capture_fx_graph(self, model: Any) -> Optional[Tuple[Any, Any]]:
         try:
-            from torch.fx import symbolic_trace
+            from torch.fx import GraphModule, Tracer
         except ImportError:
             return None
 
         try:
-            traced = symbolic_trace(model)
+            source_path = inspect.getsourcefile(type(model))
+        except (OSError, TypeError):
+            source_path = None
+        source_path = os.path.realpath(source_path) if source_path else None
+
+        class _SourcePositionTracer(Tracer):
+            def create_proxy(self, *args: Any, **kwargs: Any) -> Any:
+                frames = traceback.extract_stack()
+                proxy = super().create_proxy(*args, **kwargs)
+                if source_path is None:
+                    return proxy
+                for frame in reversed(frames):
+                    if os.path.realpath(frame.filename) == source_path:
+                        proxy.node.meta["open64_source_path"] = source_path
+                        proxy.node.meta["open64_source_line"] = frame.lineno
+                        break
+                return proxy
+
+        try:
+            tracer = _SourcePositionTracer()
+            graph = tracer.trace(model)
+            traced = GraphModule(model, graph)
         except Exception:
-            return None
-        graph = getattr(traced, "graph", None)
-        if graph is None:
             return None
         return graph, traced
 
@@ -1237,12 +1295,6 @@ class WhirlExportInterpreter:
             dtype = self._input_dtype(example)
             shape = self._input_shape(example)
             logical_shape = self._format_shape(shape)
-            tensor_type = self.builder().tensor_type(
-                type_name,
-                dtype,
-                len(shape),
-                logical_shape,
-            )
             descriptor = {
                 "kind": "tensor",
                 "dtype": dtype,
@@ -1254,23 +1306,24 @@ class WhirlExportInterpreter:
                 "placement": "host",
                 "memory": "dense",
                 "quantization": "none",
-                "runtime_state": "static",
-                "lineage": name,
             }
-            self.builder().attach_tensor_descriptor(tensor_type, descriptor)
-            value = self.builder().model_input(
-                name,
-                tensor_type,
-                ordinal,
+            tensor_type = self.builder().tensor_type(
+                type_name,
+                dtype,
+                len(shape),
+                logical_shape,
+                descriptor,
             )
-            symbol = self.builder().symbol(name, tensor_type)
+            value = self.builder().model_input(name, tensor_type, ordinal)
+            symbol = self.builder().value_result_symbol(value)
             metadata = {
                 "source_layer_name": name,
                 "lowering_hint": "model_input",
                 "logical_shape": logical_shape,
                 "input_ordinal": str(ordinal),
             }
-            self.builder().attach_symbol_metadata(symbol, metadata)
+            self.builder().attach_value_metadata(value, metadata)
+            self.builder().attach_value_lineage(value, name)
 
             tensor_types.append(
                 WhirlTensorTypeRecord(

--- a/osprey/torch2whirl/python/open64_dsc/interpreter.py
+++ b/osprey/torch2whirl/python/open64_dsc/interpreter.py
@@ -758,6 +758,7 @@ class WhirlExportInterpreter:
                         else "module_parameter_absent"
                     ),
                     "tensor_role": parameter_role,
+                    "storage_shape": logical_shape,
                 },
             )
         )

--- a/osprey/torch2whirl/python/tests/driver_native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/driver_native_ir_tools_smoke.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
@@ -152,7 +153,7 @@ def _check_invalid_graph_rejected(driver: Path, tmpdir: Path) -> int:
         print("driver accepted verifier-invalid add graph", file=sys.stderr)
         return 1
     error_text = completed.stdout + completed.stderr
-    if "shape" not in error_text:
+    if "shape" not in error_text and "incompatible" not in error_text:
         print(
             "driver rejection did not report verifier shape context:",
             file=sys.stderr,
@@ -167,7 +168,7 @@ def _check_invalid_graph_rejected(driver: Path, tmpdir: Path) -> int:
 
 def _inspect_artifact(ir_b2a: Path, artifact: Path, text_dump: Path) -> int:
     result = subprocess.run(
-        [str(ir_b2a), "-st", str(artifact), str(text_dump)],
+        [str(ir_b2a), "-st", "-src", str(artifact), str(text_dump)],
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -198,19 +199,70 @@ def _inspect_artifact(ir_b2a: Path, artifact: Path, text_dump: Path) -> int:
         "attr.semantic=logits",
         "value=safetensors://driver_native_model.safetensors#conv1.weight",
         "value_kind=implicit_zero",
+        "source files:",
+        "model.py",
         "Symbols:",
         "Types:",
     ]
     missing = [needle for needle in required if needle not in text]
     if missing:
         print(
-            "driver ir_b2a -st output missed expected text: " +
+            "driver ir_b2a -st -src output missed expected text: " +
             ", ".join(missing),
             file=sys.stderr,
         )
         print(text, file=sys.stderr)
         return 1
 
+    sourced_statement = re.search(
+        r"MSTID.*\{line: [1-9][0-9]*/[1-9][0-9]*\}", text
+    )
+    if sourced_statement is None:
+        print(
+            "driver ir_b2a -st -src output has no sourced DSL result statement",
+            file=sys.stderr,
+        )
+        print(text, file=sys.stderr)
+        return 1
+
+    return 0
+
+
+def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    model_path = work_dir / "model.py"
+    artifact = work_dir / "driver_native_model.B"
+    text_dump = work_dir / "driver_native_model.T"
+    side_file = work_dir / "driver_native_model.safetensors"
+    invalid_model = work_dir / "invalid_model.py"
+    invalid_artifact = work_dir / "invalid_model.B"
+    for path in (
+        model_path,
+        artifact,
+        text_dump,
+        side_file,
+        invalid_model,
+        invalid_artifact,
+    ):
+        if path.exists():
+            path.unlink()
+    _write_resnet_model(model_path)
+
+    driver_status = _run_valid_driver(driver, model_path, artifact)
+    if driver_status != 0:
+        return driver_status
+    if not artifact.exists() or artifact.stat().st_size == 0:
+        print("driver native WHIRL artifact was not created", file=sys.stderr)
+        return 1
+
+    inspect_status = _inspect_artifact(ir_b2a, artifact, text_dump)
+    if inspect_status != 0:
+        return inspect_status
+    invalid_status = _check_invalid_graph_rejected(driver, work_dir)
+    if invalid_status != 0:
+        return invalid_status
+
+    print(f"retained driver artifacts: {work_dir}")
     return 0
 
 
@@ -221,39 +273,16 @@ def main() -> int:
     _require_torch()
     driver = _find_driver()
 
-    with tempfile.TemporaryDirectory(prefix="torch2whirl-driver-native-") as tmp:
-        tmpdir = Path(tmp)
-        model_path = tmpdir / "model.py"
-        artifact = tmpdir / "driver_native_model.B"
-        text_dump = tmpdir / "driver_native_model.st.ir"
-        _write_resnet_model(model_path)
-
-        driver_status = _run_valid_driver(driver, model_path, artifact)
-        if driver_status != 0:
-            completed = _run_driver(
-                driver,
-                model_path,
-                artifact,
-                ("shape:1,3,64,64",),
-            )
-            error_text = completed.stdout + completed.stderr
-            if "does not support" in error_text:
-                print(
-                    "skip: native backend capability missing: " +
-                    error_text.strip()
-                )
-                return 0
-            return driver_status
-        if not artifact.exists() or artifact.stat().st_size == 0:
-            print("driver native WHIRL artifact was not created", file=sys.stderr)
-            return 1
-
-        inspect_status = _inspect_artifact(ir_b2a, artifact, text_dump)
-        if inspect_status != 0:
-            return inspect_status
-        invalid_status = _check_invalid_graph_rejected(driver, tmpdir)
-        if invalid_status != 0:
-            return invalid_status
+    artifact_dir = os.environ.get("OPEN64_DSL_TEST_ARTIFACT_DIR", "")
+    if artifact_dir:
+        status = _run_smoke(ir_b2a, driver, Path(artifact_dir))
+    else:
+        with tempfile.TemporaryDirectory(
+            prefix="torch2whirl-driver-native-"
+        ) as tmp:
+            status = _run_smoke(ir_b2a, driver, Path(tmp))
+    if status != 0:
+        return status
 
     print("driver native ir_b2a smoke passed")
     return 0

--- a/osprey/torch2whirl/python/tests/native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/native_ir_tools_smoke.py
@@ -23,6 +23,10 @@ class DummyModel:
     pass
 
 
+class InputTensor:
+    shape = (1, 1, 4, 4)
+
+
 def _append_operator_probes(module) -> None:
     builder = load_builder("native")
     lhs = ValueHandle(module.values[0].handle)
@@ -69,6 +73,9 @@ def _append_operator_probes(module) -> None:
     )
     matmul = builder.common_matmul(matmul_lhs, matmul_rhs)
     residual_add = builder.common_residual_add(lhs, rhs)
+    linear_input = builder.tensor_constant(
+        "linear_input", "float32", 2, "[1,1]", "splat", "1.0"
+    )
     linear_weight = builder.external_tensor_constant(
         "linear_weight",
         "float32",
@@ -136,9 +143,9 @@ def _append_operator_probes(module) -> None:
         conv_weight,
         conv_bias,
         {
-            "attr.kernel_shape": "3,3",
+            "attr.kernel_shape": "1,1",
             "attr.stride": "1,1",
-            "attr.padding": "1,1",
+            "attr.padding": "0,0",
             "attr.dilation": "1,1",
             "attr.groups": "1",
             "attr.input_layout": "NCHW",
@@ -287,80 +294,123 @@ def _find_ir_b2a() -> Optional[Path]:
     return None
 
 
+def _run_smoke(ir_b2a: Path, work_dir: Path) -> int:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    artifact = work_dir / "python_native_model.B"
+    text_dump = work_dir / "python_native_model.T"
+    side_file = work_dir / "python_native_model.safetensors"
+    for path in (artifact, text_dump, side_file):
+        if path.exists():
+            path.unlink()
+
+    module = export_to_whirl(
+        DummyModel(),
+        [InputTensor(), InputTensor()],
+        WhirlExportOptions(backend="native", model_name="python_native"),
+    )
+    _append_operator_probes(module)
+    save_as_whirl(module, str(artifact))
+    if not artifact.exists() or artifact.stat().st_size == 0:
+        print("native Python WHIRL artifact was not created", file=sys.stderr)
+        return 1
+
+    result = subprocess.run(
+        [str(ir_b2a), "-st", "-src", str(artifact), str(text_dump)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(result.stdout, file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        return result.returncode
+
+    text = text_dump.read_text(encoding="utf-8", errors="replace")
+    required = [
+        "FUNC_ENTRY",
+        "common.tensor_const",
+        "common.add",
+        "common.matmul",
+        "common.residual_add",
+        "common.linear",
+        "common.relu",
+        "common.flatten",
+        "common.output_logits",
+        "cnn.max_pool2d",
+        "cnn.global_avg_pool2d",
+        "cnn.conv2d",
+        "cnn.batch_norm_infer",
+        "attr.broadcast_rule=none",
+        "attr.start_dim=1",
+        "attr.transpose_kid0=false",
+        "attr.transpose_kid1=false",
+        "attr.shape_check=exact",
+        "attr.has_bias=true",
+        "attr.weight_layout=OI",
+        "value_kind=external_data",
+        "safetensors://resnet.safetensors",
+        "attr.kernel_shape=3,3",
+        "attr.output_size=1,1",
+        "attr.groups=1",
+        "attr.weight_layout=OIHW",
+        "attr.epsilon=1e-05",
+        "attr.training=false",
+        "Symbols:",
+        "Types:",
+        "DSL IR Image: version=1",
+        "DSL Opcode Descriptor Table:",
+        "DSL Node Table:",
+        "DSL Attribute Table:",
+        "DSL Value Table:",
+        "DSL Value Reference Table:",
+        "operator=OPR_DSLADD stable_name=common.add version=1",
+        "name=attr.broadcast_rule kind=string value=none",
+        "ordinal=kid0",
+        "kind=constant",
+        "tensor_descriptor={kind=tensor",
+        "no_alias=true",
+        "source files:",
+        "native_ir_tools_smoke.py",
+    ]
+    missing = [needle for needle in required if needle not in text]
+    if missing:
+        print(
+            "ir_b2a -st -src output missed expected text: " +
+            ", ".join(missing),
+            file=sys.stderr,
+        )
+        print(text, file=sys.stderr)
+        return 1
+
+    forbidden = ["OPR_DSL ", "MDSL ", "OPC_MDSL"]
+    exposed = [needle for needle in forbidden if needle in text]
+    if exposed:
+        print(
+            "ir_b2a exposed physical DSL storage text: " +
+            ", ".join(exposed),
+            file=sys.stderr,
+        )
+        print(text, file=sys.stderr)
+        return 1
+
+    print(f"retained native artifacts: {work_dir}")
+    return 0
+
+
 def main() -> int:
     ir_b2a = _find_ir_b2a()
     if ir_b2a is None:
         return 0
 
-    with tempfile.TemporaryDirectory() as work_dir_text:
-        work_dir = Path(work_dir_text)
-        artifact = work_dir / "python_native_model.B"
-        text_dump = work_dir / "python_native_model.st.ir"
-
-        module = export_to_whirl(
-            DummyModel(),
-            [object(), object()],
-            WhirlExportOptions(backend="native", model_name="python_native"),
-        )
-        _append_operator_probes(module)
-        save_as_whirl(module, str(artifact))
-        if not artifact.exists() or artifact.stat().st_size == 0:
-            print("native Python WHIRL artifact was not created", file=sys.stderr)
-            return 1
-
-        result = subprocess.run(
-            [str(ir_b2a), "-st", str(artifact), str(text_dump)],
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=False,
-        )
-        if result.returncode != 0:
-            print(result.stdout, file=sys.stderr)
-            print(result.stderr, file=sys.stderr)
-            return result.returncode
-
-        text = text_dump.read_text(encoding="utf-8", errors="replace")
-        required = [
-            "FUNC_ENTRY",
-            "common.tensor_const",
-            "common.add",
-            "common.matmul",
-            "common.residual_add",
-            "common.linear",
-            "common.relu",
-            "common.flatten",
-            "common.output_logits",
-            "cnn.max_pool2d",
-            "cnn.global_avg_pool2d",
-            "cnn.conv2d",
-            "cnn.batch_norm_infer",
-            "attr.broadcast_rule=none",
-            "attr.start_dim=1",
-            "attr.transpose_kid0=false",
-            "attr.transpose_kid1=false",
-            "attr.shape_check=exact",
-            "attr.has_bias=true",
-            "attr.weight_layout=OI",
-            "value_kind=external_data",
-            "attr.kernel_shape=3,3",
-            "attr.output_size=1,1",
-            "attr.groups=1",
-            "attr.weight_layout=OIHW",
-            "attr.epsilon=1e-05",
-            "attr.training=false",
-            "Symbols:",
-            "Types:",
-        ]
-        missing = [needle for needle in required if needle not in text]
-        if missing:
-            print(
-                "ir_b2a -st output missed expected text: " +
-                ", ".join(missing),
-                file=sys.stderr,
-            )
-            print(text, file=sys.stderr)
-            return 1
+    artifact_dir = os.environ.get("OPEN64_DSL_TEST_ARTIFACT_DIR", "")
+    if artifact_dir:
+        status = _run_smoke(ir_b2a, Path(artifact_dir))
+    else:
+        with tempfile.TemporaryDirectory() as work_dir_text:
+            status = _run_smoke(ir_b2a, Path(work_dir_text))
+    if status != 0:
+        return status
 
     print("native Python ir_b2a smoke passed")
     return 0

--- a/osprey/torch2whirl/python/tests/native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/native_ir_tools_smoke.py
@@ -73,9 +73,6 @@ def _append_operator_probes(module) -> None:
     )
     matmul = builder.common_matmul(matmul_lhs, matmul_rhs)
     residual_add = builder.common_residual_add(lhs, rhs)
-    linear_input = builder.tensor_constant(
-        "linear_input", "float32", 2, "[1,1]", "splat", "1.0"
-    )
     linear_weight = builder.external_tensor_constant(
         "linear_weight",
         "float32",
@@ -143,7 +140,7 @@ def _append_operator_probes(module) -> None:
         conv_weight,
         conv_bias,
         {
-            "attr.kernel_shape": "1,1",
+            "attr.kernel_shape": "3,3",
             "attr.stride": "1,1",
             "attr.padding": "0,0",
             "attr.dilation": "1,1",

--- a/osprey/torch2whirl/python/tests/test_open64_dsc_fx_capture_optional.py
+++ b/osprey/torch2whirl/python/tests/test_open64_dsc_fx_capture_optional.py
@@ -146,9 +146,9 @@ class Open64DscFxCaptureOptionalTest(unittest.TestCase):
                 entry_body_marker.2=common.add
                 operator.0=common.add
                 tensor_type.0=input0_type:float32:[2,3]
-                tensor_descriptor.0=float32:2:[2,3]:input0
+                tensor_descriptor.0=float32:2:[2,3]:
                 tensor_type.1=input1_type:float32:[2,3]
-                tensor_descriptor.1=float32:2:[2,3]:input1
+                tensor_descriptor.1=float32:2:[2,3]:
                 value.0=input0:input0_type:model_input
                 value_metadata.0=input0:model_input
                 value.1=input1:input1_type:model_input
@@ -211,9 +211,9 @@ class Open64DscFxCaptureOptionalTest(unittest.TestCase):
                 entry_body_marker.2=common.matmul
                 operator.0=common.matmul
                 tensor_type.0=input0_type:float32:[2,3]
-                tensor_descriptor.0=float32:2:[2,3]:input0
+                tensor_descriptor.0=float32:2:[2,3]:
                 tensor_type.1=input1_type:float32:[3,4]
-                tensor_descriptor.1=float32:2:[3,4]:input1
+                tensor_descriptor.1=float32:2:[3,4]:
                 value.0=input0:input0_type:model_input
                 value_metadata.0=input0:model_input
                 value.1=input1:input1_type:model_input

--- a/osprey/torch2whirl/python/tests/test_open64_dsc_native_optional.py
+++ b/osprey/torch2whirl/python/tests/test_open64_dsc_native_optional.py
@@ -50,6 +50,9 @@ class Open64DscNativeOptionalTest(unittest.TestCase):
                 raise unittest.SkipTest(str(exc)) from exc
             raise
 
+    def setUp(self) -> None:
+        load_builder("native").begin_program()
+
     def test_native_backend_creates_opaque_tensor_and_operator_handles(self) -> None:
         builder = load_builder("native")
 
@@ -100,6 +103,30 @@ class Open64DscNativeOptionalTest(unittest.TestCase):
         self.assertGreater(lhs.value, 0)
         self.assertGreater(rhs.value, 0)
         self.assertGreater(add.value, 0)
+
+    def test_native_tensor_identity_excludes_runtime_state_and_lineage(self) -> None:
+        builder = load_builder("native")
+        descriptor = {
+            "kind": "tensor",
+            "dtype": "float32",
+            "rank": 2,
+            "logical_shape": "[1,4]",
+            "layout": "contiguous",
+            "runtime_state": "resident",
+            "lineage": "producer_a",
+        }
+        first = builder.tensor_type(
+            "canonical_a", "float32", 2, "[1,4]", descriptor
+        )
+        second = builder.tensor_type(
+            "canonical_b",
+            "float32",
+            2,
+            "[1,4]",
+            {**descriptor, "runtime_state": "evicted", "lineage": "producer_b"},
+        )
+
+        self.assertEqual(first.value, second.value)
 
     def test_native_backend_appends_add_marker(self) -> None:
         builder = load_builder("native")
@@ -547,6 +574,7 @@ class Open64DscNativeOptionalTest(unittest.TestCase):
             ["common.model_input", "common.model_input", "common.add"],
         )
         self.assertIn("name=input0", str(markers[-3]["payload"]))
+        self.assertIn("attr.input_ordinal=0", str(markers[-3]["payload"]))
         self.assertIn("kid0=input0", str(markers[-1]["payload"]))
 
         with tempfile.TemporaryDirectory() as work_dir:

--- a/osprey/torch2whirl/python/tests/test_open64_dsc_skeleton.py
+++ b/osprey/torch2whirl/python/tests/test_open64_dsc_skeleton.py
@@ -4,6 +4,7 @@ import contextlib
 import hashlib
 import io
 import importlib.util
+import inspect
 import json
 import struct
 import tempfile
@@ -1628,9 +1629,15 @@ class Open64DscSkeletonTest(unittest.TestCase):
             )
 
             model = _load_model(model_path, "create_model")
+            source_line = inspect.getsourcelines(type(model))[1]
 
         self.assertEqual(model.__class__.__name__, "UnitModel")
         self.assertTrue(model.eval_called)
+        self.assertEqual(
+            Path(inspect.getsourcefile(type(model))).resolve(),
+            model_path.resolve(),
+        )
+        self.assertEqual(source_line, 1)
 
     def test_cli_load_model_reports_missing_factory(self) -> None:
         with tempfile.TemporaryDirectory() as work_dir:
@@ -1742,6 +1749,48 @@ class Open64DscSkeletonTest(unittest.TestCase):
         self.assertIn("attr.kernel_shape=3,3", str(markers[7]["payload"]))
         self.assertEqual(markers[8]["opcode"], "cnn.global_avg_pool2d")
         self.assertIn("attr.output_size=1,1", str(markers[8]["payload"]))
+
+    def test_builder_lifecycle_canonical_types_and_structured_verify(self) -> None:
+        builder = load_builder("mock")
+        builder.begin_program()
+        pu = builder.minimal_program_unit("lifecycle_forward")
+        descriptor = {
+            "kind": "tensor",
+            "dtype": "float32",
+            "rank": 2,
+            "logical_shape": "[1,4]",
+            "layout": "contiguous",
+            "runtime_state": "resident",
+            "lineage": "input_a",
+        }
+        first_type = builder.tensor_type(
+            "input_a_type", "float32", 2, "[1,4]", descriptor
+        )
+        second_type = builder.tensor_type(
+            "input_b_type",
+            "float32",
+            2,
+            "[1,4]",
+            {**descriptor, "runtime_state": "evicted", "lineage": "input_b"},
+        )
+        self.assertEqual(first_type.value, second_type.value)
+
+        first = builder.model_input("input_a", first_type, 0)
+        second = builder.model_input("input_b", second_type, 1)
+        result = builder.common_add(first, second)
+        builder.attach_value_metadata(result, {"lowering_hint": "keep_vho"})
+        builder.attach_value_lineage(result, "synthetic_add")
+        file_id = builder.register_source_file(pu, "/tmp/model.py")
+        builder.set_value_source_position(result, file_id, 17, 3)
+        for value in (first, second, result):
+            builder.append_program_unit_value(pu, value)
+
+        verification = builder.verify_program()
+        self.assertTrue(verification["valid"])
+        self.assertEqual(verification["native_node_count"], 3)
+        builder.abort_program()
+        with self.assertRaisesRegex(RuntimeError, "no program unit"):
+            builder.verify_program()
 
     def test_mock_backend_creates_cnn_conv2d_marker(self) -> None:
         builder = load_builder("mock")
@@ -2088,7 +2137,7 @@ class Open64DscSkeletonTest(unittest.TestCase):
         self.assertIn("input_count=2", text)
         self.assertIn("operator.0=common.add", text)
         self.assertIn("tensor_type.0=input0_type:float32:[]", text)
-        self.assertIn("tensor_descriptor.0=float32:0:[]:input0", text)
+        self.assertIn("tensor_descriptor.0=float32:0:[]:", text)
         self.assertIn("value.0=input0:input0_type:model_input", text)
         self.assertIn("value_metadata.0=input0:model_input", text)
         self.assertIn("graph_operator.0=common.add:input0,input1", text)

--- a/osprey/torch2whirl/scripts/run_torch_docker_test.sh
+++ b/osprey/torch2whirl/scripts/run_torch_docker_test.sh
@@ -13,8 +13,12 @@ torch_image=${OPEN64_TORCH2WHIRL_TORCH_IMAGE:-open64:torch2whirl-torch-test}
 torch_version=${OPEN64_TORCH2WHIRL_TORCH_VERSION:-2.4.1}
 docker_buildkit=${OPEN64_TORCH2WHIRL_DOCKER_BUILDKIT:-0}
 rebuild_image=${OPEN64_TORCH2WHIRL_REBUILD_IMAGE:-0}
+run_ir_tools=${OPEN64_TORCH2WHIRL_RUN_IR_TOOLS:-1}
+artifact_dir=${OPEN64_TORCH2WHIRL_ARTIFACT_DIR:-$build_dir/test-artifacts}
 
 mkdir -p "$build_dir"
+mkdir -p "$artifact_dir"
+find "$artifact_dir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 
 if [ "$rebuild_image" = 1 ] ||
         ! docker image inspect "$torch_image" >/dev/null 2>&1; then
@@ -31,6 +35,7 @@ fi
 docker run --rm \
     -v "$src_root:/src" \
     -v "$build_dir:/build" \
+    -v "$artifact_dir:/artifacts" \
     -w /build \
     "$torch_image" \
     /src/configure --enable-torch2whirl-only
@@ -38,6 +43,7 @@ docker run --rm \
 docker run --rm \
     -v "$src_root:/src" \
     -v "$build_dir:/build" \
+    -v "$artifact_dir:/artifacts" \
     -w /build/osprey/targdir/torch2whirl \
     "$torch_image" \
     make python_torch_test
@@ -45,6 +51,20 @@ docker run --rm \
 docker run --rm \
     -v "$src_root:/src" \
     -v "$build_dir:/build" \
+    -v "$artifact_dir:/artifacts" \
     -w /build/osprey/targdir/torch2whirl \
     "$torch_image" \
     make driver_torch_test
+
+if [ "$run_ir_tools" = 1 ]; then
+    docker run --rm \
+        -v "$src_root:/src" \
+        -v "$build_dir:/build" \
+        -v "$artifact_dir:/artifacts" \
+        -w /build/osprey/targdir/torch2whirl \
+        "$torch_image" \
+        make OPEN64_DSL_TEST_ARTIFACT_DIR=/artifacts \
+            python_native_ir_tools_smoke driver_native_ir_tools_smoke
+fi
+
+echo "retained test artifacts: $artifact_dir"


### PR DESCRIPTION
## Summary

- migrate torch2whirl to the canonical Tensor TY and explicit-result DSL builder APIs
- preserve the ResNet operator coverage from the merged Python frontend while keeping Python-facing values opaque
- attach source file and source-position data to generated WHIRL statements
- distinguish opcode attributes, tensor lineage, and compiler metadata at the frontend boundary
- retain host-mounted `.B`, `.T`, source, and tensor payload artifacts for human review

## Integration details

- uses canonical tensor type interning and direct model-input/external-tensor construction
- uses builder begin/abort lifecycle handling and structured gatekeeper diagnostics
- keeps physical WN layout and `OPR_DSL` escape records private to common/com
- emits review traces with `ir_b2a -st -src`, using the `.B` basename for the `.T` output
- fixes merge-reconciliation defects found by the native gatekeeper: duplicate external-reference declaration, missing implicit-zero storage shape, an orphan probe value, and a mismatched convolution kernel shape

## Validation

- `make -C osprey/torch2whirl -f Makefile.gbase python_test`: 105 tests, 42 skipped, passed
- Linux/amd64 Docker FX/PyTorch lane: 29 tests passed
- native Python extension build passed
- native Python producer plus `ir_b2a -st -src` smoke passed
- standalone driver plus `ir_b2a -st -src` smoke passed
- retained artifacts under `/private/tmp/open64-torch2whirl-torch-test/test-artifacts`
- `git diff --check` and added-line no-tab scan passed

## Stack

Depends on #68, which depends on #67 and #66. Review and merge the stack from #66 upward.
