### PR TITLE
Add native DSL WHIRL infrastructure for Llama 2 prefill

### DIFF
--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1264,25 +1264,30 @@ full-sequence causal prompt evaluation with no KV cache.
    pass.  The post-lowering review trace is retained as
    `artifacts/item27/llama2_prefill_lowered.T`.
 
-28. [ ] Certify the tiny prefill artifact across the process boundary.
+28. [x] Certify the tiny prefill artifact across the process boundary.
 
    Prove builder construction, gatekeeper verification, mapped-image
    write/reopen, `ir_b2a -st -src`, source correlation, external tensors,
    region interfaces, stable rejection, and `openpy -keep` plus `-O0`
-   lowering.  Preserve `llama2.B`, `llama2.safetensors`, and `llama2.T` in a
-   host-mounted review directory.
+   lowering.  Preserve `llama2.B`, `llama2.safetensors`, the binary inspection
+   trace, and the post-lowering trace in a host-mounted review directory.
 
-   Native infrastructure preflight is complete on
+   Native infrastructure and full driver certification are complete on
    `codex/llama2-common-substrate`.  The reproducible
    `dsl_builder_contract_test` target and
    `dsl_llama2_prefill_process_test.sh` native mode prove builder
    construction, positive and stable negative gatekeeper cases, mapped-image
    write/reopen, `ir_b2a -st -src`, source positions, external tensor
    references, nested region interfaces, and private escape-tag hiding.
-   Review artifacts are retained under `artifacts/item28/`.  The item remains
-   open until the torch2whirl L2-L7 handoff supplies the real Python model and
-   SafeTensors payload, after which full mode must pass `openpy -keep -O0` and
-   preserve both the source-correlated and post-lowering traces.
+   Full mode consumes the real Python model through `openpy -keep -O0`,
+   preserves `llama2.B` and `llama2.safetensors`, and proves that
+   `VHO_DSL_Lower_Driver()` replaces all executable DSL carriers with the
+   published runtime ABI calls before canonical processing.  External tensor
+   constants precede the prefill REGION in PU order so first-use lowering is
+   deterministic.  Review artifacts are retained under `artifacts/item28/`;
+   `binary/llama2.T` is the `ir_b2a -st -src` view and
+   `lowered/llama2.t` is the post-VHO trace.  Separate subdirectories avoid
+   `.T`/`.t` collisions on case-insensitive filesystems.
 
 29. [ ] Design stateful decode and KV cache as a later versioned extension.
 

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1147,7 +1147,7 @@ full-sequence causal prompt evaluation with no KV cache.
    separate value in version 1.  Existing common schemas are not widened:
    bias-free linear, batched matmul, and sequence logits use additive versions.
 
-23. [ ] Implement the published common tensor substrate schemas.
+23. [x] Implement the published common tensor substrate schemas.
 
    Add native `common.reshape.v1`, `common.transpose.v1`, bias-free
    rank-generic `common.linear.v3`, exact-prefix batched `common.matmul.v2`, and
@@ -1155,7 +1155,21 @@ full-sequence causal prompt evaluation with no KV cache.
    version-1/version-2 behavior.  Add exact-version lookup, result inference,
    gatekeeper, mapped-image, logical printer, and malformed-schema tests.
 
-24. [ ] Implement transformer-domain prefill expressions.
+   Completed on `codex/llama2-common-substrate`.  Logical operator values 14
+   and 15 append reshape and transpose without changing released values.
+   Linear, matmul, and output-logits reuse their established logical operator
+   identities with exact additive schemas; old versions continue to use their
+   original operand, attribute, verification, and lowering contracts.  The
+   builder infers static result descriptors for reshape, transpose,
+   rank-generic bias-free linear, and exact-prefix batched matmul.  Focused
+   tests reject element-changing reshape, invalid permutations, version/schema
+   mismatch, missing attributes, and corrupted inferred result descriptors.
+   The mapped-image review artifacts are retained as
+   `artifacts/item23/llama2_common_substrate.B` and the corresponding
+   `ir_b2a -st -src` output
+   `artifacts/item23/llama2_common_substrate.T`.
+
+24. [x] Implement transformer-domain prefill expressions.
 
    Add native `transformer.token_embedding.v1`, `transformer.rms_norm.v1`,
    single-result `transformer.rotary_embedding.v1`, pure no-cache
@@ -1163,7 +1177,20 @@ full-sequence causal prompt evaluation with no KV cache.
    `transformer.swiglu.v1`.  Apply every dtype, shape, layout, mask, head,
    scale, and profile check published by item 22 before partial promotion.
 
-25. [ ] Implement transformer structured-region contracts.
+   Completed on `codex/llama2-common-substrate`.  Append-only logical values
+   16 through 20 implement the five published transformer expressions without
+   changing the physical WN escape representation.  The transformer domain
+   has an explicit native registration API.  Builder inference and the
+   authoritative gatekeeper enforce the static float32/int64 profile,
+   embedding bounds guard, RMS axis and positive epsilon, exact half-split
+   RoPE tables, BHSD causal full-sequence attention with equal query/KV heads
+   and no cache, and exact-shape SiLU gating.  Focused malformed-profile tests
+   cover every expression family.  Review artifacts are retained as
+   `artifacts/item24/llama2_transformer_expressions.B` and its corresponding
+   `ir_b2a -st -src` output
+   `artifacts/item24/llama2_transformer_expressions.T`.
+
+25. [x] Implement transformer structured-region contracts.
 
    Use the common RID/WT_REGIONS substrate for
    `transformer.decoder_layer.v1` and `transformer.prefill.v1`.  Declare
@@ -1171,7 +1198,19 @@ full-sequence causal prompt evaluation with no KV cache.
    context, verify topology and outer-owned no-alias results, and print stable
    logical region evidence after mapped-image reopen.
 
-26. [ ] Complete transformer artifact inspection and compatibility coverage.
+   Completed on `codex/llama2-common-substrate`.  The opaque builder now
+   appends managed child regions and records compiler-only region metadata in
+   reserved pragma-block comments, leaving the version-1 `WT_REGIONS` image
+   layout unchanged.  The common verifier enforces the published decoder
+   operator sequence, prefill nesting and tail, deterministic first-use input
+   interfaces, independent input/output ordinal spaces, nested source
+   positions, module path and layer ordinal context, and an outer-owned
+   no-alias final result.  `ir_b2a -st -src` prints stable logical contracts,
+   interfaces, and metadata after mapped-image reopen.  Review artifacts are
+   retained as `artifacts/item25/llama2_transformer_regions.B` and
+   `artifacts/item25/llama2_transformer_regions.T`.
+
+26. [x] Complete transformer artifact inspection and compatibility coverage.
 
    Carry every new logical opcode, node, attribute, descriptor, value
    reference, region contract, RID mapping, source position, and external
@@ -1179,12 +1218,51 @@ full-sequence causal prompt evaluation with no KV cache.
    `ir_b2a -st -src` without exposing the private physical DSL escape tag.
    Preserve old-image readability and existing ResNet behavior.
 
-27. [ ] Add verified Llama 2 prefill VHO DSL lowering.
+   Completed on `codex/llama2-common-substrate`.  The retained compatibility
+   fixture generates the item-23 common schemas, item-24 transformer
+   expressions, and item-25 structured prefill as independent binary WHIRL
+   images, reopens each through `ir_b2a -st -src`, and checks all logical
+   opcode, node, typed-attribute, tensor descriptor, value, value-reference,
+   RID mapping, source-position, and compiler-metadata evidence.  The
+   structured image now carries nine deterministic SafeTensors references;
+   computed embedding results preserve dtype, layout, and quantization without
+   inheriting side-file placement or external-data memory from their weights.
+   The same current reader reopens the retained pre-transformer item-23 image
+   with no synthetic REGION table and the retained simple ResNet contract
+   image with its model-input and residual-add semantics unchanged.  No trace
+   exposes the private physical `OPR_DSL` escape tag or `MDSL` encoding.
+   Review artifacts are retained under `artifacts/item26/`.
+
+27. [x] Add verified Llama 2 prefill VHO DSL lowering.
 
    Lower only after transformer gatekeeper success.  Preserve domain semantics
    until verification, then lower approved expressions to common substrate or
    the selected runtime ABI.  Consume every executable DSL value and splice
    managed regions before standard VHO, WOPT, LNO, or CG.
+
+   Completed on `codex/llama2-common-substrate`.  Exact gatekeeper-approved
+   schemas for `common.matmul.v2`, `common.linear.v3`,
+   `common.output_logits.v3`, `common.reshape.v1`, `common.transpose.v1`, and
+   the five transformer prefill expressions now select explicit version-1
+   runtime entry points.  Fixed policy encoded by the verified schema remains
+   implicit in that ABI; dynamic operands, tensor descriptors, permutations,
+   RMS epsilon/axis, attention head geometry, optional-bias absence, and the
+   token-logits semantic are passed explicitly where required.  Older ResNet
+   routes retain their established entry points and ABI values.
+
+   `VHO_DSL_Lower_Verified_Program_Unit()` now obtains operator policy by exact
+   logical version, consumes each native value into a unique pointer PREG,
+   retains the high-level `OPR_COMMENT` projection, and removes managed REGION
+   records before splicing their lowered bodies.  When the last managed region
+   is consumed, `WT_REGIONS` returns to `Subsect_Missing`; no stale WN mapping
+   remains for a removed `OPR_REGION`.
+
+   The executable lowering fixture proves gatekeeper-first handling for 21
+   prefill values, exact runtime call names and arities, the v3 linear null-bias
+   slot, token-logits semantic value, complete removal of executable DSL
+   carriers, and managed REGION cleanup.  The backend and native syntax matrix
+   pass.  The post-lowering review trace is retained as
+   `artifacts/item27/llama2_prefill_lowered.T`.
 
 28. [ ] Certify the tiny prefill artifact across the process boundary.
 
@@ -1193,6 +1271,18 @@ full-sequence causal prompt evaluation with no KV cache.
    region interfaces, stable rejection, and `openpy -keep` plus `-O0`
    lowering.  Preserve `llama2.B`, `llama2.safetensors`, and `llama2.T` in a
    host-mounted review directory.
+
+   Native infrastructure preflight is complete on
+   `codex/llama2-common-substrate`.  The reproducible
+   `dsl_builder_contract_test` target and
+   `dsl_llama2_prefill_process_test.sh` native mode prove builder
+   construction, positive and stable negative gatekeeper cases, mapped-image
+   write/reopen, `ir_b2a -st -src`, source positions, external tensor
+   references, nested region interfaces, and private escape-tag hiding.
+   Review artifacts are retained under `artifacts/item28/`.  The item remains
+   open until the torch2whirl L2-L7 handoff supplies the real Python model and
+   SafeTensors payload, after which full mode must pass `openpy -keep -O0` and
+   preserve both the source-correlated and post-lowering traces.
 
 29. [ ] Design stateful decode and KV cache as a later versioned extension.
 

--- a/osprey/be/vho/dsl_lower.cxx
+++ b/osprey/be/vho/dsl_lower.cxx
@@ -61,6 +61,13 @@ typedef struct {
     ST *runtime_batch_norm_infer;
     ST *runtime_max_pool2d;
     ST *runtime_global_avg_pool2d;
+    ST *runtime_reshape;
+    ST *runtime_transpose;
+    ST *runtime_token_embedding;
+    ST *runtime_rms_norm;
+    ST *runtime_rotary_embedding;
+    ST *runtime_attention;
+    ST *runtime_swiglu;
 } VHO_DSL_LOWER_CONTEXT;
 
 typedef struct {
@@ -208,6 +215,7 @@ VHO_DSL_Runtime_Layout (const char *name, UINT32 *value)
     if (name == NULL || name[0] == '\0')
         *value = OPEN64_DSL_LAYOUT_UNSPECIFIED;
     else if (strcmp(name, "contiguous") == 0 ||
+             strcmp(name, "row_major") == 0 ||
              strcmp(name, "NCHW") == 0 || strcmp(name, "OIHW") == 0 ||
              strcmp(name, "OI") == 0 || strcmp(name, "C") == 0)
         *value = OPEN64_DSL_LAYOUT_CONTIGUOUS;
@@ -722,6 +730,34 @@ VHO_DSL_Runtime_Function
         slot = &context->runtime_global_avg_pool2d;
         name = "__open64_dsl_global_avg_pool2d_v1";
         break;
+    case OPR_DSLRESHAPE:
+        slot = &context->runtime_reshape;
+        name = "__open64_dsl_reshape_v1";
+        break;
+    case OPR_DSLTRANSPOSE:
+        slot = &context->runtime_transpose;
+        name = "__open64_dsl_transpose_v1";
+        break;
+    case OPR_DSLTOKENEMBEDDING:
+        slot = &context->runtime_token_embedding;
+        name = "__open64_dsl_token_embedding_v1";
+        break;
+    case OPR_DSLRMSNORM:
+        slot = &context->runtime_rms_norm;
+        name = "__open64_dsl_rms_norm_v1";
+        break;
+    case OPR_DSLROTARYEMBEDDING:
+        slot = &context->runtime_rotary_embedding;
+        name = "__open64_dsl_rotary_embedding_v1";
+        break;
+    case OPR_DSLATTENTION:
+        slot = &context->runtime_attention;
+        name = "__open64_dsl_attention_v1";
+        break;
+    case OPR_DSLSWIGLU:
+        slot = &context->runtime_swiglu;
+        name = "__open64_dsl_swiglu_v1";
+        break;
     default:
         return NULL;
     }
@@ -943,6 +979,20 @@ VHO_DSL_Build_Runtime_Call
         parameter_count = 11;
     else if (dsl_operator == OPR_DSLGLOBALAVGPOOL2D)
         parameter_count = 5;
+    else if (dsl_operator == OPR_DSLRESHAPE)
+        parameter_count = 2;
+    else if (dsl_operator == OPR_DSLTRANSPOSE)
+        parameter_count = 3;
+    else if (dsl_operator == OPR_DSLTOKENEMBEDDING)
+        parameter_count = 3;
+    else if (dsl_operator == OPR_DSLRMSNORM)
+        parameter_count = 5;
+    else if (dsl_operator == OPR_DSLROTARYEMBEDDING)
+        parameter_count = 4;
+    else if (dsl_operator == OPR_DSLATTENTION)
+        parameter_count = 7;
+    else if (dsl_operator == OPR_DSLSWIGLU)
+        parameter_count = 3;
     else
         return FALSE;
 
@@ -970,6 +1020,10 @@ VHO_DSL_Build_Runtime_Call
                                             (WN_LdidPreg(Pointer_Mtype, preg));
         }
     }
+
+    if (dsl_operator == OPR_DSLLINEAR && annotation.version == 3)
+        WN_kid(call, parameter++) = VHO_DSL_Pointer_Parm
+                                        (WN_Intconst(Pointer_Mtype, 0));
 
     WN_kid(call, parameter++) = VHO_DSL_Pointer_Parm
                                     (WN_Lda(Pointer_Mtype, 0, descriptor));
@@ -1050,11 +1104,17 @@ VHO_DSL_Build_Runtime_Call
     } else if (dsl_operator == OPR_DSLOUTPUTLOGITS) {
         char semantic[32];
         if (!VHO_DSL_Payload_Value(annotation.payload, "attr.semantic",
-                                   semantic, sizeof(semantic)) ||
-            strcmp(semantic, "logits") != 0)
+                                   semantic, sizeof(semantic)))
             return FALSE;
-        WN_kid(call, parameter++) = VHO_DSL_U4_Parm
-                                        (OPEN64_DSL_OUTPUT_SEMANTIC_LOGITS);
+        UINT32 output_semantic;
+        if (strcmp(semantic, "logits") == 0)
+            output_semantic = OPEN64_DSL_OUTPUT_SEMANTIC_LOGITS;
+        else if (annotation.version == 3 &&
+                 strcmp(semantic, "token_logits") == 0)
+            output_semantic = OPEN64_DSL_OUTPUT_SEMANTIC_TOKEN_LOGITS;
+        else
+            return FALSE;
+        WN_kid(call, parameter++) = VHO_DSL_U4_Parm(output_semantic);
     } else if (dsl_operator == OPR_DSLLINEAR) {
         BOOL has_bias;
         BOOL transpose_input;
@@ -1176,6 +1236,39 @@ VHO_DSL_Build_Runtime_Call
         WN_kid(call, parameter++) = VHO_DSL_U4_Parm(output_size[1]);
         WN_kid(call, parameter++) = VHO_DSL_U4_Parm
                                         (OPEN64_DSL_REDUCTION_AXES_SPATIAL);
+    } else if (dsl_operator == OPR_DSLTRANSPOSE) {
+        char permutation[256];
+        if (!VHO_DSL_Payload_Value
+                 (annotation.payload, "attr.permutation", permutation,
+                  sizeof(permutation)))
+            return FALSE;
+        WN_kid(call, parameter++) = VHO_DSL_Pointer_Parm
+                                        (WN_LdaString
+                                             (permutation, 0,
+                                              strlen(permutation) + 1));
+    } else if (dsl_operator == OPR_DSLRMSNORM) {
+        UINT64 epsilon_bits;
+        INT32 axis;
+        if (!VHO_DSL_Payload_Double_Bits
+                 (annotation.payload, "attr.epsilon", &epsilon_bits) ||
+            !VHO_DSL_Payload_I4(annotation.payload, "attr.axis", &axis))
+            return FALSE;
+        WN_kid(call, parameter++) = VHO_DSL_U8_Parm(epsilon_bits);
+        WN_kid(call, parameter++) = VHO_DSL_I4_Parm(axis);
+    } else if (dsl_operator == OPR_DSLATTENTION) {
+        UINT32 query_heads;
+        UINT32 kv_heads;
+        UINT32 head_dim;
+        if (!VHO_DSL_Payload_U4
+                 (annotation.payload, "attr.query_heads", &query_heads) ||
+            !VHO_DSL_Payload_U4
+                 (annotation.payload, "attr.kv_heads", &kv_heads) ||
+            !VHO_DSL_Payload_U4
+                 (annotation.payload, "attr.head_dim", &head_dim))
+            return FALSE;
+        WN_kid(call, parameter++) = VHO_DSL_U4_Parm(query_heads);
+        WN_kid(call, parameter++) = VHO_DSL_U4_Parm(kv_heads);
+        WN_kid(call, parameter++) = VHO_DSL_U4_Parm(head_dim);
     }
 
     if (parameter != parameter_count)
@@ -1323,13 +1416,14 @@ VHO_DSL_Lower_Definition
 
     if (!DSL_WN_Get_Logical_Opcode
              (native, &logical_opcode, context->diagnostic) ||
-        !DSL_Operator_Get_Info(logical_opcode.dsl_operator, &info)) {
+        !DSL_Operator_Get_Info_Version
+             (logical_opcode.dsl_operator,
+              logical_opcode.effective_version, &info)) {
         ++context->result.malformed_node_count;
         return VHO_DSL_Lower_Report
                    (context, "native node has no supported logical operator");
     }
-    if (logical_opcode.effective_version != info.version ||
-        info.lowering_model != DSL_LOWERING_MODEL_RUNTIME_CALL) {
+    if (info.lowering_model != DSL_LOWERING_MODEL_RUNTIME_CALL) {
         ++context->result.unsupported_node_count;
         return VHO_DSL_Lower_Report
                    (context, "%s.v%u has no executable VHO lowering route "
@@ -1410,6 +1504,13 @@ VHO_DSL_Lower_Tree
                            (context->pu_info, statement)) {
                 if (!VHO_DSL_Lower_Tree(statement, context)) {
                     valid = FALSE;
+                } else if (!DSL_Region_Consume_WN
+                                (context->pu_info, statement)) {
+                    valid = FALSE;
+                    ++context->result.malformed_node_count;
+                    VHO_DSL_Lower_Report
+                        (context,
+                         "could not consume lowered managed REGION record");
                 } else {
                     WN *body = WN_region_body(statement);
                     for (WN *child = WN_first(body); child != NULL; ) {
@@ -1508,6 +1609,13 @@ VHO_DSL_Lower_Verified_Program_Unit
     context.runtime_batch_norm_infer = NULL;
     context.runtime_max_pool2d = NULL;
     context.runtime_global_avg_pool2d = NULL;
+    context.runtime_reshape = NULL;
+    context.runtime_transpose = NULL;
+    context.runtime_token_embedding = NULL;
+    context.runtime_rms_norm = NULL;
+    context.runtime_rotary_embedding = NULL;
+    context.runtime_attention = NULL;
+    context.runtime_swiglu = NULL;
 
     BOOL valid = pu_info != NULL && tree != NULL;
     if (valid)

--- a/osprey/be/vho/tests/dsl_lower_contract_test.cxx
+++ b/osprey/be/vho/tests/dsl_lower_contract_test.cxx
@@ -24,6 +24,8 @@
 #include "dsl_builder.h"
 #include "dsl_gatekeeper.h"
 #include "dsl_lower.h"
+#include "dsl_region.h"
+#include "open64_dsl_runtime_abi.h"
 
 BOOL Run_vsaopt = FALSE;
 INT8 Debug_Level = 0;
@@ -1052,6 +1054,335 @@ Check_Complete_ResNet_Vertical_Slice (BOOL artifact_only)
     return call_count == 18 && capture_count == 18 && comment_count == 18;
 }
 
+static BOOL
+Check_Llama2_Prefill_Expression_Lowering(void)
+{
+    DSL_BUILDER_PROGRAM_UNIT pu =
+        DSL_Builder_Create_Minimal_PU("dsl_llama2_prefill_lowering");
+    TY_IDX token_ty = Create_Shaped_Tensor_Type
+        ("llama_token_type", "int64", MTYPE_To_TY(MTYPE_I8), 2,
+         "[1,8]", "host", "dense");
+    TY_IDX embedding_weight_ty = Create_Shaped_Tensor_Type
+        ("llama_embedding_weight_type", "float32",
+         MTYPE_To_TY(MTYPE_F4), 2, "[128,32]", "host", "dense");
+    TY_IDX scale_ty = Create_Shaped_Tensor_Type
+        ("llama_scale_type", "float32", MTYPE_To_TY(MTYPE_F4), 1,
+         "[32]", "host", "dense");
+    TY_IDX qkv_ty = Create_Shaped_Tensor_Type
+        ("llama_qkv_type", "float32", MTYPE_To_TY(MTYPE_F4), 4,
+         "[1,4,8,8]", "host", "dense");
+    TY_IDX rope_ty = Create_Shaped_Tensor_Type
+        ("llama_rope_type", "float32", MTYPE_To_TY(MTYPE_F4), 4,
+         "[1,1,8,8]", "host", "dense");
+    TY_IDX swiglu_ty = Create_Shaped_Tensor_Type
+        ("llama_swiglu_type", "float32", MTYPE_To_TY(MTYPE_F4), 3,
+         "[1,8,88]", "host", "dense");
+    if (pu == NULL || token_ty == TY_IDX_ZERO ||
+        embedding_weight_ty == TY_IDX_ZERO || scale_ty == TY_IDX_ZERO ||
+        qkv_ty == TY_IDX_ZERO || rope_ty == TY_IDX_ZERO ||
+        swiglu_ty == TY_IDX_ZERO)
+        return FALSE;
+
+    DSL_Opcode_Register_Transformer_Domain();
+    DSL_DOMAIN_ID common = DSL_Domain_Find("common");
+    DSL_DOMAIN_ID transformer = DSL_Domain_Find("transformer");
+    DSL_OPCODE_ID embedding_id = DSL_Opcode_Find
+        (transformer, "transformer.token_embedding", 1);
+    DSL_OPCODE_ID rms_id = DSL_Opcode_Find
+        (transformer, "transformer.rms_norm", 1);
+    DSL_OPCODE_ID rotary_id = DSL_Opcode_Find
+        (transformer, "transformer.rotary_embedding", 1);
+    DSL_OPCODE_ID attention_id = DSL_Opcode_Find
+        (transformer, "transformer.attention", 1);
+    DSL_OPCODE_ID swiglu_id = DSL_Opcode_Find
+        (transformer, "transformer.swiglu", 1);
+    DSL_OPCODE_ID reshape_id = DSL_Opcode_Find
+        (common, "common.reshape", 1);
+    DSL_OPCODE_ID transpose_id = DSL_Opcode_Find
+        (common, "common.transpose", 1);
+    DSL_OPCODE_ID matmul_id = DSL_Opcode_Find
+        (common, "common.matmul", 2);
+    DSL_OPCODE_ID linear_id = DSL_Opcode_Find
+        (common, "common.linear", 3);
+    DSL_OPCODE_ID output_id = DSL_Opcode_Find
+        (common, "common.output_logits", 3);
+    if (embedding_id == DSL_OPCODE_INVALID_ID ||
+        rms_id == DSL_OPCODE_INVALID_ID ||
+        rotary_id == DSL_OPCODE_INVALID_ID ||
+        attention_id == DSL_OPCODE_INVALID_ID ||
+        swiglu_id == DSL_OPCODE_INVALID_ID ||
+        reshape_id == DSL_OPCODE_INVALID_ID ||
+        transpose_id == DSL_OPCODE_INVALID_ID ||
+        matmul_id == DSL_OPCODE_INVALID_ID ||
+        linear_id == DSL_OPCODE_INVALID_ID ||
+        output_id == DSL_OPCODE_INVALID_ID)
+        return FALSE;
+
+    DSL_BUILDER_VALUE values[21];
+    values[0] = DSL_Builder_Create_Model_Input("token_ids", token_ty, 0);
+    values[1] = DSL_Builder_Create_Tensor_Constant
+        ("embedding_weight", embedding_weight_ty, "float32", 2,
+         "[128,32]", "splat", "1");
+    DSL_BUILDER_OPERATOR_ATTRIBUTE embedding_attrs[2] = {
+        { "attr.padding_idx", "none" },
+        { "attr.bounds_policy", "runtime_check" }
+    };
+    DSL_BUILDER_VALUE kids[3] = { values[0], values[1], NULL };
+    values[2] = DSL_Builder_Create_Operator
+        (embedding_id, 1, kids, 2, embedding_attrs, 2);
+
+    values[3] = DSL_Builder_Create_Tensor_Constant
+        ("rms_scale", scale_ty, "float32", 1, "[32]", "splat", "1");
+    DSL_BUILDER_OPERATOR_ATTRIBUTE rms_attrs[3] = {
+        { "attr.axis", "-1" },
+        { "attr.epsilon", "0.00001" },
+        { "attr.accum_dtype", "float32" }
+    };
+    kids[0] = values[2];
+    kids[1] = values[3];
+    values[4] = DSL_Builder_Create_Operator
+        (rms_id, 1, kids, 2, rms_attrs, 3);
+
+    values[5] = DSL_Builder_Create_Model_Input("query", qkv_ty, 1);
+    values[6] = DSL_Builder_Create_Model_Input("key", qkv_ty, 2);
+    values[7] = DSL_Builder_Create_Model_Input("value", qkv_ty, 3);
+    values[8] = DSL_Builder_Create_Tensor_Constant
+        ("rope_cos", rope_ty, "float32", 4, "[1,1,8,8]", "splat", "1");
+    values[9] = DSL_Builder_Create_Tensor_Constant
+        ("rope_sin", rope_ty, "float32", 4, "[1,1,8,8]", "splat", "0");
+    DSL_BUILDER_OPERATOR_ATTRIBUTE rotary_attrs[6] = {
+        { "attr.head_layout", "BHSD" },
+        { "attr.sequence_axis", "2" },
+        { "attr.feature_axis", "3" },
+        { "attr.pairing", "half_split" },
+        { "attr.position_mode", "zero_based_static" },
+        { "attr.position_offset", "0" }
+    };
+    kids[0] = values[5];
+    kids[1] = values[8];
+    kids[2] = values[9];
+    values[10] = DSL_Builder_Create_Operator
+        (rotary_id, 1, kids, 3, rotary_attrs, 6);
+    kids[0] = values[6];
+    values[11] = DSL_Builder_Create_Operator
+        (rotary_id, 1, kids, 3, rotary_attrs, 6);
+
+    DSL_BUILDER_OPERATOR_ATTRIBUTE attention_attrs[10] = {
+        { "attr.execution_mode", "full_sequence" },
+        { "attr.mask_mode", "causal" },
+        { "attr.head_layout", "BHSD" },
+        { "attr.query_heads", "4" },
+        { "attr.kv_heads", "4" },
+        { "attr.head_dim", "8" },
+        { "attr.scale_mode", "inverse_sqrt_head_dim" },
+        { "attr.softmax_axis", "-1" },
+        { "attr.softmax_accum_dtype", "float32" },
+        { "attr.cache_mode", "none" }
+    };
+    kids[0] = values[10];
+    kids[1] = values[11];
+    kids[2] = values[7];
+    values[12] = DSL_Builder_Create_Operator
+        (attention_id, 1, kids, 3, attention_attrs, 10);
+
+    values[13] = DSL_Builder_Create_Model_Input
+        ("gate_projection", swiglu_ty, 4);
+    values[14] = DSL_Builder_Create_Model_Input
+        ("up_projection", swiglu_ty, 5);
+    DSL_BUILDER_OPERATOR_ATTRIBUTE swiglu_attr = {
+        "attr.activation", "silu"
+    };
+    kids[0] = values[13];
+    kids[1] = values[14];
+    values[15] = DSL_Builder_Create_Operator
+        (swiglu_id, 1, kids, 2, &swiglu_attr, 1);
+
+    DSL_BUILDER_OPERATOR_ATTRIBUTE reshape_attr = {
+        "attr.target_shape", "1,8,32"
+    };
+    kids[0] = values[5];
+    values[16] = DSL_Builder_Create_Operator
+        (reshape_id, 1, kids, 1, &reshape_attr, 1);
+    DSL_BUILDER_OPERATOR_ATTRIBUTE transpose_attr = {
+        "attr.permutation", "0,2,1,3"
+    };
+    kids[0] = values[5];
+    values[17] = DSL_Builder_Create_Operator
+        (transpose_id, 1, kids, 1, &transpose_attr, 1);
+    DSL_BUILDER_OPERATOR_ATTRIBUTE matmul_attrs[4] = {
+        { "attr.transpose_kid0", "false" },
+        { "attr.transpose_kid1", "true" },
+        { "attr.batch_rule", "exact" },
+        { "attr.accum_dtype", "float32" }
+    };
+    kids[0] = values[5];
+    kids[1] = values[6];
+    values[18] = DSL_Builder_Create_Operator
+        (matmul_id, 2, kids, 2, matmul_attrs, 4);
+    DSL_BUILDER_OPERATOR_ATTRIBUTE linear_attrs[4] = {
+        { "attr.has_bias", "false" },
+        { "attr.transpose_input", "false" },
+        { "attr.transpose_weight", "true" },
+        { "attr.weight_layout", "OI" }
+    };
+    kids[0] = values[2];
+    kids[1] = values[1];
+    values[19] = DSL_Builder_Create_Operator
+        (linear_id, 3, kids, 2, linear_attrs, 4);
+    DSL_BUILDER_OPERATOR_ATTRIBUTE output_attrs[3] = {
+        { "attr.semantic", "token_logits" },
+        { "attr.sequence_axis", "-2" },
+        { "attr.vocabulary_axis", "-1" }
+    };
+    kids[0] = values[19];
+    values[20] = DSL_Builder_Create_Operator
+        (output_id, 3, kids, 1, output_attrs, 3);
+
+    for (UINT32 i = 0; i < 21; ++i) {
+        if (values[i] == NULL || !DSL_Builder_Append_PU_Value(pu, values[i]))
+            return FALSE;
+    }
+    DSL_GATEKEEPER_RESULT gatekeeper_result;
+    if (!DSL_Gatekeeper_Verify_Program(pu, stderr, &gatekeeper_result) ||
+        gatekeeper_result.native_node_count != 21 ||
+        gatekeeper_result.error_count != 0)
+        return FALSE;
+
+    VHO_DSL_LOWER_RESULT lower_result;
+    if (!VHO_DSL_Lower_Verified_Program_Unit
+             (pu, PU_Info_tree_ptr(pu), stderr, &lower_result) ||
+        lower_result.native_node_count != 21 ||
+        lower_result.lowered_node_count != 21 ||
+        lower_result.remaining_executable_carrier_count != 0)
+        return FALSE;
+
+    const char *expected_calls[21] = {
+        "__open64_dsl_model_input_v1",
+        "__open64_dsl_tensor_const_v1",
+        "__open64_dsl_token_embedding_v1",
+        "__open64_dsl_tensor_const_v1",
+        "__open64_dsl_rms_norm_v1",
+        "__open64_dsl_model_input_v1",
+        "__open64_dsl_model_input_v1",
+        "__open64_dsl_model_input_v1",
+        "__open64_dsl_tensor_const_v1",
+        "__open64_dsl_tensor_const_v1",
+        "__open64_dsl_rotary_embedding_v1",
+        "__open64_dsl_rotary_embedding_v1",
+        "__open64_dsl_attention_v1",
+        "__open64_dsl_model_input_v1",
+        "__open64_dsl_model_input_v1",
+        "__open64_dsl_swiglu_v1",
+        "__open64_dsl_reshape_v1",
+        "__open64_dsl_transpose_v1",
+        "__open64_dsl_matmul_v1",
+        "__open64_dsl_linear_v1",
+        "__open64_dsl_output_logits_v1"
+    };
+    const UINT32 expected_parameters[21] = {
+        2, 2, 3, 2, 5, 2, 2, 2, 2, 2, 4, 4, 7, 2, 2, 3, 2, 3,
+        4, 6, 3
+    };
+    UINT32 call_count = 0;
+    UINT32 capture_count = 0;
+    UINT32 comment_count = 0;
+    WN *body = WN_func_body(PU_Info_tree_ptr(pu));
+    for (WN *statement = WN_first(body); statement != NULL;
+         statement = WN_next(statement)) {
+        if (WN_operator(statement) == OPR_COMMENT) {
+            ++comment_count;
+        } else if (WN_operator(statement) == OPR_CALL) {
+            if (call_count >= 21 ||
+                strcmp(ST_name(WN_st(statement)),
+                       expected_calls[call_count]) != 0 ||
+                WN_kid_count(statement) != expected_parameters[call_count])
+                return FALSE;
+            if (call_count == 19 &&
+                (WN_operator(WN_kid0(WN_kid(statement, 2))) != OPR_INTCONST ||
+                 WN_const_val(WN_kid0(WN_kid(statement, 2))) != 0 ||
+                 WN_operator(WN_kid0(WN_kid(statement, 3))) != OPR_LDA))
+                return FALSE;
+            if (call_count == 20 &&
+                (WN_operator(WN_kid0(WN_kid(statement, 2))) != OPR_INTCONST ||
+                 WN_const_val(WN_kid0(WN_kid(statement, 2))) !=
+                     OPEN64_DSL_OUTPUT_SEMANTIC_TOKEN_LOGITS))
+                return FALSE;
+            ++call_count;
+        } else if (WN_operator(statement) == OPR_STID &&
+                   ST_class(WN_st(statement)) == CLASS_PREG) {
+            ++capture_count;
+        } else {
+            return FALSE;
+        }
+    }
+    if (call_count != 21 || capture_count != 21 || comment_count != 21 ||
+        Tree_Has_Native_DSL(body))
+        return FALSE;
+
+    const char *trace_path = getenv("OPEN64_DSL_LLAMA2_LOWER_TRACE");
+    if (trace_path != NULL && trace_path[0] != '\0') {
+        FILE *trace = fopen(trace_path, "w");
+        if (trace == NULL)
+            return FALSE;
+        fprintf(trace, "WHIRL after verified Llama 2 prefill VHO DSL lowering\n");
+        fdump_tree(trace, PU_Info_tree_ptr(pu));
+        fclose(trace);
+    }
+    return TRUE;
+}
+
+static BOOL
+Check_Managed_Region_Lowering(void)
+{
+    DSL_BUILDER_PROGRAM_UNIT pu =
+        DSL_Builder_Create_Minimal_PU("dsl_managed_region_lowering");
+    TY_IDX tensor_ty = Create_Tensor_Type_With_Representation
+                           ("dsl_region_lowering_type", "host", "host");
+    DSL_BUILDER_VALUE input = DSL_Builder_Create_Model_Input
+                                  ("region_input", tensor_ty, 0);
+    DSL_Opcode_Register_Common_Substrate();
+    DSL_DOMAIN_ID common = DSL_Domain_Find("common");
+    DSL_OPCODE_ID relu_id = DSL_Opcode_Find(common, "common.relu", 2);
+    DSL_BUILDER_VALUE kid[1] = { input };
+    DSL_BUILDER_VALUE relu = DSL_Builder_Create_Operator
+                                 (relu_id, 2, kid, 1, NULL, 0);
+    DSL_BUILDER_REGION region = DSL_Builder_Create_Region
+        (pu, NULL, "test.lowering", 1);
+    if (pu == NULL || tensor_ty == TY_IDX_ZERO || input == NULL ||
+        relu_id == DSL_OPCODE_INVALID_ID || relu == NULL || region == NULL ||
+        !DSL_Builder_Append_PU_Value(pu, input) ||
+        !DSL_Builder_Append_Region_Value(region, relu) ||
+        !DSL_Builder_Append_PU_Region(pu, region) ||
+        !DSL_Region_Verify_PU(pu, stderr))
+        return FALSE;
+
+    DSL_GATEKEEPER_RESULT gatekeeper_result;
+    if (!DSL_Gatekeeper_Verify_Program(pu, stderr, &gatekeeper_result) ||
+        gatekeeper_result.native_node_count != 2)
+        return FALSE;
+
+    VHO_DSL_LOWER_RESULT lower_result;
+    WN *tree = PU_Info_tree_ptr(pu);
+    if (!VHO_DSL_Lower_Verified_Program_Unit
+             (pu, tree, stderr, &lower_result) ||
+        lower_result.native_node_count != 2 ||
+        lower_result.lowered_node_count != 2 ||
+        PU_Info_state(pu, WT_REGIONS) != Subsect_Missing ||
+        PU_Info_regions_ptr(pu) != NULL)
+        return FALSE;
+
+    UINT32 call_count = 0;
+    WN *body = WN_func_body(tree);
+    for (WN *statement = WN_first(body); statement != NULL;
+         statement = WN_next(statement)) {
+        if (WN_operator(statement) == OPR_REGION)
+            return FALSE;
+        if (WN_operator(statement) == OPR_CALL)
+            ++call_count;
+    }
+    return call_count == 2 && !Tree_Has_Native_DSL(body);
+}
+
 int
 main(void)
 {
@@ -1216,6 +1547,16 @@ main(void)
 
     if (!Check_Complete_ResNet_Vertical_Slice(FALSE)) {
         fprintf(stderr, "complete ResNet lowering contract changed\n");
+        return 1;
+    }
+
+    if (!Check_Llama2_Prefill_Expression_Lowering()) {
+        fprintf(stderr, "Llama 2 prefill expression lowering changed\n");
+        return 1;
+    }
+
+    if (!Check_Managed_Region_Lowering()) {
+        fprintf(stderr, "managed REGION lowering contract changed\n");
         return 1;
     }
 

--- a/osprey/be/vho/tests/dsl_runtime_abi_contract_test.cxx
+++ b/osprey/be/vho/tests/dsl_runtime_abi_contract_test.cxx
@@ -12,6 +12,8 @@ typedef char DSL_runtime_abi_version_must_be_1
     [OPEN64_DSL_RUNTIME_ABI_VERSION == 1 ? 1 : -1];
 typedef char DSL_runtime_logits_semantic_must_be_1
     [OPEN64_DSL_OUTPUT_SEMANTIC_LOGITS == 1 ? 1 : -1];
+typedef char DSL_runtime_token_logits_semantic_must_be_2
+    [OPEN64_DSL_OUTPUT_SEMANTIC_TOKEN_LOGITS == 2 ? 1 : -1];
 typedef char DSL_runtime_operator_layout_nchw_must_be_1
     [OPEN64_DSL_OPERATOR_LAYOUT_NCHW == 1 ? 1 : -1];
 typedef char DSL_runtime_operator_layout_oihw_must_be_2

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -7,6 +7,7 @@
 #endif /* USE_PCH */
 #pragma hdrstop
 #include <ctype.h>
+#include <float.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -338,7 +339,7 @@ DSL_Builder_Parse_Matrix_Shape
 }
 
 static TY_IDX
-DSL_Builder_Create_Matmul_Result_Type
+DSL_Builder_Create_Matmul_V1_Result_Type
         (TY_IDX kid0_ty,
          TY_IDX kid1_ty,
          const char *name)
@@ -410,6 +411,58 @@ DSL_Builder_Find_Operator_Attribute
 }
 
 static BOOL
+DSL_Builder_Attributes_Match_Schema
+        (const DSL_OPERATOR_INFO *info,
+         const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count)
+{
+    if (info == NULL || (attr_count != 0 && attrs == NULL))
+        return FALSE;
+
+    const char *schema = DSL_Builder_Safe_String(info->attribute_schema);
+    const char *cursor = schema;
+    UINT32 required_count = 0;
+    while (*cursor != '\0') {
+        const char *end = strchr(cursor, ';');
+        size_t length = end == NULL ? strlen(cursor) :
+                                     (size_t)(end - cursor);
+        if (length != 0) {
+            ++required_count;
+            UINT32 matches = 0;
+            for (UINT32 i = 0; i < attr_count; ++i) {
+                if (attrs[i].name != NULL &&
+                    strlen(attrs[i].name) == length &&
+                    strncmp(attrs[i].name, cursor, length) == 0)
+                    ++matches;
+            }
+            if (matches != 1)
+                return FALSE;
+        }
+        if (end == NULL)
+            break;
+        cursor = end + 1;
+    }
+    return required_count == attr_count;
+}
+
+static BOOL
+DSL_Builder_Requires_Exact_Attribute_Schema
+        (DSL_OPERATOR dsl_operator,
+         UINT16 version)
+{
+    return dsl_operator == OPR_DSLRESHAPE ||
+           dsl_operator == OPR_DSLTRANSPOSE ||
+           dsl_operator == OPR_DSLTOKENEMBEDDING ||
+           dsl_operator == OPR_DSLRMSNORM ||
+           dsl_operator == OPR_DSLROTARYEMBEDDING ||
+           dsl_operator == OPR_DSLATTENTION ||
+           dsl_operator == OPR_DSLSWIGLU ||
+           (dsl_operator == OPR_DSLMATMUL && version == 2) ||
+           (dsl_operator == OPR_DSLLINEAR && version == 3) ||
+           (dsl_operator == OPR_DSLOUTPUTLOGITS && version == 3);
+}
+
+static BOOL
 DSL_Builder_Parse_Signed_Attribute
         (const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
          UINT32 attr_count,
@@ -426,6 +479,33 @@ DSL_Builder_Parse_Signed_Attribute
         parsed > INT32_MAX)
         return FALSE;
     *value = (INT32)parsed;
+    return TRUE;
+}
+
+static BOOL
+DSL_Builder_Parse_Unsigned_Attribute
+        (const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count,
+         const char *name,
+         UINT64 *value)
+{
+    const char *text = DSL_Builder_Find_Operator_Attribute
+                           (attrs, attr_count, name);
+    if (text == NULL || !isdigit((unsigned char)text[0]))
+        return FALSE;
+    UINT64 parsed = 0;
+    const char *cursor = text;
+    while (isdigit((unsigned char)*cursor)) {
+        UINT64 digit = (UINT64)(*cursor - '0');
+        if (parsed > (~(UINT64)0 - digit) / 10)
+            return FALSE;
+        parsed = parsed * 10 + digit;
+        ++cursor;
+    }
+    if (*cursor != '\0')
+        return FALSE;
+    if (value != NULL)
+        *value = parsed;
     return TRUE;
 }
 
@@ -476,12 +556,62 @@ DSL_Builder_Parse_Static_Shape
     return *cursor == '\0';
 }
 
+static BOOL
+DSL_Builder_Parse_Unsigned_List
+        (const char *text,
+         BOOL allow_zero,
+         std::vector<UINT64> *values)
+{
+    if (text == NULL || values == NULL || text[0] == '\0')
+        return FALSE;
+
+    values->clear();
+    const char *cursor = text;
+    while (*cursor != '\0') {
+        if (!isdigit((unsigned char)*cursor))
+            return FALSE;
+        UINT64 value = 0;
+        while (isdigit((unsigned char)*cursor)) {
+            UINT64 digit = (UINT64)(*cursor - '0');
+            if (value > (~(UINT64)0 - digit) / 10)
+                return FALSE;
+            value = value * 10 + digit;
+            ++cursor;
+        }
+        if (!allow_zero && value == 0)
+            return FALSE;
+        values->push_back(value);
+        if (*cursor == '\0')
+            break;
+        if (*cursor++ != ',' || *cursor == '\0')
+            return FALSE;
+    }
+    return !values->empty();
+}
+
+static BOOL
+DSL_Builder_Tensor_Element_Type_Compatible
+        (TY_IDX left,
+         TY_IDX right)
+{
+    const char *left_dtype =
+        TY_tensor_attribute(left, TY_TENSOR_SCHEMA_DTYPE);
+    const char *right_dtype =
+        TY_tensor_attribute(right, TY_TENSOR_SCHEMA_DTYPE);
+
+    return TY_is_tensor_extension(left) && TY_is_tensor_extension(right) &&
+           TY_tensor_element_ty(left) == TY_tensor_element_ty(right) &&
+           left_dtype != NULL && right_dtype != NULL &&
+           strcmp(left_dtype, right_dtype) == 0;
+}
+
 static TY_IDX
-DSL_Builder_Create_Derived_Result_Type
+DSL_Builder_Create_Result_Type
         (TY_IDX input_ty,
          const std::vector<UINT64> &dimensions,
          const char *name,
-         const char *lineage)
+         const char *lineage,
+         BOOL preserve_representation)
 {
     std::string shape = "[";
     for (UINT32 i = 0; i < dimensions.size(); ++i) {
@@ -504,18 +634,25 @@ DSL_Builder_Create_Derived_Result_Type
     descriptor.type_core.logical_shape = shape.c_str();
     descriptor.traits.traits =
         TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_TRAITS);
-    descriptor.representation.layout =
-        TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_LAYOUT);
-    descriptor.representation.sharding =
-        TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_SHARDING);
-    descriptor.representation.placement =
-        TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_PLACEMENT);
-    descriptor.representation.memory =
-        TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_MEMORY);
-    descriptor.representation.quantization =
-        TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_QUANTIZATION);
-    descriptor.representation.runtime_state =
-        TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_RUNTIME_STATE);
+    if (preserve_representation) {
+        descriptor.representation.layout =
+            TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_LAYOUT);
+        descriptor.representation.sharding =
+            TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_SHARDING);
+        descriptor.representation.placement =
+            TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_PLACEMENT);
+        descriptor.representation.memory =
+            TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_MEMORY);
+        descriptor.representation.quantization =
+            TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_QUANTIZATION);
+        descriptor.representation.runtime_state =
+            TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_RUNTIME_STATE);
+    } else {
+        descriptor.representation.layout =
+            TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_LAYOUT);
+        descriptor.representation.quantization =
+            TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_QUANTIZATION);
+    }
     descriptor.lineage.lineage = lineage;
 
     TY_IDX result_ty = DSL_Builder_Create_Tensor_Type_Core
@@ -524,6 +661,17 @@ DSL_Builder_Create_Derived_Result_Type
     if (!DSL_Builder_Attach_Tensor_Descriptor(result_ty, &descriptor))
         return TY_IDX_ZERO;
     return result_ty;
+}
+
+static TY_IDX
+DSL_Builder_Create_Derived_Result_Type
+        (TY_IDX input_ty,
+         const std::vector<UINT64> &dimensions,
+         const char *name,
+         const char *lineage)
+{
+    return DSL_Builder_Create_Result_Type
+               (input_ty, dimensions, name, lineage, TRUE);
 }
 
 static BOOL
@@ -567,8 +715,309 @@ DSL_Builder_Attribute_Equals
 }
 
 static TY_IDX
-DSL_Builder_Create_Linear_Result_Type
+DSL_Builder_Create_Reshape_Result_Type
         (TY_IDX input_ty,
+         const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count,
+         const char *name)
+{
+    std::vector<UINT64> input;
+    std::vector<UINT64> result;
+    const char *target_shape = DSL_Builder_Find_Operator_Attribute
+                                   (attrs, attr_count, "attr.target_shape");
+    if (!DSL_Builder_Parse_Static_Shape
+             (TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_SHAPE), &input) ||
+        !DSL_Builder_Parse_Unsigned_List
+             (target_shape, FALSE, &result))
+        return TY_IDX_ZERO;
+
+    UINT64 input_elements = 1;
+    UINT64 result_elements = 1;
+    for (UINT32 i = 0; i < input.size(); ++i) {
+        if (input_elements > ~(UINT64)0 / input[i])
+            return TY_IDX_ZERO;
+        input_elements *= input[i];
+    }
+    for (UINT32 i = 0; i < result.size(); ++i) {
+        if (result_elements > ~(UINT64)0 / result[i])
+            return TY_IDX_ZERO;
+        result_elements *= result[i];
+    }
+    if (input_elements != result_elements)
+        return TY_IDX_ZERO;
+
+    return DSL_Builder_Create_Derived_Result_Type
+               (input_ty, result, name, "common.reshape");
+}
+
+static TY_IDX
+DSL_Builder_Create_Transpose_Result_Type
+        (TY_IDX input_ty,
+         const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count,
+         const char *name)
+{
+    std::vector<UINT64> input;
+    std::vector<UINT64> permutation;
+    const char *permutation_text = DSL_Builder_Find_Operator_Attribute
+                                       (attrs, attr_count, "attr.permutation");
+    if (!DSL_Builder_Parse_Static_Shape
+             (TY_tensor_attribute(input_ty, TY_TENSOR_SCHEMA_SHAPE), &input) ||
+        !DSL_Builder_Parse_Unsigned_List
+             (permutation_text, TRUE, &permutation) ||
+        permutation.size() != input.size())
+        return TY_IDX_ZERO;
+
+    std::vector<BOOL> seen(input.size(), FALSE);
+    std::vector<UINT64> result(input.size());
+    for (UINT32 i = 0; i < permutation.size(); ++i) {
+        if (permutation[i] >= input.size() || seen[permutation[i]])
+            return TY_IDX_ZERO;
+        seen[permutation[i]] = TRUE;
+        result[i] = input[permutation[i]];
+    }
+    return DSL_Builder_Create_Derived_Result_Type
+               (input_ty, result, name, "common.transpose");
+}
+
+static BOOL
+DSL_Builder_Dimensions_Equal
+        (const std::vector<UINT64> &left,
+         const std::vector<UINT64> &right)
+{
+    if (left.size() != right.size())
+        return FALSE;
+    for (UINT32 i = 0; i < left.size(); ++i) {
+        if (left[i] != right[i])
+            return FALSE;
+    }
+    return TRUE;
+}
+
+static BOOL
+DSL_Builder_Positive_Float_Attribute
+        (const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count,
+         const char *name)
+{
+    const char *text = DSL_Builder_Find_Operator_Attribute
+                           (attrs, attr_count, name);
+    if (text == NULL || text[0] == '\0')
+        return FALSE;
+    char *end = NULL;
+    double value = strtod(text, &end);
+    return end != text && *end == '\0' && value > 0.0 && value <= DBL_MAX;
+}
+
+static TY_IDX
+DSL_Builder_Create_Transformer_Result_Type
+        (DSL_OPERATOR dsl_operator,
+         TY_IDX kid0_ty,
+         TY_IDX kid1_ty,
+         TY_IDX kid2_ty,
+         const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count,
+         const char *name)
+{
+    std::vector<UINT64> kid0;
+    std::vector<UINT64> kid1;
+    std::vector<UINT64> kid2;
+    const char *lineage = NULL;
+
+    if (!DSL_Builder_Parse_Static_Shape
+             (TY_tensor_attribute(kid0_ty, TY_TENSOR_SCHEMA_SHAPE), &kid0) ||
+        !DSL_Builder_Parse_Static_Shape
+             (TY_tensor_attribute(kid1_ty, TY_TENSOR_SCHEMA_SHAPE), &kid1))
+        return TY_IDX_ZERO;
+
+    if (dsl_operator == OPR_DSLTOKENEMBEDDING) {
+        const char *token_dtype =
+            TY_tensor_attribute(kid0_ty, TY_TENSOR_SCHEMA_DTYPE);
+        const char *weight_dtype =
+            TY_tensor_attribute(kid1_ty, TY_TENSOR_SCHEMA_DTYPE);
+        if (kid0.size() != 2 || kid1.size() != 2 ||
+            token_dtype == NULL || strcmp(token_dtype, "int64") != 0 ||
+            weight_dtype == NULL || strcmp(weight_dtype, "float32") != 0 ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.padding_idx", "none") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.bounds_policy", "runtime_check"))
+            return TY_IDX_ZERO;
+        std::vector<UINT64> result;
+        result.push_back(kid0[0]);
+        result.push_back(kid0[1]);
+        result.push_back(kid1[1]);
+        return DSL_Builder_Create_Result_Type
+                   (kid1_ty, result, name, "transformer.token_embedding",
+                    FALSE);
+    }
+
+    const char *activation_dtype =
+        TY_tensor_attribute(kid0_ty, TY_TENSOR_SCHEMA_DTYPE);
+    if (activation_dtype == NULL || strcmp(activation_dtype, "float32") != 0)
+        return TY_IDX_ZERO;
+
+    if (dsl_operator == OPR_DSLRMSNORM) {
+        if (kid0.size() < 2 || kid1.size() != 1 ||
+            kid1[0] != kid0[kid0.size() - 1] ||
+            !DSL_Builder_Tensor_Element_Type_Compatible(kid0_ty, kid1_ty) ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.axis", "-1") ||
+            !DSL_Builder_Positive_Float_Attribute
+                 (attrs, attr_count, "attr.epsilon") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.accum_dtype", "float32"))
+            return TY_IDX_ZERO;
+        lineage = "transformer.rms_norm";
+    } else if (dsl_operator == OPR_DSLROTARYEMBEDDING) {
+        if (!DSL_Builder_Parse_Static_Shape
+                 (TY_tensor_attribute(kid2_ty, TY_TENSOR_SCHEMA_SHAPE),
+                  &kid2) ||
+            kid0.size() != 4 || kid1.size() != 4 ||
+            !DSL_Builder_Dimensions_Equal(kid1, kid2) ||
+            kid1[0] != 1 || kid1[1] != 1 || kid1[2] != kid0[2] ||
+            kid1[3] != kid0[3] || kid0[3] % 2 != 0 ||
+            !DSL_Builder_Tensor_Element_Type_Compatible(kid0_ty, kid1_ty) ||
+            !DSL_Builder_Tensor_Element_Type_Compatible(kid0_ty, kid2_ty) ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.head_layout", "BHSD") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.sequence_axis", "2") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.feature_axis", "3") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.pairing", "half_split") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.position_mode",
+                  "zero_based_static") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.position_offset", "0"))
+            return TY_IDX_ZERO;
+        lineage = "transformer.rotary_embedding";
+    } else if (dsl_operator == OPR_DSLATTENTION) {
+        UINT64 query_heads;
+        UINT64 kv_heads;
+        UINT64 head_dim;
+        if (!DSL_Builder_Parse_Static_Shape
+                 (TY_tensor_attribute(kid2_ty, TY_TENSOR_SCHEMA_SHAPE),
+                  &kid2) ||
+            kid0.size() != 4 ||
+            !DSL_Builder_Dimensions_Equal(kid0, kid1) ||
+            !DSL_Builder_Dimensions_Equal(kid0, kid2) ||
+            !DSL_Builder_Tensor_Element_Type_Compatible(kid0_ty, kid1_ty) ||
+            !DSL_Builder_Tensor_Element_Type_Compatible(kid0_ty, kid2_ty) ||
+            !DSL_Builder_Parse_Unsigned_Attribute
+                 (attrs, attr_count, "attr.query_heads", &query_heads) ||
+            !DSL_Builder_Parse_Unsigned_Attribute
+                 (attrs, attr_count, "attr.kv_heads", &kv_heads) ||
+            !DSL_Builder_Parse_Unsigned_Attribute
+                 (attrs, attr_count, "attr.head_dim", &head_dim) ||
+            query_heads <= 0 || kv_heads != query_heads || head_dim <= 0 ||
+            query_heads != kid0[1] || head_dim != kid0[3] ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.execution_mode", "full_sequence") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.mask_mode", "causal") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.head_layout", "BHSD") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.scale_mode",
+                  "inverse_sqrt_head_dim") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.softmax_axis", "-1") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.softmax_accum_dtype", "float32") ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.cache_mode", "none"))
+            return TY_IDX_ZERO;
+        lineage = "transformer.attention";
+    } else if (dsl_operator == OPR_DSLSWIGLU) {
+        if (!DSL_Builder_Dimensions_Equal(kid0, kid1) ||
+            kid0.size() != 3 ||
+            !DSL_Builder_Tensor_Element_Type_Compatible(kid0_ty, kid1_ty) ||
+            !DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.activation", "silu"))
+            return TY_IDX_ZERO;
+        lineage = "transformer.swiglu";
+    } else {
+        return TY_IDX_ZERO;
+    }
+
+    return DSL_Builder_Create_Derived_Result_Type
+               (kid0_ty, kid0, name, lineage);
+}
+
+static TY_IDX
+DSL_Builder_Create_Matmul_Result_Type
+        (UINT16 version,
+         TY_IDX kid0_ty,
+         TY_IDX kid1_ty,
+         const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count,
+         const char *name)
+{
+    if (version == 1)
+        return DSL_Builder_Create_Matmul_V1_Result_Type
+                   (kid0_ty, kid1_ty, name);
+    if (version != 2 ||
+        !DSL_Builder_Attribute_Equals
+             (attrs, attr_count, "attr.batch_rule", "exact") ||
+        !DSL_Builder_Attribute_Equals
+             (attrs, attr_count, "attr.accum_dtype", "float32") ||
+        !DSL_Builder_Tensor_Element_Type_Compatible(kid0_ty, kid1_ty))
+        return TY_IDX_ZERO;
+
+    BOOL transpose_kid0;
+    BOOL transpose_kid1;
+    if (DSL_Builder_Attribute_Equals
+            (attrs, attr_count, "attr.transpose_kid0", "true"))
+        transpose_kid0 = TRUE;
+    else if (DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.transpose_kid0", "false"))
+        transpose_kid0 = FALSE;
+    else
+        return TY_IDX_ZERO;
+    if (DSL_Builder_Attribute_Equals
+            (attrs, attr_count, "attr.transpose_kid1", "true"))
+        transpose_kid1 = TRUE;
+    else if (DSL_Builder_Attribute_Equals
+                 (attrs, attr_count, "attr.transpose_kid1", "false"))
+        transpose_kid1 = FALSE;
+    else
+        return TY_IDX_ZERO;
+
+    std::vector<UINT64> kid0;
+    std::vector<UINT64> kid1;
+    if (!DSL_Builder_Parse_Static_Shape
+             (TY_tensor_attribute(kid0_ty, TY_TENSOR_SCHEMA_SHAPE), &kid0) ||
+        !DSL_Builder_Parse_Static_Shape
+             (TY_tensor_attribute(kid1_ty, TY_TENSOR_SCHEMA_SHAPE), &kid1) ||
+        kid0.size() < 2 || kid0.size() != kid1.size())
+        return TY_IDX_ZERO;
+    for (UINT32 i = 0; i + 2 < kid0.size(); ++i) {
+        if (kid0[i] != kid1[i])
+            return TY_IDX_ZERO;
+    }
+
+    UINT32 rank = kid0.size();
+    UINT64 left_m = kid0[rank - (transpose_kid0 ? 1 : 2)];
+    UINT64 left_k = kid0[rank - (transpose_kid0 ? 2 : 1)];
+    UINT64 right_k = kid1[rank - (transpose_kid1 ? 1 : 2)];
+    UINT64 right_n = kid1[rank - (transpose_kid1 ? 2 : 1)];
+    if (left_k != right_k)
+        return TY_IDX_ZERO;
+
+    std::vector<UINT64> result = kid0;
+    result[rank - 2] = left_m;
+    result[rank - 1] = right_n;
+    return DSL_Builder_Create_Derived_Result_Type
+               (kid0_ty, result, name, "common.matmul");
+}
+
+static TY_IDX
+DSL_Builder_Create_Linear_Result_Type
+        (UINT16 version,
+         TY_IDX input_ty,
          TY_IDX weight_ty,
          TY_IDX bias_ty,
          const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
@@ -578,8 +1027,10 @@ DSL_Builder_Create_Linear_Result_Type
     std::vector<UINT64> input;
     std::vector<UINT64> weight;
     std::vector<UINT64> bias;
-    if (!DSL_Builder_Attribute_Equals
-             (attrs, attr_count, "attr.has_bias", "true") ||
+    const char *required_bias = version == 2 ? "true" : "false";
+    if ((version != 2 && version != 3) ||
+        !DSL_Builder_Attribute_Equals
+             (attrs, attr_count, "attr.has_bias", required_bias) ||
         !DSL_Builder_Attribute_Equals
              (attrs, attr_count, "attr.transpose_input", "false") ||
         !DSL_Builder_Attribute_Equals
@@ -591,10 +1042,15 @@ DSL_Builder_Create_Linear_Result_Type
         !DSL_Builder_Parse_Static_Shape
              (TY_tensor_attribute(weight_ty, TY_TENSOR_SCHEMA_SHAPE),
               &weight) ||
-        !DSL_Builder_Parse_Static_Shape
+        input.size() < 2 || weight.size() != 2 ||
+        input[input.size() - 1] != weight[1] ||
+        !DSL_Builder_Tensor_Element_Type_Compatible(input_ty, weight_ty))
+        return TY_IDX_ZERO;
+    if (version == 2 &&
+        (!DSL_Builder_Parse_Static_Shape
              (TY_tensor_attribute(bias_ty, TY_TENSOR_SCHEMA_SHAPE), &bias) ||
-        input.empty() || weight.size() != 2 || bias.size() != 1 ||
-        input[input.size() - 1] != weight[1] || bias[0] != weight[0])
+         bias.size() != 1 || bias[0] != weight[0] ||
+         !DSL_Builder_Tensor_Element_Type_Compatible(input_ty, bias_ty)))
         return TY_IDX_ZERO;
     input[input.size() - 1] = weight[0];
     return DSL_Builder_Create_Derived_Result_Type
@@ -803,13 +1259,15 @@ DSL_Builder_Create_Flatten_Result_Type
 }
 
 static DSL_IR_OPCODE_DESCRIPTOR_ID
-DSL_Builder_Get_Image_Opcode_Descriptor (DSL_OPERATOR dsl_operator)
+DSL_Builder_Get_Image_Opcode_Descriptor
+        (DSL_OPERATOR dsl_operator,
+         UINT16 version)
 {
     DSL_OPERATOR_INFO info;
     DSL_IR_OPCODE_DESCRIPTOR_RECORD record;
     DSL_IR_OPCODE_DESCRIPTOR_ID id;
 
-    if (!DSL_Operator_Get_Info(dsl_operator, &info))
+    if (!DSL_Operator_Get_Info_Version(dsl_operator, version, &info))
         return DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID;
 
     id = DSL_IR_Image_Find_Opcode_Descriptor(dsl_operator, info.version);
@@ -838,6 +1296,7 @@ DSL_Builder_Get_Image_Opcode_Descriptor (DSL_OPERATOR dsl_operator)
 static BOOL
 DSL_Builder_Add_Image_Node
         (DSL_OPERATOR dsl_operator,
+         UINT16 version,
          const char *payload,
          DSL_BUILDER_VALUE_RECORD **operand_records,
          UINT32 operand_count,
@@ -856,7 +1315,8 @@ DSL_Builder_Add_Image_Node
         DSL_IR_VALUE_REFERENCE_INVALID_ID;
     DSL_IR_ATTRIBUTE_ID first_attribute_id = DSL_IR_ATTRIBUTE_INVALID_ID;
 
-    descriptor_id = DSL_Builder_Get_Image_Opcode_Descriptor(dsl_operator);
+    descriptor_id = DSL_Builder_Get_Image_Opcode_Descriptor
+                        (dsl_operator, version);
     if (descriptor_id == DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID)
         return FALSE;
 
@@ -970,7 +1430,7 @@ DSL_Builder_Create_Native_Value
                                result_ty, expression);
 
     if (!DSL_Builder_Add_Image_Node
-             (dsl_operator, payload, operand_records, kid_count, attrs,
+             (dsl_operator, version, payload, operand_records, kid_count, attrs,
               attr_count, result_st, result_ty, value_kind,
               &image_value_id)) {
         delete [] operand_records;
@@ -1419,15 +1879,25 @@ DSL_Builder_Create_Operator
 {
     DSL_OPCODE_INFO info;
     DSL_OPERATOR dsl_operator;
+    DSL_OPERATOR_INFO logical_info;
     char *payload;
     WN *wn;
 
-    if (!DSL_Opcode_Get_Info (opcode_id, &info))
+    if (!DSL_Opcode_Get_Info (opcode_id, &info) || info.version != version)
+        return NULL;
+
+    dsl_operator = DSL_Operator_Find(info.name, strlen(info.name), version);
+    if (dsl_operator != OPR_DSLUNKNOWN &&
+        (!DSL_Operator_Get_Info_Version
+              (dsl_operator, version, &logical_info) ||
+         (DSL_Builder_Requires_Exact_Attribute_Schema
+              (dsl_operator, version) &&
+          !DSL_Builder_Attributes_Match_Schema
+               (&logical_info, attrs, attr_count))))
         return NULL;
 
     payload = DSL_Builder_Format_Operator_Payload (kids, kid_count, attrs,
                                                    attr_count);
-    dsl_operator = DSL_Operator_Find(info.name, strlen(info.name), version);
     if ((dsl_operator == OPR_DSLADD || dsl_operator == OPR_DSLMATMUL ||
          dsl_operator == OPR_DSLLINEAR ||
          dsl_operator == OPR_DSLRELU || dsl_operator == OPR_DSLFLATTEN ||
@@ -1436,7 +1906,14 @@ DSL_Builder_Create_Operator
          dsl_operator == OPR_DSLBATCHNORMINFER ||
          dsl_operator == OPR_DSLMAXPOOL2D ||
          dsl_operator == OPR_DSLGLOBALAVGPOOL2D ||
-         dsl_operator == OPR_DSLOUTPUTLOGITS) && kid_count != 0) {
+         dsl_operator == OPR_DSLOUTPUTLOGITS ||
+         dsl_operator == OPR_DSLRESHAPE ||
+         dsl_operator == OPR_DSLTRANSPOSE ||
+         dsl_operator == OPR_DSLTOKENEMBEDDING ||
+         dsl_operator == OPR_DSLRMSNORM ||
+         dsl_operator == OPR_DSLROTARYEMBEDDING ||
+         dsl_operator == OPR_DSLATTENTION ||
+         dsl_operator == OPR_DSLSWIGLU) && kid_count != 0) {
         if ((info.nkids >= 0 && (UINT32)info.nkids != kid_count) ||
             (attr_count != 0 && attrs == NULL)) {
             delete [] payload;
@@ -1464,7 +1941,8 @@ DSL_Builder_Create_Operator
                           "%s_type", result_name);
                 result_ty = second == NULL ? TY_IDX_ZERO :
                     DSL_Builder_Create_Matmul_Result_Type
-                        (first->result_ty, second->result_ty,
+                        (version, first->result_ty, second->result_ty,
+                         attrs, attr_count,
                          result_type_name);
                 if (result_ty == TY_IDX_ZERO) {
                     delete [] payload;
@@ -1477,9 +1955,11 @@ DSL_Builder_Create_Operator
                     DSL_Builder_Find_Value_Record(kids[2]);
                 snprintf (result_type_name, sizeof(result_type_name),
                           "%s_type", result_name);
-                result_ty = weight == NULL || bias == NULL ? TY_IDX_ZERO :
+                result_ty = weight == NULL ||
+                            (version == 2 && bias == NULL) ? TY_IDX_ZERO :
                     DSL_Builder_Create_Linear_Result_Type
-                        (first->result_ty, weight->result_ty, bias->result_ty,
+                        (version, first->result_ty, weight->result_ty,
+                         bias == NULL ? TY_IDX_ZERO : bias->result_ty,
                          attrs, attr_count, result_type_name);
                 if (result_ty == TY_IDX_ZERO) {
                     delete [] payload;
@@ -1526,6 +2006,46 @@ DSL_Builder_Create_Operator
                 result_ty = DSL_Builder_Create_Global_Avg_Pool_Result_Type
                                 (first->result_ty, attrs, attr_count,
                                  result_type_name);
+                if (result_ty == TY_IDX_ZERO) {
+                    delete [] payload;
+                    return NULL;
+                }
+            } else if (dsl_operator == OPR_DSLRESHAPE) {
+                snprintf (result_type_name, sizeof(result_type_name),
+                          "%s_type", result_name);
+                result_ty = DSL_Builder_Create_Reshape_Result_Type
+                                (first->result_ty, attrs, attr_count,
+                                 result_type_name);
+                if (result_ty == TY_IDX_ZERO) {
+                    delete [] payload;
+                    return NULL;
+                }
+            } else if (dsl_operator == OPR_DSLTRANSPOSE) {
+                snprintf (result_type_name, sizeof(result_type_name),
+                          "%s_type", result_name);
+                result_ty = DSL_Builder_Create_Transpose_Result_Type
+                                (first->result_ty, attrs, attr_count,
+                                 result_type_name);
+                if (result_ty == TY_IDX_ZERO) {
+                    delete [] payload;
+                    return NULL;
+                }
+            } else if (dsl_operator == OPR_DSLTOKENEMBEDDING ||
+                       dsl_operator == OPR_DSLRMSNORM ||
+                       dsl_operator == OPR_DSLROTARYEMBEDDING ||
+                       dsl_operator == OPR_DSLATTENTION ||
+                       dsl_operator == OPR_DSLSWIGLU) {
+                DSL_BUILDER_VALUE_RECORD *second = kid_count < 2 ? NULL :
+                    DSL_Builder_Find_Value_Record(kids[1]);
+                DSL_BUILDER_VALUE_RECORD *third = kid_count < 3 ? NULL :
+                    DSL_Builder_Find_Value_Record(kids[2]);
+                snprintf (result_type_name, sizeof(result_type_name),
+                          "%s_type", result_name);
+                result_ty = second == NULL ? TY_IDX_ZERO :
+                    DSL_Builder_Create_Transformer_Result_Type
+                        (dsl_operator, first->result_ty, second->result_ty,
+                         third == NULL ? TY_IDX_ZERO : third->result_ty,
+                         attrs, attr_count, result_type_name);
                 if (result_ty == TY_IDX_ZERO) {
                     delete [] payload;
                     return NULL;
@@ -1591,10 +2111,11 @@ DSL_Builder_Create_Operator_With_Result
 {
     DSL_OPCODE_INFO info;
     DSL_OPERATOR dsl_operator;
+    DSL_OPERATOR_INFO logical_info;
     char *payload;
     DSL_BUILDER_OPERATOR result;
 
-    if (!DSL_Opcode_Get_Info(opcode_id, &info) ||
+    if (!DSL_Opcode_Get_Info(opcode_id, &info) || info.version != version ||
         result_name == NULL || result_name[0] == '\0' ||
         !DSL_Builder_Tensor_Type_Is_Canonical(result_ty) ||
         (kid_count != 0 && kids == NULL) ||
@@ -1608,7 +2129,13 @@ DSL_Builder_Create_Operator_With_Result
     }
 
     dsl_operator = DSL_Operator_Find(info.name, strlen(info.name), version);
-    if (dsl_operator == OPR_DSLUNKNOWN)
+    if (dsl_operator == OPR_DSLUNKNOWN ||
+        !DSL_Operator_Get_Info_Version
+             (dsl_operator, version, &logical_info) ||
+        (DSL_Builder_Requires_Exact_Attribute_Schema
+             (dsl_operator, version) &&
+         !DSL_Builder_Attributes_Match_Schema
+              (&logical_info, attrs, attr_count)))
         return NULL;
 
     payload = DSL_Builder_Format_Operator_Payload
@@ -1950,6 +2477,14 @@ DSL_Builder_Append_Region_Value
 }
 
 BOOL
+DSL_Builder_Append_Child_Region
+        (DSL_BUILDER_REGION parent,
+         DSL_BUILDER_REGION child)
+{
+    return DSL_Region_Append_Child(parent, child);
+}
+
+BOOL
 DSL_Builder_Append_PU_Region
         (DSL_BUILDER_PROGRAM_UNIT pu,
          DSL_BUILDER_REGION region)
@@ -1970,6 +2505,15 @@ DSL_Builder_Declare_Region_Value
     return record != NULL &&
            DSL_Region_Declare_Symbol
                (region, record->result_st, roles, ordinal, flags);
+}
+
+BOOL
+DSL_Builder_Set_Region_Metadata
+        (DSL_BUILDER_REGION region,
+         const char *key,
+         const char *value)
+{
+    return DSL_Region_Set_Metadata(region, key, value);
 }
 
 BOOL

--- a/osprey/common/com/dsl_builder.h
+++ b/osprey/common/com/dsl_builder.h
@@ -213,6 +213,9 @@ extern DSL_BUILDER_REGION DSL_Builder_Create_Region
 extern BOOL DSL_Builder_Append_Region_Value
                                 (DSL_BUILDER_REGION region,
                                  DSL_BUILDER_VALUE value);
+extern BOOL DSL_Builder_Append_Child_Region
+                                (DSL_BUILDER_REGION parent,
+                                 DSL_BUILDER_REGION child);
 extern BOOL DSL_Builder_Append_PU_Region
                                 (DSL_BUILDER_PROGRAM_UNIT pu,
                                  DSL_BUILDER_REGION region);
@@ -226,6 +229,10 @@ extern BOOL DSL_Builder_Set_Region_Source_Position
                                 (DSL_BUILDER_REGION region,
                                  const DSL_BUILDER_SOURCE_POSITION
                                      *source_position);
+extern BOOL DSL_Builder_Set_Region_Metadata
+                                (DSL_BUILDER_REGION region,
+                                 const char *key,
+                                 const char *value);
 extern BOOL DSL_Builder_Verify_Program
                                 (DSL_BUILDER_VERIFY_RESULT *result);
 /*

--- a/osprey/common/com/dsl_gatekeeper.cxx
+++ b/osprey/common/com/dsl_gatekeeper.cxx
@@ -4,6 +4,7 @@
 
 #include <stdarg.h>
 #include <ctype.h>
+#include <float.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
@@ -391,6 +392,39 @@ DSL_Gatekeeper_Parse_Static_Shape
     return *cursor == '\0';
 }
 
+static BOOL
+DSL_Gatekeeper_Parse_Unsigned_List
+        (const char *text,
+         BOOL allow_zero,
+         std::vector<UINT64> *values)
+{
+    if (text == NULL || values == NULL || text[0] == '\0')
+        return FALSE;
+
+    values->clear();
+    const char *cursor = text;
+    while (*cursor != '\0') {
+        if (!isdigit((unsigned char)*cursor))
+            return FALSE;
+        UINT64 value = 0;
+        while (isdigit((unsigned char)*cursor)) {
+            UINT64 digit = (UINT64)(*cursor - '0');
+            if (value > (~(UINT64)0 - digit) / 10)
+                return FALSE;
+            value = value * 10 + digit;
+            ++cursor;
+        }
+        if (!allow_zero && value == 0)
+            return FALSE;
+        values->push_back(value);
+        if (*cursor == '\0')
+            break;
+        if (*cursor++ != ',' || *cursor == '\0')
+            return FALSE;
+    }
+    return !values->empty();
+}
+
 static BOOL DSL_Gatekeeper_Parse_Unsigned(const char *, UINT64 *);
 
 static BOOL
@@ -457,14 +491,41 @@ DSL_Gatekeeper_Result_Dimensions
 }
 
 static BOOL
+DSL_Gatekeeper_Computed_Result_Dimensions
+        (TY_IDX input_ty,
+         TY_IDX result_ty,
+         const std::vector<UINT64> &expected)
+{
+    std::vector<UINT64> result;
+    const char *placement =
+        TY_tensor_attribute(result_ty, TY_TENSOR_SCHEMA_PLACEMENT);
+    const char *memory =
+        TY_tensor_attribute(result_ty, TY_TENSOR_SCHEMA_MEMORY);
+    return DSL_Gatekeeper_Static_Dimensions(result_ty, &result) &&
+           DSL_Gatekeeper_Dimensions_Equal(result, expected) &&
+           DSL_Gatekeeper_Tensor_Element_Type_Compatible
+               (input_ty, result_ty) &&
+           DSL_Gatekeeper_Tensor_Key_Equal
+               (input_ty, result_ty, TY_TENSOR_SCHEMA_LAYOUT) &&
+           DSL_Gatekeeper_Tensor_Key_Equal
+               (input_ty, result_ty, TY_TENSOR_SCHEMA_QUANTIZATION) &&
+           (placement == NULL || strcmp(placement, "side_file") != 0) &&
+           (memory == NULL || strcmp(memory, "external_data") != 0);
+}
+
+static BOOL
 DSL_Gatekeeper_Linear_Result_Valid
         (const DSL_IR_NODE_RECORD *node,
          const std::vector<TY_IDX> &operands,
-         TY_IDX result_ty)
+         TY_IDX result_ty,
+         UINT16 version)
 {
-    if (operands.size() != 3 ||
+    UINT32 expected_operands = version == 2 ? 3 : 2;
+    const char *expected_bias = version == 2 ? "true" : "false";
+    if ((version != 2 && version != 3) ||
+        operands.size() != expected_operands ||
         !DSL_Gatekeeper_Attribute_Equals
-             (node, "attr.has_bias", "true") ||
+             (node, "attr.has_bias", expected_bias) ||
         !DSL_Gatekeeper_Attribute_Equals
              (node, "attr.transpose_input", "false") ||
         !DSL_Gatekeeper_Attribute_Equals
@@ -478,17 +539,324 @@ DSL_Gatekeeper_Linear_Result_Valid
     std::vector<UINT64> bias;
     if (!DSL_Gatekeeper_Static_Dimensions(operands[0], &input) ||
         !DSL_Gatekeeper_Static_Dimensions(operands[1], &weight) ||
-        !DSL_Gatekeeper_Static_Dimensions(operands[2], &bias) ||
-        input.empty() || weight.size() != 2 || bias.size() != 1 ||
-        input[input.size() - 1] != weight[1] || bias[0] != weight[0] ||
+        input.size() < 2 || weight.size() != 2 ||
+        input[input.size() - 1] != weight[1] ||
         !DSL_Gatekeeper_Tensor_Element_Type_Compatible
-             (operands[0], operands[1]) ||
-        !DSL_Gatekeeper_Tensor_Element_Type_Compatible
-             (operands[0], operands[2]))
+             (operands[0], operands[1]))
+        return FALSE;
+    if (version == 2 &&
+        (!DSL_Gatekeeper_Static_Dimensions(operands[2], &bias) ||
+         bias.size() != 1 || bias[0] != weight[0] ||
+         !DSL_Gatekeeper_Tensor_Element_Type_Compatible
+             (operands[0], operands[2])))
         return FALSE;
     input[input.size() - 1] = weight[0];
     return DSL_Gatekeeper_Result_Dimensions
                (operands[0], result_ty, input);
+}
+
+static BOOL
+DSL_Gatekeeper_Reshape_Result_Valid
+        (const DSL_IR_NODE_RECORD *node,
+         TY_IDX input_ty,
+         TY_IDX result_ty)
+{
+    const char *target_shape = NULL;
+    std::vector<UINT64> input;
+    std::vector<UINT64> target;
+    std::vector<UINT64> result;
+    if (!DSL_Gatekeeper_Node_Attribute
+             (node, "attr.target_shape", &target_shape) ||
+        !DSL_Gatekeeper_Static_Dimensions(input_ty, &input) ||
+        !DSL_Gatekeeper_Parse_Unsigned_List
+             (target_shape, FALSE, &target) ||
+        !DSL_Gatekeeper_Static_Dimensions(result_ty, &result) ||
+        !DSL_Gatekeeper_Dimensions_Equal(target, result))
+        return FALSE;
+
+    UINT64 input_elements = 1;
+    UINT64 target_elements = 1;
+    for (UINT32 i = 0; i < input.size(); ++i) {
+        if (input_elements > ~(UINT64)0 / input[i])
+            return FALSE;
+        input_elements *= input[i];
+    }
+    for (UINT32 i = 0; i < target.size(); ++i) {
+        if (target_elements > ~(UINT64)0 / target[i])
+            return FALSE;
+        target_elements *= target[i];
+    }
+    return input_elements == target_elements &&
+           DSL_Gatekeeper_Tensor_Element_Representation_Compatible
+               (input_ty, result_ty);
+}
+
+static BOOL
+DSL_Gatekeeper_Transpose_Result_Valid
+        (const DSL_IR_NODE_RECORD *node,
+         TY_IDX input_ty,
+         TY_IDX result_ty)
+{
+    const char *permutation_text = NULL;
+    std::vector<UINT64> input;
+    std::vector<UINT64> permutation;
+    std::vector<UINT64> expected;
+    if (!DSL_Gatekeeper_Node_Attribute
+             (node, "attr.permutation", &permutation_text) ||
+        !DSL_Gatekeeper_Static_Dimensions(input_ty, &input) ||
+        !DSL_Gatekeeper_Parse_Unsigned_List
+             (permutation_text, TRUE, &permutation) ||
+        permutation.size() != input.size())
+        return FALSE;
+
+    std::vector<BOOL> seen(input.size(), FALSE);
+    expected.resize(input.size());
+    for (UINT32 i = 0; i < permutation.size(); ++i) {
+        if (permutation[i] >= input.size() || seen[permutation[i]])
+            return FALSE;
+        seen[permutation[i]] = TRUE;
+        expected[i] = input[permutation[i]];
+    }
+    return DSL_Gatekeeper_Result_Dimensions(input_ty, result_ty, expected);
+}
+
+static BOOL
+DSL_Gatekeeper_Matmul_V2_Result_Valid
+        (const DSL_IR_NODE_RECORD *node,
+         TY_IDX kid0_ty,
+         TY_IDX kid1_ty,
+         TY_IDX result_ty)
+{
+    BOOL transpose_kid0;
+    BOOL transpose_kid1;
+    if (DSL_Gatekeeper_Attribute_Equals
+            (node, "attr.transpose_kid0", "true"))
+        transpose_kid0 = TRUE;
+    else if (DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.transpose_kid0", "false"))
+        transpose_kid0 = FALSE;
+    else
+        return FALSE;
+    if (DSL_Gatekeeper_Attribute_Equals
+            (node, "attr.transpose_kid1", "true"))
+        transpose_kid1 = TRUE;
+    else if (DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.transpose_kid1", "false"))
+        transpose_kid1 = FALSE;
+    else
+        return FALSE;
+    if (!DSL_Gatekeeper_Attribute_Equals
+             (node, "attr.batch_rule", "exact") ||
+        !DSL_Gatekeeper_Attribute_Equals
+             (node, "attr.accum_dtype", "float32"))
+        return FALSE;
+
+    std::vector<UINT64> kid0;
+    std::vector<UINT64> kid1;
+    if (!DSL_Gatekeeper_Static_Dimensions(kid0_ty, &kid0) ||
+        !DSL_Gatekeeper_Static_Dimensions(kid1_ty, &kid1) ||
+        kid0.size() < 2 || kid0.size() != kid1.size() ||
+        !DSL_Gatekeeper_Tensor_Element_Representation_Compatible
+             (kid0_ty, kid1_ty))
+        return FALSE;
+    for (UINT32 i = 0; i + 2 < kid0.size(); ++i) {
+        if (kid0[i] != kid1[i])
+            return FALSE;
+    }
+
+    UINT32 rank = kid0.size();
+    UINT64 left_m = kid0[rank - (transpose_kid0 ? 1 : 2)];
+    UINT64 left_k = kid0[rank - (transpose_kid0 ? 2 : 1)];
+    UINT64 right_k = kid1[rank - (transpose_kid1 ? 1 : 2)];
+    UINT64 right_n = kid1[rank - (transpose_kid1 ? 2 : 1)];
+    if (left_k != right_k)
+        return FALSE;
+
+    std::vector<UINT64> expected = kid0;
+    expected[rank - 2] = left_m;
+    expected[rank - 1] = right_n;
+    return DSL_Gatekeeper_Result_Dimensions(kid0_ty, result_ty, expected);
+}
+
+static BOOL
+DSL_Gatekeeper_Output_Logits_Result_Valid
+        (const DSL_IR_NODE_RECORD *node,
+         TY_IDX input_ty,
+         TY_IDX result_ty,
+         UINT16 version)
+{
+    if (!DSL_Gatekeeper_Tensor_Compatible(input_ty, result_ty, TRUE))
+        return FALSE;
+    if (version == 2)
+        return DSL_Gatekeeper_Attribute_Equals
+                   (node, "attr.semantic", "logits");
+    if (version != 3 ||
+        !DSL_Gatekeeper_Attribute_Equals
+             (node, "attr.semantic", "token_logits") ||
+        !DSL_Gatekeeper_Attribute_Equals
+             (node, "attr.sequence_axis", "-2") ||
+        !DSL_Gatekeeper_Attribute_Equals
+             (node, "attr.vocabulary_axis", "-1"))
+        return FALSE;
+
+    std::vector<UINT64> dimensions;
+    return DSL_Gatekeeper_Static_Dimensions(input_ty, &dimensions) &&
+           dimensions.size() == 3;
+}
+
+static BOOL
+DSL_Gatekeeper_Positive_Float_Attribute
+        (const DSL_IR_NODE_RECORD *node,
+         const char *name)
+{
+    const char *text = NULL;
+    if (!DSL_Gatekeeper_Node_Attribute(node, name, &text) ||
+        text == NULL || text[0] == '\0')
+        return FALSE;
+    char *end = NULL;
+    double value = strtod(text, &end);
+    return end != text && *end == '\0' && value > 0.0 && value <= DBL_MAX;
+}
+
+static BOOL
+DSL_Gatekeeper_Transformer_Result_Valid
+        (DSL_OPERATOR dsl_operator,
+         const DSL_IR_NODE_RECORD *node,
+         const std::vector<TY_IDX> &operands,
+         TY_IDX result_ty)
+{
+    const UINT32 expected_operands =
+        dsl_operator == OPR_DSLROTARYEMBEDDING ||
+        dsl_operator == OPR_DSLATTENTION ? 3 : 2;
+    if (operands.size() != expected_operands)
+        return FALSE;
+
+    std::vector<UINT64> kid0;
+    std::vector<UINT64> kid1;
+    std::vector<UINT64> kid2;
+    if (!DSL_Gatekeeper_Static_Dimensions(operands[0], &kid0) ||
+        !DSL_Gatekeeper_Static_Dimensions(operands[1], &kid1))
+        return FALSE;
+
+    if (dsl_operator == OPR_DSLTOKENEMBEDDING) {
+        const char *token_dtype =
+            TY_tensor_attribute(operands[0], TY_TENSOR_SCHEMA_DTYPE);
+        const char *weight_dtype =
+            TY_tensor_attribute(operands[1], TY_TENSOR_SCHEMA_DTYPE);
+        if (kid0.size() != 2 || kid1.size() != 2 ||
+            token_dtype == NULL || strcmp(token_dtype, "int64") != 0 ||
+            weight_dtype == NULL || strcmp(weight_dtype, "float32") != 0 ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.padding_idx", "none") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.bounds_policy", "runtime_check"))
+            return FALSE;
+        std::vector<UINT64> expected;
+        expected.push_back(kid0[0]);
+        expected.push_back(kid0[1]);
+        expected.push_back(kid1[1]);
+        return DSL_Gatekeeper_Computed_Result_Dimensions
+                   (operands[1], result_ty, expected);
+    }
+
+    const char *activation_dtype =
+        TY_tensor_attribute(operands[0], TY_TENSOR_SCHEMA_DTYPE);
+    if (activation_dtype == NULL || strcmp(activation_dtype, "float32") != 0)
+        return FALSE;
+
+    if (dsl_operator == OPR_DSLRMSNORM) {
+        return kid0.size() >= 2 && kid1.size() == 1 &&
+               kid1[0] == kid0[kid0.size() - 1] &&
+               DSL_Gatekeeper_Tensor_Element_Type_Compatible
+                   (operands[0], operands[1]) &&
+               DSL_Gatekeeper_Attribute_Equals(node, "attr.axis", "-1") &&
+               DSL_Gatekeeper_Positive_Float_Attribute
+                   (node, "attr.epsilon") &&
+               DSL_Gatekeeper_Attribute_Equals
+                   (node, "attr.accum_dtype", "float32") &&
+               DSL_Gatekeeper_Result_Dimensions
+                   (operands[0], result_ty, kid0);
+    }
+
+    if (dsl_operator == OPR_DSLROTARYEMBEDDING) {
+        if (!DSL_Gatekeeper_Static_Dimensions(operands[2], &kid2) ||
+            kid0.size() != 4 || kid1.size() != 4 ||
+            !DSL_Gatekeeper_Dimensions_Equal(kid1, kid2) ||
+            kid1[0] != 1 || kid1[1] != 1 || kid1[2] != kid0[2] ||
+            kid1[3] != kid0[3] || kid0[3] % 2 != 0 ||
+            !DSL_Gatekeeper_Tensor_Element_Type_Compatible
+                 (operands[0], operands[1]) ||
+            !DSL_Gatekeeper_Tensor_Element_Type_Compatible
+                 (operands[0], operands[2]) ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.head_layout", "BHSD") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.sequence_axis", "2") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.feature_axis", "3") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.pairing", "half_split") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.position_mode", "zero_based_static") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.position_offset", "0"))
+            return FALSE;
+        return DSL_Gatekeeper_Result_Dimensions
+                   (operands[0], result_ty, kid0);
+    }
+
+    if (dsl_operator == OPR_DSLATTENTION) {
+        const char *query_heads_text = NULL;
+        const char *kv_heads_text = NULL;
+        const char *head_dim_text = NULL;
+        UINT64 query_heads;
+        UINT64 kv_heads;
+        UINT64 head_dim;
+        if (!DSL_Gatekeeper_Static_Dimensions(operands[2], &kid2) ||
+            kid0.size() != 4 ||
+            !DSL_Gatekeeper_Dimensions_Equal(kid0, kid1) ||
+            !DSL_Gatekeeper_Dimensions_Equal(kid0, kid2) ||
+            !DSL_Gatekeeper_Tensor_Element_Representation_Compatible
+                 (operands[0], operands[1]) ||
+            !DSL_Gatekeeper_Tensor_Element_Representation_Compatible
+                 (operands[0], operands[2]) ||
+            !DSL_Gatekeeper_Node_Attribute
+                 (node, "attr.query_heads", &query_heads_text) ||
+            !DSL_Gatekeeper_Node_Attribute
+                 (node, "attr.kv_heads", &kv_heads_text) ||
+            !DSL_Gatekeeper_Node_Attribute
+                 (node, "attr.head_dim", &head_dim_text) ||
+            !DSL_Gatekeeper_Parse_Unsigned(query_heads_text, &query_heads) ||
+            !DSL_Gatekeeper_Parse_Unsigned(kv_heads_text, &kv_heads) ||
+            !DSL_Gatekeeper_Parse_Unsigned(head_dim_text, &head_dim) ||
+            query_heads == 0 || query_heads != kv_heads || head_dim == 0 ||
+            query_heads != kid0[1] || head_dim != kid0[3] ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.execution_mode", "full_sequence") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.mask_mode", "causal") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.head_layout", "BHSD") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.scale_mode", "inverse_sqrt_head_dim") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.softmax_axis", "-1") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.softmax_accum_dtype", "float32") ||
+            !DSL_Gatekeeper_Attribute_Equals
+                 (node, "attr.cache_mode", "none"))
+            return FALSE;
+        return DSL_Gatekeeper_Result_Dimensions
+                   (operands[0], result_ty, kid0);
+    }
+
+    return dsl_operator == OPR_DSLSWIGLU && kid0.size() == 3 &&
+           DSL_Gatekeeper_Dimensions_Equal(kid0, kid1) &&
+           DSL_Gatekeeper_Tensor_Element_Representation_Compatible
+               (operands[0], operands[1]) &&
+           DSL_Gatekeeper_Attribute_Equals
+               (node, "attr.activation", "silu") &&
+           DSL_Gatekeeper_Result_Dimensions(operands[0], result_ty, kid0);
 }
 
 static BOOL
@@ -938,6 +1306,7 @@ DSL_Gatekeeper_Required_Attributes
                          Index_To_Str(descriptor->attribute_schema);
     const char *cursor = schema;
     BOOL valid = TRUE;
+    UINT32 required_count = 0;
 
     while (*cursor != '\0') {
         const char *end = strchr(cursor, ';');
@@ -946,16 +1315,40 @@ DSL_Gatekeeper_Required_Attributes
         char *name = new char[length + 1];
         memcpy (name, cursor, length);
         name[length] = '\0';
-        if (length != 0 && !DSL_Gatekeeper_Node_Has_Attribute(node, name))
-            valid = DSL_Gatekeeper_Report
-                        (context, "%s.v%u is missing typed attribute %s",
-                         Index_To_Str(descriptor->stable_name),
-                         descriptor->version, name);
+        if (length != 0) {
+            ++required_count;
+            if (!DSL_Gatekeeper_Node_Has_Attribute(node, name))
+                valid = DSL_Gatekeeper_Report
+                            (context, "%s.v%u is missing typed attribute %s",
+                             Index_To_Str(descriptor->stable_name),
+                             descriptor->version, name);
+        }
         delete [] name;
         if (end == NULL)
             break;
         cursor = end + 1;
     }
+    DSL_OPERATOR dsl_operator =
+        (DSL_OPERATOR)descriptor->logical_operator;
+    BOOL exact_schema = dsl_operator == OPR_DSLRESHAPE ||
+                        dsl_operator == OPR_DSLTRANSPOSE ||
+                        dsl_operator == OPR_DSLTOKENEMBEDDING ||
+                        dsl_operator == OPR_DSLRMSNORM ||
+                        dsl_operator == OPR_DSLROTARYEMBEDDING ||
+                        dsl_operator == OPR_DSLATTENTION ||
+                        dsl_operator == OPR_DSLSWIGLU ||
+                        (dsl_operator == OPR_DSLMATMUL &&
+                         descriptor->version == 2) ||
+                        (dsl_operator == OPR_DSLLINEAR &&
+                         descriptor->version == 3) ||
+                        (dsl_operator == OPR_DSLOUTPUTLOGITS &&
+                         descriptor->version == 3);
+    if (exact_schema && node->attribute_count != required_count)
+        valid = DSL_Gatekeeper_Report
+                    (context, "%s.v%u requires exactly %u typed attributes, "
+                     "found %u", Index_To_Str(descriptor->stable_name),
+                     descriptor->version, required_count,
+                     node->attribute_count);
     return valid;
 }
 
@@ -979,8 +1372,8 @@ DSL_Gatekeeper_Verify_Native_Node
     if (!DSL_WN_Get_Logical_Opcode(expression, &logical_opcode,
                                    context->diagnostic) ||
         (dsl_operator = logical_opcode.dsl_operator) == OPR_DSLUNKNOWN ||
-        !DSL_Operator_Get_Info(dsl_operator, &info) ||
-        info.version != logical_opcode.effective_version ||
+        !DSL_Operator_Get_Info_Version
+             (dsl_operator, logical_opcode.effective_version, &info) ||
         (info.nkids >= 0 && (UINT32)info.nkids != WN_kid_count(expression)))
         valid = DSL_Gatekeeper_Report
                     (context, "unsupported logical operator or version");
@@ -1063,15 +1456,25 @@ DSL_Gatekeeper_Verify_Native_Node
         valid = DSL_Gatekeeper_Report
                     (context, "OPR_DSLADD result tensor is incompatible "
                      "with its operands");
-    if (dsl_operator == OPR_DSLMATMUL && first_operand_ty != TY_IDX_ZERO &&
-        (second_operand_ty == TY_IDX_ZERO ||
-         !DSL_Gatekeeper_Tensor_Compatible
-              (first_operand_ty, result_ty, FALSE) ||
-         !DSL_Gatekeeper_Matmul_Shapes_Compatible
-              (first_operand_ty, second_operand_ty, result_ty)))
-        valid = DSL_Gatekeeper_Report
-                    (context, "OPR_DSLMATMUL result dtype or representation "
-                     "is incompatible with kid0");
+    if (dsl_operator == OPR_DSLMATMUL && first_operand_ty != TY_IDX_ZERO) {
+        BOOL matmul_valid = second_operand_ty != TY_IDX_ZERO && image_valid;
+        if (matmul_valid && logical_opcode.effective_version == 1)
+            matmul_valid = DSL_Gatekeeper_Tensor_Compatible
+                               (first_operand_ty, result_ty, FALSE) &&
+                           DSL_Gatekeeper_Matmul_Shapes_Compatible
+                               (first_operand_ty, second_operand_ty, result_ty);
+        else if (matmul_valid && logical_opcode.effective_version == 2)
+            matmul_valid = DSL_Gatekeeper_Matmul_V2_Result_Valid
+                               (&image_node, first_operand_ty,
+                                second_operand_ty, result_ty);
+        else
+            matmul_valid = FALSE;
+        if (!matmul_valid)
+            valid = DSL_Gatekeeper_Report
+                        (context, "OPR_DSLMATMUL.v%u tensor or attribute "
+                         "contract is invalid",
+                         logical_opcode.effective_version);
+    }
     if ((dsl_operator == OPR_DSLRELU ||
          dsl_operator == OPR_DSLRESIDUALADD ||
          dsl_operator == OPR_DSLOUTPUTLOGITS) &&
@@ -1089,7 +1492,8 @@ DSL_Gatekeeper_Verify_Native_Node
                     (context, "OPR_DSLFLATTEN result shape is invalid");
     if (image_valid && dsl_operator == OPR_DSLLINEAR &&
         !DSL_Gatekeeper_Linear_Result_Valid
-             (&image_node, operand_types, result_ty))
+             (&image_node, operand_types, result_ty,
+              logical_opcode.effective_version))
         valid = DSL_Gatekeeper_Report
                     (context, "OPR_DSLLINEAR tensor or attribute contract "
                      "is invalid");
@@ -1119,6 +1523,32 @@ DSL_Gatekeeper_Verify_Native_Node
         valid = DSL_Gatekeeper_Report
                     (context, "OPR_DSLGLOBALAVGPOOL2D result shape or "
                      "attribute contract is invalid");
+    if (image_valid && dsl_operator == OPR_DSLRESHAPE &&
+        (first_operand_ty == TY_IDX_ZERO ||
+         !DSL_Gatekeeper_Reshape_Result_Valid
+              (&image_node, first_operand_ty, result_ty)))
+        valid = DSL_Gatekeeper_Report
+                    (context, "OPR_DSLRESHAPE result shape or attribute "
+                     "contract is invalid");
+    if (image_valid && dsl_operator == OPR_DSLTRANSPOSE &&
+        (first_operand_ty == TY_IDX_ZERO ||
+         !DSL_Gatekeeper_Transpose_Result_Valid
+              (&image_node, first_operand_ty, result_ty)))
+        valid = DSL_Gatekeeper_Report
+                    (context, "OPR_DSLTRANSPOSE result shape or permutation "
+                     "contract is invalid");
+    if (image_valid &&
+        (dsl_operator == OPR_DSLTOKENEMBEDDING ||
+         dsl_operator == OPR_DSLRMSNORM ||
+         dsl_operator == OPR_DSLROTARYEMBEDDING ||
+         dsl_operator == OPR_DSLATTENTION ||
+         dsl_operator == OPR_DSLSWIGLU) &&
+        !DSL_Gatekeeper_Transformer_Result_Valid
+             (dsl_operator, &image_node, operand_types, result_ty))
+        valid = DSL_Gatekeeper_Report
+                    (context, "%s.v%u transformer expression contract is "
+                     "invalid", info.stable_name,
+                     logical_opcode.effective_version);
     if (image_valid && dsl_operator == OPR_DSLRESIDUALADD &&
         (!DSL_Gatekeeper_Attribute_Equals
              (&image_node, "attr.broadcast_rule", "none") ||
@@ -1130,10 +1560,13 @@ DSL_Gatekeeper_Verify_Native_Node
                     (context, "OPR_DSLRESIDUALADD requires exact no-broadcast "
                      "residual semantics");
     if (image_valid && dsl_operator == OPR_DSLOUTPUTLOGITS &&
-        !DSL_Gatekeeper_Attribute_Equals
-             (&image_node, "attr.semantic", "logits"))
+        (first_operand_ty == TY_IDX_ZERO ||
+         !DSL_Gatekeeper_Output_Logits_Result_Valid
+              (&image_node, first_operand_ty, result_ty,
+               logical_opcode.effective_version)))
         valid = DSL_Gatekeeper_Report
-                    (context, "OPR_DSLOUTPUTLOGITS requires semantic=logits");
+                    (context, "OPR_DSLOUTPUTLOGITS.v%u tensor or attribute "
+                     "contract is invalid", logical_opcode.effective_version);
     return valid;
 }
 

--- a/osprey/common/com/dsl_ir_image.cxx
+++ b/osprey/common/com/dsl_ir_image.cxx
@@ -152,9 +152,9 @@ DSL_IR_Image_View_Validate (const DSL_IR_IMAGE_VIEW *view, FILE *diagnostic)
             !DSL_IR_Image_String_Id_Valid(record.stable_name, TRUE) ||
             !DSL_IR_Image_String_Id_Valid(record.attribute_schema, FALSE) ||
             !DSL_IR_Image_String_Id_Valid(record.diagnostic_prefix, FALSE) ||
-            !DSL_Operator_Get_Info
-                 ((DSL_OPERATOR)record.logical_operator, &info) ||
-            info.version != record.version ||
+            !DSL_Operator_Get_Info_Version
+                 ((DSL_OPERATOR)record.logical_operator, record.version,
+                  &info) ||
             strcmp(Index_To_Str(record.logical_name), info.logical_name) != 0 ||
             strcmp(Index_To_Str(record.stable_name), info.stable_name) != 0)
             return DSL_IR_Image_Report

--- a/osprey/common/com/dsl_opcode.cxx
+++ b/osprey/common/com/dsl_opcode.cxx
@@ -128,7 +128,14 @@ static const char *DSL_operator_name[] = {
     "OPR_DSLCONV2D",
     "OPR_DSLBATCHNORMINFER",
     "OPR_DSLMAXPOOL2D",
-    "OPR_DSLGLOBALAVGPOOL2D"
+    "OPR_DSLGLOBALAVGPOOL2D",
+    "OPR_DSLRESHAPE",
+    "OPR_DSLTRANSPOSE",
+    "OPR_DSLTOKENEMBEDDING",
+    "OPR_DSLRMSNORM",
+    "OPR_DSLROTARYEMBEDDING",
+    "OPR_DSLATTENTION",
+    "OPR_DSLSWIGLU"
 };
 
 static const char *DSL_cprom_diagnostic_code[] = {
@@ -460,6 +467,12 @@ static const DSL_LOGICAL_OPERATOR_SEED DSL_logical_operator_seed[] = {
         DSL_SHAPE_RULE_CONTRACTION, DSL_EFFECT_MODEL_PURE,
         DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_MATMUL",
         "attr.transpose_kid0;attr.transpose_kid1" },
+    { OPR_DSLMATMUL, "common.matmul", 2,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_2_NUMERIC, 2,
+        DSL_SHAPE_RULE_CONTRACTION, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_MATMUL_V2",
+        "attr.transpose_kid0;attr.transpose_kid1;attr.batch_rule;"
+        "attr.accum_dtype" },
     { OPR_DSLMODELINPUT, "common.model_input", 2,
         DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_3_NN_COMMON, 0,
         DSL_SHAPE_RULE_OPAQUE, DSL_EFFECT_MODEL_PURE,
@@ -485,11 +498,22 @@ static const DSL_LOGICAL_OPERATOR_SEED DSL_logical_operator_seed[] = {
         DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_LINEAR_V2",
         "attr.has_bias;attr.transpose_input;attr.transpose_weight;"
         "attr.weight_layout" },
+    { OPR_DSLLINEAR, "common.linear", 3,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_2_NUMERIC, 2,
+        DSL_SHAPE_RULE_CONTRACTION, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_LINEAR_V3",
+        "attr.has_bias;attr.transpose_input;attr.transpose_weight;"
+        "attr.weight_layout" },
     { OPR_DSLOUTPUTLOGITS, "common.output_logits", 2,
         DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_3_NN_COMMON, 1,
         DSL_SHAPE_RULE_IDENTITY, DSL_EFFECT_MODEL_PURE,
         DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_OUTPUT_LOGITS_V2",
         "attr.semantic" },
+    { OPR_DSLOUTPUTLOGITS, "common.output_logits", 3,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_3_NN_COMMON, 1,
+        DSL_SHAPE_RULE_IDENTITY, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_OUTPUT_LOGITS_V3",
+        "attr.semantic;attr.sequence_axis;attr.vocabulary_axis" },
     { OPR_DSLCONV2D, "cnn.conv2d", 2,
         DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_3_NN_COMMON, 3,
         DSL_SHAPE_RULE_CONTRACTION, DSL_EFFECT_MODEL_PURE,
@@ -511,28 +535,84 @@ static const DSL_LOGICAL_OPERATOR_SEED DSL_logical_operator_seed[] = {
         DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_3_NN_COMMON, 1,
         DSL_SHAPE_RULE_REDUCTION, DSL_EFFECT_MODEL_PURE,
         DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_CNN_GLOBAL_AVG_POOL2D_V2",
-        "attr.output_size;attr.reduction_axes" }
+        "attr.output_size;attr.reduction_axes" },
+    { OPR_DSLRESHAPE, "common.reshape", 1,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_1_TENSOR, 1,
+        DSL_SHAPE_RULE_VIEW, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_RESHAPE_V1",
+        "attr.target_shape" },
+    { OPR_DSLTRANSPOSE, "common.transpose", 1,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_1_TENSOR, 1,
+        DSL_SHAPE_RULE_VIEW, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_TRANSPOSE_V1",
+        "attr.permutation" },
+    { OPR_DSLTOKENEMBEDDING, "transformer.token_embedding", 1,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_3_NN_COMMON, 2,
+        DSL_SHAPE_RULE_OPAQUE, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_RUNTIME_CALL,
+        "DOPC_TRANSFORMER_TOKEN_EMBEDDING_V1",
+        "attr.padding_idx;attr.bounds_policy" },
+    { OPR_DSLRMSNORM, "transformer.rms_norm", 1,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_3_NN_COMMON, 2,
+        DSL_SHAPE_RULE_REDUCTION, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_TRANSFORMER_RMS_NORM_V1",
+        "attr.axis;attr.epsilon;attr.accum_dtype" },
+    { OPR_DSLROTARYEMBEDDING, "transformer.rotary_embedding", 1,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_3_NN_COMMON, 3,
+        DSL_SHAPE_RULE_IDENTITY, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_RUNTIME_CALL,
+        "DOPC_TRANSFORMER_ROTARY_EMBEDDING_V1",
+        "attr.head_layout;attr.sequence_axis;attr.feature_axis;attr.pairing;"
+        "attr.position_mode;attr.position_offset" },
+    { OPR_DSLATTENTION, "transformer.attention", 1,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_3_NN_COMMON, 3,
+        DSL_SHAPE_RULE_CONTRACTION, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_TRANSFORMER_ATTENTION_V1",
+        "attr.execution_mode;attr.mask_mode;attr.head_layout;"
+        "attr.query_heads;attr.kv_heads;attr.head_dim;attr.scale_mode;"
+        "attr.softmax_axis;attr.softmax_accum_dtype;attr.cache_mode" },
+    { OPR_DSLSWIGLU, "transformer.swiglu", 1,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_3_NN_COMMON, 2,
+        DSL_SHAPE_RULE_BROADCAST, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_TRANSFORMER_SWIGLU_V1",
+        "attr.activation" }
 };
 
 static const DSL_LOGICAL_OPERATOR_SEED *
 DSL_Operator_Seed (DSL_OPERATOR dsl_operator)
 {
+    const DSL_LOGICAL_OPERATOR_SEED *current = NULL;
+
     for (UINT32 i = 0; i < DSL_ARRAY_COUNT(DSL_logical_operator_seed); ++i) {
-        if (DSL_logical_operator_seed[i].dsl_operator == dsl_operator)
+        if (DSL_logical_operator_seed[i].dsl_operator == dsl_operator &&
+            (current == NULL ||
+             DSL_logical_operator_seed[i].version > current->version))
+            current = &DSL_logical_operator_seed[i];
+    }
+
+    return current;
+}
+
+static const DSL_LOGICAL_OPERATOR_SEED *
+DSL_Operator_Seed_Version
+        (DSL_OPERATOR dsl_operator,
+         UINT16 version)
+{
+    for (UINT32 i = 0; i < DSL_ARRAY_COUNT(DSL_logical_operator_seed); ++i) {
+        if (DSL_logical_operator_seed[i].dsl_operator == dsl_operator &&
+            DSL_logical_operator_seed[i].version == version)
             return &DSL_logical_operator_seed[i];
     }
 
     return NULL;
 }
 
-BOOL
-DSL_Operator_Get_Info
-        (DSL_OPERATOR dsl_operator,
+static BOOL
+DSL_Operator_Copy_Info
+        (const DSL_LOGICAL_OPERATOR_SEED *seed,
          DSL_OPERATOR_INFO *info)
 {
-    const DSL_LOGICAL_OPERATOR_SEED *seed = DSL_Operator_Seed(dsl_operator);
-
-    if (seed == NULL || dsl_operator == OPR_DSLUNKNOWN)
+    if (seed == NULL || seed->dsl_operator == OPR_DSLUNKNOWN)
         return FALSE;
 
     if (info != NULL) {
@@ -552,6 +632,28 @@ DSL_Operator_Get_Info
     }
 
     return TRUE;
+}
+
+BOOL
+DSL_Operator_Get_Info
+        (DSL_OPERATOR dsl_operator,
+         DSL_OPERATOR_INFO *info)
+{
+    const DSL_LOGICAL_OPERATOR_SEED *seed = DSL_Operator_Seed(dsl_operator);
+
+    return DSL_Operator_Copy_Info(seed, info);
+}
+
+BOOL
+DSL_Operator_Get_Info_Version
+        (DSL_OPERATOR dsl_operator,
+         UINT16 version,
+         DSL_OPERATOR_INFO *info)
+{
+    const DSL_LOGICAL_OPERATOR_SEED *seed =
+        DSL_Operator_Seed_Version(dsl_operator, version);
+
+    return DSL_Operator_Copy_Info(seed, info);
 }
 
 DSL_OPERATOR
@@ -926,14 +1028,15 @@ DSL_Opcode_At (UINT32 ordinal, DSL_OPCODE_INFO *info)
 static UINT32
 DSL_Opcode_Register_Logical_Domain
         (const char *domain_name,
-         DSL_DOMAIN_ID domain_id)
+         DSL_DOMAIN_ID domain_id,
+         UINT16 minimum_version)
 {
     size_t domain_length = strlen(domain_name);
     UINT32 registered = 0;
 
     for (UINT32 i = 0; i < DSL_ARRAY_COUNT(DSL_logical_operator_seed); ++i) {
         const DSL_LOGICAL_OPERATOR_SEED &seed = DSL_logical_operator_seed[i];
-        if (seed.version < 2 ||
+        if (seed.version < minimum_version ||
             strncmp(seed.name, domain_name, domain_length) != 0 ||
             seed.name[domain_length] != '.')
             continue;
@@ -979,7 +1082,7 @@ DSL_Opcode_Register_Common_Substrate (void)
             ++registered;
     }
 
-    registered += DSL_Opcode_Register_Logical_Domain("common", common_id);
+    registered += DSL_Opcode_Register_Logical_Domain("common", common_id, 2);
 
     return registered;
 }
@@ -1022,9 +1125,27 @@ DSL_Opcode_Register_Domain_Wrapper_Examples (void)
 
     DSL_DOMAIN_ID cnn_id = DSL_Domain_Find("cnn");
     if (cnn_id != DSL_DOMAIN_INVALID_ID)
-        registered += DSL_Opcode_Register_Logical_Domain("cnn", cnn_id);
+        registered += DSL_Opcode_Register_Logical_Domain("cnn", cnn_id, 2);
 
     return registered;
+}
+
+UINT32
+DSL_Opcode_Register_Transformer_Domain (void)
+{
+    DSL_Opcode_Register_Common_Substrate();
+    DSL_DOMAIN_ID common_id = DSL_Domain_Find("common");
+    DSL_DOMAIN_ID transformer_id = DSL_Domain_Find("transformer");
+
+    if (common_id == DSL_DOMAIN_INVALID_ID)
+        return 0;
+    if (transformer_id == DSL_DOMAIN_INVALID_ID)
+        transformer_id = DSL_Domain_Register
+                             ("transformer", common_id, 1, 0);
+    if (transformer_id == DSL_DOMAIN_INVALID_ID)
+        return 0;
+    return DSL_Opcode_Register_Logical_Domain
+               ("transformer", transformer_id, 1);
 }
 
 DSL_OPCODE_ID

--- a/osprey/common/com/dsl_opcode.h
+++ b/osprey/common/com/dsl_opcode.h
@@ -33,7 +33,14 @@ typedef enum {
     OPR_DSLCONV2D = 10,
     OPR_DSLBATCHNORMINFER = 11,
     OPR_DSLMAXPOOL2D = 12,
-    OPR_DSLGLOBALAVGPOOL2D = 13
+    OPR_DSLGLOBALAVGPOOL2D = 13,
+    OPR_DSLRESHAPE = 14,
+    OPR_DSLTRANSPOSE = 15,
+    OPR_DSLTOKENEMBEDDING = 16,
+    OPR_DSLRMSNORM = 17,
+    OPR_DSLROTARYEMBEDDING = 18,
+    OPR_DSLATTENTION = 19,
+    OPR_DSLSWIGLU = 20
 } DSL_OPERATOR;
 
 typedef enum {
@@ -173,6 +180,9 @@ extern UINT32 DSL_Opcode_Count (void);
 extern BOOL DSL_Opcode_At (UINT32 ordinal, DSL_OPCODE_INFO *info);
 extern BOOL DSL_Operator_Get_Info (DSL_OPERATOR dsl_operator,
                                    DSL_OPERATOR_INFO *info);
+extern BOOL DSL_Operator_Get_Info_Version (DSL_OPERATOR dsl_operator,
+                                           UINT16 version,
+                                           DSL_OPERATOR_INFO *info);
 extern DSL_OPERATOR DSL_Operator_Find (const char *stable_name,
                                        UINT32 stable_name_len,
                                        UINT16 version);
@@ -180,6 +190,7 @@ extern DSL_OPERATOR DSL_Operator_Find_Current (const char *stable_name,
                                                UINT32 stable_name_len);
 extern const char *DSL_OPERATOR_name (DSL_OPERATOR dsl_operator);
 extern UINT32 DSL_Opcode_Register_Common_Substrate (void);
+extern UINT32 DSL_Opcode_Register_Transformer_Domain (void);
 extern UINT32 DSL_Opcode_Register_Domain_Wrapper_Examples (void);
 extern DSL_OPCODE_ID DSL_Opcode_Wrapper_Target (DSL_OPCODE_ID id);
 extern void DSL_Opcode_Promotion_Registry_Reset (void);

--- a/osprey/common/com/dsl_region.cxx
+++ b/osprey/common/com/dsl_region.cxx
@@ -3,6 +3,7 @@
  */
 
 #include <errno.h>
+#include <ctype.h>
 #include <string.h>
 #include <vector>
 
@@ -10,6 +11,7 @@
 #include "ir_bwrite.h"
 #include "ir_bcom.h"
 #include "strtab.h"
+#include "symtab.h"
 
 typedef char DSL_Region_Header_Size_Check
     [sizeof(DSL_REGION_IMAGE_HEADER) == 24 ? 1 : -1];
@@ -54,6 +56,46 @@ DSL_Region_Get_Store (PU_Info *pu, BOOL create)
     Set_PU_Info_regions_ptr(pu, NULL);
     Set_PU_Info_state(pu, WT_REGIONS, Subsect_InMem);
     return store;
+}
+
+static DSL_REGION_STORE *
+DSL_Region_Find_Owning_Store (DSL_REGION region)
+{
+    if (region == NULL)
+        return NULL;
+    for (UINT32 i = 0; i < DSL_region_stores.size(); ++i) {
+        for (UINT32 j = 0; j < DSL_region_stores[i]->regions.size(); ++j) {
+            if (DSL_region_stores[i]->regions[j] == region)
+                return DSL_region_stores[i];
+        }
+    }
+    return NULL;
+}
+
+static const char *
+DSL_Region_Metadata_Value (const dsl_region_runtime &region,
+                           const char *key)
+{
+    const char *prefix = WN_DSL_Comment_Prefix();
+    const char *domain = "region_metadata:";
+    const size_t prefix_length = strlen(prefix);
+    const size_t domain_length = strlen(domain);
+    const size_t key_length = key == NULL ? 0 : strlen(key);
+
+    for (WN *wn = WN_first(WN_region_pragmas(region.wn)); wn != NULL;
+         wn = WN_next(wn)) {
+        if (!WN_Is_DSL_Comment(wn))
+            continue;
+        const char *comment = Index_To_Str(WN_GetComment(wn));
+        const char *cursor = comment + prefix_length;
+        if (strncmp(cursor, domain, domain_length) != 0)
+            continue;
+        cursor += domain_length;
+        if (strncmp(cursor, key, key_length) == 0 &&
+            cursor[key_length] == ':')
+            return cursor + key_length + 1;
+    }
+    return NULL;
 }
 
 void
@@ -112,23 +154,52 @@ DSL_Region_Append_Statement (DSL_REGION region, WN *statement)
 }
 
 BOOL
+DSL_Region_Append_Child (DSL_REGION parent, DSL_REGION child)
+{
+    DSL_REGION_STORE *parent_store = DSL_Region_Find_Owning_Store(parent);
+    DSL_REGION_STORE *child_store = DSL_Region_Find_Owning_Store(child);
+    if (parent_store == NULL || parent_store != child_store ||
+        child->image.parent_region_id != parent->image.region_id)
+        return FALSE;
+
+    for (WN *wn = WN_first(WN_region_body(parent->wn)); wn != NULL;
+         wn = WN_next(wn)) {
+        if (wn == child->wn)
+            return FALSE;
+    }
+    WN_INSERT_BlockLast(WN_region_body(parent->wn), child->wn);
+    return TRUE;
+}
+
+BOOL
 DSL_Region_Append_To_PU (DSL_REGION region)
 {
     if (region == NULL)
         return FALSE;
-    DSL_REGION_STORE *store = NULL;
-    for (UINT32 i = 0; i < DSL_region_stores.size(); ++i) {
-        for (UINT32 j = 0; j < DSL_region_stores[i]->regions.size(); ++j) {
-            if (DSL_region_stores[i]->regions[j] == region) {
-                store = DSL_region_stores[i];
-                break;
-            }
-        }
-    }
+    DSL_REGION_STORE *store = DSL_Region_Find_Owning_Store(region);
     if (store == NULL)
         return FALSE;
     WN *entry = PU_Info_tree_ptr(store->pu);
     WN_INSERT_BlockLast(WN_func_body(entry), region->wn);
+    return TRUE;
+}
+
+BOOL
+DSL_Region_Set_Metadata (DSL_REGION region, const char *key,
+                         const char *value)
+{
+    if (region == NULL || key == NULL || key[0] == '\0' || value == NULL ||
+        DSL_Region_Metadata_Value(*region, key) != NULL)
+        return FALSE;
+    for (const char *cursor = key; *cursor != '\0'; ++cursor) {
+        if (!isalnum((unsigned char)*cursor) && *cursor != '_' &&
+            *cursor != '.' && *cursor != '-')
+            return FALSE;
+    }
+
+    WN *metadata = WN_Create_DSL_Comment("region_metadata", key, value);
+    WN_Set_Linenum(metadata, WN_Get_Linenum(region->wn));
+    WN_INSERT_BlockLast(WN_region_pragmas(region->wn), metadata);
     return TRUE;
 }
 
@@ -141,13 +212,7 @@ DSL_Region_Declare_Symbol (DSL_REGION region, ST_IDX st, UINT32 roles,
                    DSL_REGION_VALUE_INOUT | DSL_REGION_VALUE_RESULT)) != 0)
         return FALSE;
 
-    DSL_REGION_STORE *store = NULL;
-    for (UINT32 i = 0; i < DSL_region_stores.size(); ++i) {
-        for (UINT32 j = 0; j < DSL_region_stores[i]->regions.size(); ++j) {
-            if (DSL_region_stores[i]->regions[j] == region)
-                store = DSL_region_stores[i];
-        }
-    }
+    DSL_REGION_STORE *store = DSL_Region_Find_Owning_Store(region);
     if (store == NULL)
         return FALSE;
 
@@ -171,6 +236,9 @@ DSL_Region_Set_Source_Position (DSL_REGION region, SRCPOS spos)
     WN_Set_Linenum(WN_region_body(region->wn), spos);
     WN_Set_Linenum(WN_region_pragmas(region->wn), spos);
     WN_Set_Linenum(WN_region_exits(region->wn), spos);
+    for (WN *wn = WN_first(WN_region_pragmas(region->wn)); wn != NULL;
+         wn = WN_next(wn))
+        WN_Set_Linenum(wn, spos);
     return TRUE;
 }
 
@@ -193,12 +261,297 @@ DSL_Region_Is_Managed_WN (PU_Info *pu, const WN *wn)
     return FALSE;
 }
 
+BOOL
+DSL_Region_Consume_WN (PU_Info *pu, const WN *wn)
+{
+    DSL_REGION_STORE *store = DSL_Region_Find_Store(pu);
+    if (store == NULL || wn == NULL)
+        return FALSE;
+
+    UINT32 region_index = store->regions.size();
+    UINT32 region_id = 0;
+    for (UINT32 i = 0; i < store->regions.size(); ++i) {
+        if (store->regions[i]->wn == wn) {
+            region_index = i;
+            region_id = store->regions[i]->image.region_id;
+            break;
+        }
+    }
+    if (region_index == store->regions.size())
+        return FALSE;
+
+    delete store->regions[region_index];
+    store->regions.erase(store->regions.begin() + region_index);
+    for (UINT32 i = 0; i < store->interfaces.size(); ) {
+        if (store->interfaces[i].region_id == region_id)
+            store->interfaces.erase(store->interfaces.begin() + i);
+        else
+            ++i;
+    }
+    if (!store->regions.empty())
+        return TRUE;
+
+    for (UINT32 i = 0; i < DSL_region_stores.size(); ++i) {
+        if (DSL_region_stores[i] == store) {
+            DSL_region_stores.erase(DSL_region_stores.begin() + i);
+            break;
+        }
+    }
+    delete store;
+    Set_PU_Info_regions_ptr(pu, NULL);
+    Set_PU_Info_state(pu, WT_REGIONS, Subsect_Missing);
+    return TRUE;
+}
+
 static BOOL
 DSL_Region_Report (FILE *diagnostic, const char *message, UINT32 id)
 {
     if (diagnostic != NULL)
         fprintf (diagnostic, "DSL region error: %s id=%u\n", message, id);
     return FALSE;
+}
+
+static BOOL
+DSL_Region_Vector_Has_ST (const std::vector<ST_IDX> &values, ST_IDX st)
+{
+    for (UINT32 i = 0; i < values.size(); ++i) {
+        if (values[i] == st)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+static void
+DSL_Region_Collect_Definitions (WN *block, std::vector<ST_IDX> *definitions)
+{
+    for (WN *stmt = WN_first(block); stmt != NULL; stmt = WN_next(stmt)) {
+        if (WN_operator(stmt) == OPR_STID)
+            definitions->push_back(WN_st_idx(stmt));
+        else if (WN_operator(stmt) == OPR_REGION)
+            DSL_Region_Collect_Definitions(WN_region_body(stmt), definitions);
+    }
+}
+
+static void
+DSL_Region_Collect_External_First_Use
+        (WN *block,
+         const std::vector<ST_IDX> &definitions,
+         std::vector<ST_IDX> *external)
+{
+    for (WN *stmt = WN_first(block); stmt != NULL; stmt = WN_next(stmt)) {
+        if (WN_operator(stmt) == OPR_REGION) {
+            DSL_Region_Collect_External_First_Use
+                (WN_region_body(stmt), definitions, external);
+            continue;
+        }
+        if (WN_operator(stmt) != OPR_STID || WN_kid_count(stmt) != 1 ||
+            !DSL_WN_Is_Native(WN_kid0(stmt)))
+            continue;
+        WN *expression = WN_kid0(stmt);
+        for (UINT32 kid = 0; kid < WN_kid_count(expression); ++kid) {
+            WN *operand = WN_kid(expression, kid);
+            if (operand == NULL || WN_operator(operand) != OPR_LDID)
+                continue;
+            ST_IDX st = WN_st_idx(operand);
+            if (!DSL_Region_Vector_Has_ST(definitions, st) &&
+                !DSL_Region_Vector_Has_ST(*external, st))
+                external->push_back(st);
+        }
+    }
+}
+
+static ST_IDX
+DSL_Region_Last_Result (WN *block)
+{
+    ST_IDX result = ST_IDX_ZERO;
+    for (WN *stmt = WN_first(block); stmt != NULL; stmt = WN_next(stmt)) {
+        if (WN_operator(stmt) == OPR_STID && WN_kid_count(stmt) == 1 &&
+            DSL_WN_Is_Native(WN_kid0(stmt)))
+            result = WN_st_idx(stmt);
+        else if (WN_operator(stmt) == OPR_REGION) {
+            ST_IDX nested = DSL_Region_Last_Result(WN_region_body(stmt));
+            if (ST_IDX_index(nested) != 0)
+                result = nested;
+        }
+    }
+    return result;
+}
+
+static BOOL
+DSL_Region_Source_Positions_Valid (WN *block)
+{
+    for (WN *stmt = WN_first(block); stmt != NULL; stmt = WN_next(stmt)) {
+        if (WN_Get_Linenum(stmt) == 0)
+            return FALSE;
+        if (WN_operator(stmt) == OPR_REGION &&
+            !DSL_Region_Source_Positions_Valid(WN_region_body(stmt)))
+            return FALSE;
+    }
+    return TRUE;
+}
+
+static BOOL
+DSL_Region_Verify_Value_Interface
+        (const DSL_REGION_STORE &store,
+         const dsl_region_runtime &region,
+         FILE *diagnostic)
+{
+    std::vector<ST_IDX> definitions;
+    std::vector<ST_IDX> external;
+    std::vector<const DSL_REGION_INTERFACE_RECORD *> inputs;
+    const DSL_REGION_INTERFACE_RECORD *output = NULL;
+    DSL_Region_Collect_Definitions
+        (WN_region_body(region.wn), &definitions);
+    DSL_Region_Collect_External_First_Use
+        (WN_region_body(region.wn), definitions, &external);
+
+    for (UINT32 i = 0; i < store.interfaces.size(); ++i) {
+        const DSL_REGION_INTERFACE_RECORD &binding = store.interfaces[i];
+        if (binding.region_id != region.image.region_id)
+            continue;
+        if (binding.roles == DSL_REGION_VALUE_INPUT)
+            inputs.push_back(&binding);
+        else if (binding.roles ==
+                 (DSL_REGION_VALUE_OUTPUT | DSL_REGION_VALUE_RESULT)) {
+            if (output != NULL)
+                return DSL_Region_Report
+                           (diagnostic, "DOPC_LLAMA_TOPOLOGY duplicate "
+                            "result interface", region.image.region_id);
+            output = &binding;
+        } else {
+            return DSL_Region_Report
+                       (diagnostic, "DOPC_LLAMA_TOPOLOGY unsupported "
+                        "transformer interface role",
+                        region.image.region_id);
+        }
+    }
+    if (inputs.size() != external.size())
+        return DSL_Region_Report
+                   (diagnostic, "DOPC_LLAMA_TOPOLOGY external input count "
+                    "does not match first-use interface",
+                    region.image.region_id);
+    for (UINT32 ordinal = 0; ordinal < external.size(); ++ordinal) {
+        const DSL_REGION_INTERFACE_RECORD *binding = NULL;
+        for (UINT32 i = 0; i < inputs.size(); ++i) {
+            if (inputs[i]->ordinal == ordinal)
+                binding = inputs[i];
+        }
+        if (binding == NULL || binding->st != external[ordinal])
+            return DSL_Region_Report
+                       (diagnostic, "DOPC_LLAMA_TOPOLOGY input interface "
+                        "is not in deterministic first-use order",
+                        region.image.region_id);
+    }
+
+    ST_IDX last = DSL_Region_Last_Result(WN_region_body(region.wn));
+    if (output == NULL || output->ordinal != 0 || output->st != last ||
+        ST_IDX_index(last) == 0 ||
+        ST_tensor_attribute
+            (last, TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_NO_ALIAS)) ==
+            NULL ||
+        strcmp(ST_tensor_attribute
+                   (last,
+                    TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_NO_ALIAS)),
+               "true") != 0)
+        return DSL_Region_Report
+                   (diagnostic, "DOPC_LLAMA_TOPOLOGY result must be the "
+                    "outer-owned no-alias final value",
+                    region.image.region_id);
+    return TRUE;
+}
+
+static BOOL
+DSL_Region_Verify_Decoder_Topology
+        (const dsl_region_runtime &region, FILE *diagnostic)
+{
+    static const DSL_OPERATOR expected[] = {
+        OPR_DSLRMSNORM,
+        OPR_DSLLINEAR, OPR_DSLLINEAR, OPR_DSLLINEAR,
+        OPR_DSLRESHAPE, OPR_DSLTRANSPOSE,
+        OPR_DSLROTARYEMBEDDING, OPR_DSLROTARYEMBEDDING,
+        OPR_DSLATTENTION,
+        OPR_DSLTRANSPOSE, OPR_DSLRESHAPE,
+        OPR_DSLLINEAR, OPR_DSLRESIDUALADD,
+        OPR_DSLRMSNORM,
+        OPR_DSLLINEAR, OPR_DSLLINEAR, OPR_DSLSWIGLU,
+        OPR_DSLLINEAR, OPR_DSLRESIDUALADD
+    };
+    UINT32 ordinal = 0;
+    for (WN *stmt = WN_first(WN_region_body(region.wn)); stmt != NULL;
+         stmt = WN_next(stmt)) {
+        if (WN_operator(stmt) != OPR_STID || WN_kid_count(stmt) != 1 ||
+            !DSL_WN_Is_Native(WN_kid0(stmt)) ||
+            ordinal >= sizeof(expected) / sizeof(expected[0]) ||
+            DSL_WN_operator(WN_kid0(stmt)) != expected[ordinal])
+            return DSL_Region_Report
+                       (diagnostic, "DOPC_LLAMA_TOPOLOGY decoder operator "
+                        "sequence mismatch", region.image.region_id);
+        ++ordinal;
+    }
+    if (ordinal != sizeof(expected) / sizeof(expected[0]))
+        return DSL_Region_Report
+                   (diagnostic, "DOPC_LLAMA_TOPOLOGY incomplete decoder "
+                    "operator sequence", region.image.region_id);
+    return TRUE;
+}
+
+static BOOL
+DSL_Region_Verify_Prefill_Topology
+        (const DSL_REGION_STORE &store,
+         const dsl_region_runtime &region,
+         FILE *diagnostic)
+{
+    static const DSL_OPERATOR tail[] = {
+        OPR_DSLRMSNORM, OPR_DSLLINEAR, OPR_DSLOUTPUTLOGITS
+    };
+    WN *stmt = WN_first(WN_region_body(region.wn));
+    if (stmt == NULL || WN_operator(stmt) != OPR_STID ||
+        !DSL_WN_Is_Native(WN_kid0(stmt)) ||
+        DSL_WN_operator(WN_kid0(stmt)) != OPR_DSLTOKENEMBEDDING)
+        return DSL_Region_Report
+                   (diagnostic, "DOPC_LLAMA_TOPOLOGY prefill must begin "
+                    "with token embedding", region.image.region_id);
+
+    UINT32 decoder_count = 0;
+    stmt = WN_next(stmt);
+    while (stmt != NULL && WN_operator(stmt) == OPR_REGION) {
+        BOOL matched = FALSE;
+        for (UINT32 i = 0; i < store.regions.size(); ++i) {
+            const dsl_region_runtime &child = *store.regions[i];
+            if (child.wn == stmt &&
+                child.image.parent_region_id == region.image.region_id &&
+                child.image.contract_name != STR_IDX_ZERO &&
+                child.image.contract_name < STR_Table_Size() &&
+                strcmp(Index_To_Str(child.image.contract_name),
+                       "transformer.decoder_layer") == 0 &&
+                child.image.contract_version == 1)
+                matched = TRUE;
+        }
+        if (!matched)
+            return DSL_Region_Report
+                       (diagnostic, "DOPC_LLAMA_TOPOLOGY invalid prefill "
+                        "child region", region.image.region_id);
+        ++decoder_count;
+        stmt = WN_next(stmt);
+    }
+    if (decoder_count == 0)
+        return DSL_Region_Report
+                   (diagnostic, "DOPC_LLAMA_TOPOLOGY prefill has no decoder "
+                    "region", region.image.region_id);
+    for (UINT32 i = 0; i < sizeof(tail) / sizeof(tail[0]); ++i) {
+        if (stmt == NULL || WN_operator(stmt) != OPR_STID ||
+            !DSL_WN_Is_Native(WN_kid0(stmt)) ||
+            DSL_WN_operator(WN_kid0(stmt)) != tail[i])
+            return DSL_Region_Report
+                       (diagnostic, "DOPC_LLAMA_TOPOLOGY invalid prefill "
+                        "final operator sequence", region.image.region_id);
+        stmt = WN_next(stmt);
+    }
+    if (stmt != NULL)
+        return DSL_Region_Report
+                   (diagnostic, "DOPC_LLAMA_TOPOLOGY trailing prefill "
+                    "statement", region.image.region_id);
+    return TRUE;
 }
 
 BOOL
@@ -243,6 +596,42 @@ DSL_Region_Verify_PU (PU_Info *pu, FILE *diagnostic)
                            (diagnostic, "invalid parent",
                             region.image.region_id);
         }
+
+        const char *contract = Index_To_Str(region.image.contract_name);
+        BOOL decoder = strcmp(contract, "transformer.decoder_layer") == 0;
+        BOOL prefill = strcmp(contract, "transformer.prefill") == 0;
+        if ((decoder || prefill) &&
+            (region.image.contract_version != 1 ||
+             WN_Get_Linenum(region.wn) == 0 ||
+             !DSL_Region_Source_Positions_Valid
+                  (WN_region_body(region.wn)) ||
+             DSL_Region_Metadata_Value(region, "module_path") == NULL))
+            return DSL_Region_Report
+                       (diagnostic, "DOPC_LLAMA_TOPOLOGY incomplete source "
+                        "or module context", region.image.region_id);
+        if (decoder) {
+            const char *ordinal =
+                DSL_Region_Metadata_Value(region, "layer_ordinal");
+            if (ordinal == NULL || ordinal[0] == '\0')
+                return DSL_Region_Report
+                           (diagnostic, "DOPC_LLAMA_TOPOLOGY missing decoder "
+                            "layer ordinal", region.image.region_id);
+            for (const char *cursor = ordinal; *cursor != '\0'; ++cursor) {
+                if (!isdigit((unsigned char)*cursor))
+                    return DSL_Region_Report
+                               (diagnostic, "DOPC_LLAMA_TOPOLOGY invalid "
+                                "decoder layer ordinal",
+                                region.image.region_id);
+            }
+            if (!DSL_Region_Verify_Decoder_Topology(region, diagnostic))
+                return FALSE;
+        }
+        if (prefill &&
+            !DSL_Region_Verify_Prefill_Topology(*store, region, diagnostic))
+            return FALSE;
+        if ((decoder || prefill) &&
+            !DSL_Region_Verify_Value_Interface(*store, region, diagnostic))
+            return FALSE;
     }
     for (UINT32 i = 0; i < store->interfaces.size(); ++i) {
         const DSL_REGION_INTERFACE_RECORD &binding = store->interfaces[i];
@@ -263,8 +652,17 @@ DSL_Region_Verify_PU (PU_Info *pu, FILE *diagnostic)
         for (UINT32 j = 0; j < i; ++j) {
             const DSL_REGION_INTERFACE_RECORD &previous =
                 store->interfaces[j];
+            const UINT32 input_roles = DSL_REGION_VALUE_INPUT |
+                                       DSL_REGION_VALUE_INOUT;
+            const UINT32 output_roles = DSL_REGION_VALUE_OUTPUT |
+                                        DSL_REGION_VALUE_INOUT |
+                                        DSL_REGION_VALUE_RESULT;
             if (previous.region_id == binding.region_id &&
-                previous.ordinal == binding.ordinal)
+                previous.ordinal == binding.ordinal &&
+                (((previous.roles & input_roles) != 0 &&
+                  (binding.roles & input_roles) != 0) ||
+                 ((previous.roles & output_roles) != 0 &&
+                  (binding.roles & output_roles) != 0)))
                 return DSL_Region_Report
                            (diagnostic, "duplicate interface ordinal",
                             binding.region_id);
@@ -287,6 +685,16 @@ DSL_Region_Print_PU (FILE *file, PU_Info *pu)
                  region.image.parent_region_id, region.image.depth,
                  region.image.kind, Index_To_Str(region.image.contract_name),
                  region.image.contract_version);
+        for (WN *wn = WN_first(WN_region_pragmas(region.wn)); wn != NULL;
+             wn = WN_next(wn)) {
+            if (!WN_Is_DSL_Comment(wn))
+                continue;
+            const char *comment = Index_To_Str(WN_GetComment(wn));
+            const char *prefix = WN_DSL_Comment_Prefix();
+            const char *metadata = comment + strlen(prefix);
+            if (strncmp(metadata, "region_metadata:", 16) == 0)
+                fprintf (file, "  METADATA %s\n", metadata + 16);
+        }
         for (UINT32 j = 0; j < store->interfaces.size(); ++j) {
             const DSL_REGION_INTERFACE_RECORD &binding = store->interfaces[j];
             if (binding.region_id == region.image.region_id)

--- a/osprey/common/com/dsl_region.h
+++ b/osprey/common/com/dsl_region.h
@@ -59,13 +59,17 @@ extern DSL_REGION DSL_Region_Create (PU_Info *pu, DSL_REGION parent,
                                      const char *contract_name,
                                      UINT32 contract_version);
 extern BOOL DSL_Region_Append_Statement (DSL_REGION region, WN *statement);
+extern BOOL DSL_Region_Append_Child (DSL_REGION parent, DSL_REGION child);
 extern BOOL DSL_Region_Append_To_PU (DSL_REGION region);
+extern BOOL DSL_Region_Set_Metadata (DSL_REGION region, const char *key,
+                                     const char *value);
 extern BOOL DSL_Region_Declare_Symbol (DSL_REGION region, ST_IDX st,
                                       UINT32 roles, UINT32 ordinal,
                                       UINT32 flags);
 extern BOOL DSL_Region_Set_Source_Position (DSL_REGION region, SRCPOS spos);
 extern WN *DSL_Region_WN (DSL_REGION region);
 extern BOOL DSL_Region_Is_Managed_WN (PU_Info *pu, const WN *wn);
+extern BOOL DSL_Region_Consume_WN (PU_Info *pu, const WN *wn);
 extern BOOL DSL_Region_Verify_PU (PU_Info *pu, FILE *diagnostic);
 extern void DSL_Region_Print_PU (FILE *file, PU_Info *pu);
 

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -1102,7 +1102,6 @@ Check_Production_Native_Builder(void)
         fprintf(stderr, "production builder DSL image rows changed\n");
         failed = 1;
     }
-
     FILE *gatekeeper_dump = tmpfile();
     if (!DSL_Gatekeeper_Verify_Program
              (pu, gatekeeper_dump, &gatekeeper_result) ||
@@ -1112,7 +1111,6 @@ Check_Production_Native_Builder(void)
         fprintf(stderr, "gatekeeper rejected a valid native program\n");
         failed = 1;
     }
-
     ST_tensor_bind_attribute
         (WN_st_idx(add),
          TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_NO_ALIAS), "false");
@@ -1162,6 +1160,17 @@ Check_Production_Native_Builder(void)
     }
     WN_offset(add_expression) = saved_record;
 
+    saved_record = WN_offset(matmul_expression);
+    WN_offset(matmul_expression) = Save_Str
+        ("__WHIRL_DSL__:opcode:common.matmul:v1:");
+    if (DSL_Gatekeeper_Verify_Program
+            (pu, gatekeeper_dump, &gatekeeper_result) ||
+        gatekeeper_result.error_count == 0) {
+        fprintf(stderr, "gatekeeper accepted missing typed attributes\n");
+        failed = 1;
+    }
+    WN_offset(matmul_expression) = saved_record;
+
     WN *body = WN_func_body(PU_Info_tree_ptr(pu));
     WN *escape = WN_CreateEval
                      (WN_Lda(Pointer_Mtype, 0,
@@ -1191,30 +1200,6 @@ Check_Production_Native_Builder(void)
     }
     if (retained_artifact == NULL || retained_artifact[0] == '\0')
         (void) unlink(request.path);
-
-    DSL_BUILDER_PROGRAM_UNIT bad_pu =
-        DSL_Builder_Create_Minimal_PU("gatekeeper_missing_attribute");
-    DSL_BUILDER_VALUE bad_kids[2];
-    bad_kids[0] = DSL_Builder_Create_Tensor_Constant
-                  ("bad_attr_kid0", tensor_ty, "int32", 2, "[2,2]",
-                   "splat", "1");
-    bad_kids[1] = DSL_Builder_Create_Tensor_Constant
-                  ("bad_attr_kid1", tensor_ty, "int32", 2, "[2,2]",
-                   "splat", "1");
-    DSL_BUILDER_VALUE bad_matmul = DSL_Builder_Create_Operator
-                                       (matmul_id, 1, bad_kids, 2, NULL, 0);
-    DSL_Builder_Append_PU_Value(bad_pu, bad_kids[0]);
-    DSL_Builder_Append_PU_Value(bad_pu, bad_kids[1]);
-    DSL_Builder_Append_PU_Value(bad_pu, bad_matmul);
-    gatekeeper_dump = tmpfile();
-    if (DSL_Gatekeeper_Verify_Program
-            (bad_pu, gatekeeper_dump, &gatekeeper_result) ||
-        gatekeeper_result.error_count == 0) {
-        fprintf(stderr, "gatekeeper accepted missing typed attributes\n");
-        failed = 1;
-    }
-    if (gatekeeper_dump != NULL)
-        fclose(gatekeeper_dump);
 
     return failed;
 }
@@ -1604,6 +1589,1130 @@ Check_Native_DSL_Node_Layout(void)
 }
 
 static int
+Check_Llama2_Common_Substrate(void)
+{
+    DSL_OPERATOR_INFO current_info;
+    DSL_OPERATOR_INFO exact_info;
+    DSL_BUILDER_PROGRAM_UNIT pu;
+    DSL_DOMAIN_ID common_id;
+    DSL_OPCODE_ID reshape_id;
+    DSL_OPCODE_ID transpose_id;
+    DSL_OPCODE_ID linear_v2_id;
+    DSL_OPCODE_ID linear_v3_id;
+    DSL_OPCODE_ID matmul_v2_id;
+    DSL_OPCODE_ID output_v3_id;
+    DSL_BUILDER_TENSOR_TYPE_CORE type_core;
+    DSL_BUILDER_VALUE values[10];
+    UINT32 source_lines[10];
+    DSL_BUILDER_VALUE kids[2];
+    DSL_BUILDER_OPERATOR_ATTRIBUTE linear_attrs[4];
+    DSL_BUILDER_OPERATOR_ATTRIBUTE reshape_attr;
+    DSL_BUILDER_OPERATOR_ATTRIBUTE transpose_attr;
+    DSL_BUILDER_OPERATOR_ATTRIBUTE matmul_attrs[4];
+    DSL_BUILDER_OPERATOR_ATTRIBUTE output_attrs[3];
+    DSL_BUILDER_VERIFY_RESULT verify;
+    DSL_BUILDER_MAPPED_IMAGE_REQUEST request;
+    TY_IDX activation_ty;
+    TY_IDX weight_ty;
+    TY_IDX attention_ty;
+    TY_IDX logits_ty;
+    UINT32 file_id;
+    char diagnostic[2048];
+    int failed = 0;
+
+    if (!DSL_Builder_Begin_Program())
+        return 1;
+    DSL_Opcode_Register_Common_Substrate();
+    common_id = DSL_Domain_Find("common");
+    reshape_id = DSL_Opcode_Find(common_id, "common.reshape", 1);
+    transpose_id = DSL_Opcode_Find(common_id, "common.transpose", 1);
+    linear_v2_id = DSL_Opcode_Find(common_id, "common.linear", 2);
+    linear_v3_id = DSL_Opcode_Find(common_id, "common.linear", 3);
+    matmul_v2_id = DSL_Opcode_Find(common_id, "common.matmul", 2);
+    output_v3_id = DSL_Opcode_Find(common_id, "common.output_logits", 3);
+    if (reshape_id == DSL_OPCODE_INVALID_ID ||
+        transpose_id == DSL_OPCODE_INVALID_ID ||
+        linear_v2_id == DSL_OPCODE_INVALID_ID ||
+        linear_v3_id == DSL_OPCODE_INVALID_ID ||
+        matmul_v2_id == DSL_OPCODE_INVALID_ID ||
+        output_v3_id == DSL_OPCODE_INVALID_ID ||
+        (UINT32)OPR_DSLRESHAPE != 14 ||
+        (UINT32)OPR_DSLTRANSPOSE != 15 ||
+        !DSL_Operator_Get_Info(OPR_DSLLINEAR, &current_info) ||
+        current_info.version != 3 || current_info.nkids != 2 ||
+        !DSL_Operator_Get_Info_Version(OPR_DSLLINEAR, 2, &exact_info) ||
+        exact_info.version != 2 || exact_info.nkids != 3 ||
+        !DSL_Operator_Get_Info_Version(OPR_DSLMATMUL, 1, &exact_info) ||
+        exact_info.version != 1 ||
+        !DSL_Operator_Get_Info_Version(OPR_DSLMATMUL, 2, &exact_info) ||
+        exact_info.version != 2 ||
+        !DSL_Operator_Get_Info_Version
+             (OPR_DSLOUTPUTLOGITS, 2, &exact_info) ||
+        !DSL_Operator_Get_Info_Version
+             (OPR_DSLOUTPUTLOGITS, 3, &current_info) ||
+        DSL_Operator_Get_Info_Version(OPR_DSLLINEAR, 1, NULL)) {
+        fprintf(stderr, "item-23 exact operator schema lookup changed\n");
+        return 1;
+    }
+
+    memset(&type_core, 0, sizeof(type_core));
+    type_core.kind = "tensor";
+    type_core.dtype = "float32";
+    type_core.rank = 3;
+    type_core.logical_shape = "[1,8,32]";
+    activation_ty = DSL_Builder_Create_Tensor_Type_Core
+                        ("llama_activation", MTYPE_To_TY(MTYPE_F4),
+                         &type_core);
+    type_core.rank = 2;
+    type_core.logical_shape = "[64,32]";
+    weight_ty = DSL_Builder_Create_Tensor_Type_Core
+                    ("llama_weight", MTYPE_To_TY(MTYPE_F4), &type_core);
+    type_core.rank = 4;
+    type_core.logical_shape = "[1,4,8,8]";
+    attention_ty = DSL_Builder_Create_Tensor_Type_Core
+                       ("llama_attention", MTYPE_To_TY(MTYPE_F4),
+                        &type_core);
+    type_core.rank = 3;
+    type_core.logical_shape = "[1,8,128]";
+    logits_ty = DSL_Builder_Create_Tensor_Type_Core
+                    ("llama_logits", MTYPE_To_TY(MTYPE_F4), &type_core);
+
+    pu = DSL_Builder_Create_Minimal_PU("llama2_common_substrate");
+    file_id = DSL_Builder_Register_Source_File(pu, __FILE__);
+    source_lines[0] = __LINE__ + 1;
+    values[0] = DSL_Builder_Create_Model_Input
+                    ("llama_activation_input", activation_ty, 0);
+    source_lines[1] = __LINE__ + 1;
+    values[1] = DSL_Builder_Create_Tensor_Constant
+                    ("llama_projection_weight", weight_ty, "float32", 2,
+                     "[64,32]", "splat", "1");
+    source_lines[2] = __LINE__ + 1;
+    values[2] = DSL_Builder_Create_Model_Input
+                    ("llama_query", attention_ty, 1);
+    source_lines[3] = __LINE__ + 1;
+    values[3] = DSL_Builder_Create_Model_Input
+                    ("llama_key", attention_ty, 2);
+    source_lines[4] = __LINE__ + 1;
+    values[4] = DSL_Builder_Create_Model_Input
+                    ("llama_logits_input", logits_ty, 3);
+
+    linear_attrs[0].name = "attr.has_bias";
+    linear_attrs[0].value = "false";
+    linear_attrs[1].name = "attr.transpose_input";
+    linear_attrs[1].value = "false";
+    linear_attrs[2].name = "attr.transpose_weight";
+    linear_attrs[2].value = "true";
+    linear_attrs[3].name = "attr.weight_layout";
+    linear_attrs[3].value = "OI";
+    kids[0] = values[0];
+    kids[1] = values[1];
+    source_lines[5] = __LINE__ + 1;
+    values[5] = DSL_Builder_Create_Operator
+                    (linear_v3_id, 3, kids, 2, linear_attrs, 4);
+
+    reshape_attr.name = "attr.target_shape";
+    reshape_attr.value = "1,8,4,16";
+    kids[0] = values[5];
+    source_lines[6] = __LINE__ + 1;
+    values[6] = DSL_Builder_Create_Operator
+                    (reshape_id, 1, kids, 1, &reshape_attr, 1);
+
+    transpose_attr.name = "attr.permutation";
+    transpose_attr.value = "0,2,1,3";
+    kids[0] = values[6];
+    source_lines[7] = __LINE__ + 1;
+    values[7] = DSL_Builder_Create_Operator
+                    (transpose_id, 1, kids, 1, &transpose_attr, 1);
+
+    matmul_attrs[0].name = "attr.transpose_kid0";
+    matmul_attrs[0].value = "false";
+    matmul_attrs[1].name = "attr.transpose_kid1";
+    matmul_attrs[1].value = "true";
+    matmul_attrs[2].name = "attr.batch_rule";
+    matmul_attrs[2].value = "exact";
+    matmul_attrs[3].name = "attr.accum_dtype";
+    matmul_attrs[3].value = "float32";
+    kids[0] = values[2];
+    kids[1] = values[3];
+    source_lines[8] = __LINE__ + 1;
+    values[8] = DSL_Builder_Create_Operator
+                    (matmul_v2_id, 2, kids, 2, matmul_attrs, 4);
+
+    output_attrs[0].name = "attr.semantic";
+    output_attrs[0].value = "token_logits";
+    output_attrs[1].name = "attr.sequence_axis";
+    output_attrs[1].value = "-2";
+    output_attrs[2].name = "attr.vocabulary_axis";
+    output_attrs[2].value = "-1";
+    kids[0] = values[4];
+    source_lines[9] = __LINE__ + 1;
+    values[9] = DSL_Builder_Create_Operator
+                    (output_v3_id, 3, kids, 1, output_attrs, 3);
+
+    for (UINT32 i = 0; i < sizeof(values) / sizeof(values[0]); ++i) {
+        if (values[i] == NULL || !DSL_Builder_Append_PU_Value(pu, values[i])) {
+            fprintf(stderr, "item-23 builder rejected value %u\n", i);
+            return 1;
+        }
+        DSL_BUILDER_SOURCE_POSITION position;
+        memset(&position, 0, sizeof(position));
+        position.file_id = file_id;
+        position.line = source_lines[i];
+        position.column = 1;
+        position.statement_begin = 1;
+        if (!DSL_Builder_Set_Value_Source_Position(values[i], &position)) {
+            fprintf(stderr, "item-23 source position failed for value %u\n",
+                    i);
+            failed = 1;
+        }
+    }
+
+    if (strcmp(TY_tensor_attribute
+                   (DSL_Builder_Get_Value_Type(values[5]),
+                    TY_TENSOR_SCHEMA_SHAPE), "[1,8,64]") != 0 ||
+        strcmp(TY_tensor_attribute
+                   (DSL_Builder_Get_Value_Type(values[6]),
+                    TY_TENSOR_SCHEMA_SHAPE), "[1,8,4,16]") != 0 ||
+        strcmp(TY_tensor_attribute
+                   (DSL_Builder_Get_Value_Type(values[7]),
+                    TY_TENSOR_SCHEMA_SHAPE), "[1,4,8,16]") != 0 ||
+        strcmp(TY_tensor_attribute
+                   (DSL_Builder_Get_Value_Type(values[8]),
+                    TY_TENSOR_SCHEMA_SHAPE), "[1,4,8,8]") != 0 ||
+        DSL_Builder_Get_Value_Type(values[9]) != logits_ty) {
+        fprintf(stderr, "item-23 result descriptor inference changed\n");
+        failed = 1;
+    }
+
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (!DSL_Builder_Verify_Program(&verify) || verify.error_count != 0) {
+        fprintf(stderr, "item-23 gatekeeper rejected valid graph: %s\n",
+                diagnostic);
+        failed = 1;
+    }
+
+    TY_IDX transpose_result_ty = DSL_Builder_Get_Value_Type(values[7]);
+    TY_tensor_bind_attribute
+        (transpose_result_ty, TY_TENSOR_SCHEMA_SHAPE, "[1,8,4,16]");
+    memset(&verify, 0, sizeof(verify));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (DSL_Builder_Verify_Program(&verify) || verify.error_count == 0) {
+        fprintf(stderr, "item-23 gatekeeper accepted bad transpose result\n");
+        failed = 1;
+    }
+    TY_tensor_bind_attribute
+        (transpose_result_ty, TY_TENSOR_SCHEMA_SHAPE, "[1,4,8,16]");
+
+    DSL_BUILDER_OPERATOR_ATTRIBUTE bad_reshape = reshape_attr;
+    bad_reshape.value = "1,8,4,15";
+    kids[0] = values[5];
+    if (DSL_Builder_Create_Operator
+            (reshape_id, 1, kids, 1, &bad_reshape, 1) != NULL) {
+        fprintf(stderr, "item-23 builder accepted element-changing reshape\n");
+        failed = 1;
+    }
+
+    DSL_BUILDER_OPERATOR_ATTRIBUTE bad_transpose = transpose_attr;
+    bad_transpose.value = "0,2,2,3";
+    kids[0] = values[6];
+    if (DSL_Builder_Create_Operator
+            (transpose_id, 1, kids, 1, &bad_transpose, 1) != NULL ||
+        DSL_Builder_Create_Operator
+            (linear_v2_id, 3, kids, 1, linear_attrs, 4) != NULL ||
+        DSL_Builder_Create_Operator
+            (output_v3_id, 3, kids, 1, output_attrs, 2) != NULL) {
+        fprintf(stderr, "item-23 builder accepted a malformed schema\n");
+        failed = 1;
+    }
+
+    FILE *image_dump = tmpfile();
+    if (image_dump == NULL) {
+        fprintf(stderr, "item-23 failed to create logical image dump\n");
+        failed = 1;
+    } else {
+        char text[32768];
+        size_t count;
+
+        DSL_IR_Image_Print(image_dump);
+        rewind(image_dump);
+        count = fread(text, 1, sizeof(text) - 1, image_dump);
+        text[count] = '\0';
+        fclose(image_dump);
+        if (strstr(text, "operator=OPR_DSLRESHAPE version=1") == NULL ||
+            strstr(text, "operator=OPR_DSLTRANSPOSE version=1") == NULL ||
+            strstr(text, "operator=OPR_DSLLINEAR version=3") == NULL ||
+            strstr(text, "operator=OPR_DSLMATMUL version=2") == NULL ||
+            strstr(text, "operator=OPR_DSLOUTPUTLOGITS version=3") == NULL ||
+            strstr(text, "stable_name=common.reshape") == NULL ||
+            strstr(text, "stable_name=common.transpose") == NULL ||
+            strstr(text, "OPR_DSL ") != NULL ||
+            strstr(text, "MDSL ") != NULL) {
+            fprintf(stderr, "item-23 logical image dump changed\n");
+            failed = 1;
+        }
+    }
+
+    const char *artifact = getenv("OPEN64_DSL_LLAMA2_COMMON_ARTIFACT");
+    request.path = artifact == NULL || artifact[0] == '\0' ?
+                   "llama2_common_substrate.B" : artifact;
+    request.flags = 0;
+    (void) unlink(request.path);
+    if (!DSL_Builder_Finalize_Mapped_Image(&request) ||
+        access(request.path, F_OK) != 0) {
+        fprintf(stderr, "item-23 mapped-image finalization failed\n");
+        failed = 1;
+    }
+    if (artifact == NULL || artifact[0] == '\0')
+        (void) unlink(request.path);
+
+    return failed;
+}
+
+static int
+Check_Llama2_Transformer_Expressions(void)
+{
+    DSL_BUILDER_TENSOR_TYPE_CORE core;
+    DSL_BUILDER_PROGRAM_UNIT pu;
+    DSL_DOMAIN_ID transformer_id;
+    DSL_OPCODE_ID embedding_id;
+    DSL_OPCODE_ID rms_id;
+    DSL_OPCODE_ID rotary_id;
+    DSL_OPCODE_ID attention_id;
+    DSL_OPCODE_ID swiglu_id;
+    DSL_BUILDER_VALUE values[16];
+    UINT32 source_lines[16];
+    DSL_BUILDER_VALUE kids[3];
+    DSL_BUILDER_OPERATOR_ATTRIBUTE embedding_attrs[2];
+    DSL_BUILDER_OPERATOR_ATTRIBUTE rms_attrs[3];
+    DSL_BUILDER_OPERATOR_ATTRIBUTE rotary_attrs[6];
+    DSL_BUILDER_OPERATOR_ATTRIBUTE attention_attrs[10];
+    DSL_BUILDER_OPERATOR_ATTRIBUTE swiglu_attr;
+    DSL_BUILDER_VERIFY_RESULT verify;
+    DSL_BUILDER_MAPPED_IMAGE_REQUEST request;
+    TY_IDX token_ty;
+    TY_IDX embedding_weight_ty;
+    TY_IDX scale_ty;
+    TY_IDX qkv_ty;
+    TY_IDX rope_ty;
+    TY_IDX swiglu_ty;
+    UINT32 file_id;
+    char diagnostic[4096];
+    int failed = 0;
+
+    if (!DSL_Builder_Begin_Program() ||
+        DSL_Opcode_Register_Transformer_Domain() != 5)
+        return 1;
+    transformer_id = DSL_Domain_Find("transformer");
+    embedding_id = DSL_Opcode_Find
+                       (transformer_id, "transformer.token_embedding", 1);
+    rms_id = DSL_Opcode_Find
+                 (transformer_id, "transformer.rms_norm", 1);
+    rotary_id = DSL_Opcode_Find
+                    (transformer_id, "transformer.rotary_embedding", 1);
+    attention_id = DSL_Opcode_Find
+                       (transformer_id, "transformer.attention", 1);
+    swiglu_id = DSL_Opcode_Find
+                    (transformer_id, "transformer.swiglu", 1);
+    if (transformer_id == DSL_DOMAIN_INVALID_ID ||
+        embedding_id == DSL_OPCODE_INVALID_ID ||
+        rms_id == DSL_OPCODE_INVALID_ID ||
+        rotary_id == DSL_OPCODE_INVALID_ID ||
+        attention_id == DSL_OPCODE_INVALID_ID ||
+        swiglu_id == DSL_OPCODE_INVALID_ID ||
+        (UINT32)OPR_DSLTOKENEMBEDDING != 16 ||
+        (UINT32)OPR_DSLRMSNORM != 17 ||
+        (UINT32)OPR_DSLROTARYEMBEDDING != 18 ||
+        (UINT32)OPR_DSLATTENTION != 19 ||
+        (UINT32)OPR_DSLSWIGLU != 20) {
+        fprintf(stderr, "item-24 transformer registry changed\n");
+        return 1;
+    }
+
+    memset(&core, 0, sizeof(core));
+    core.kind = "tensor";
+    core.dtype = "int64";
+    core.rank = 2;
+    core.logical_shape = "[1,8]";
+    token_ty = DSL_Builder_Create_Tensor_Type_Core
+                   ("llama_token_ids", MTYPE_To_TY(MTYPE_I8), &core);
+    core.dtype = "float32";
+    core.rank = 2;
+    core.logical_shape = "[128,32]";
+    embedding_weight_ty = DSL_Builder_Create_Tensor_Type_Core
+                              ("llama_embedding_weight",
+                               MTYPE_To_TY(MTYPE_F4), &core);
+    core.rank = 1;
+    core.logical_shape = "[32]";
+    scale_ty = DSL_Builder_Create_Tensor_Type_Core
+                   ("llama_rms_scale", MTYPE_To_TY(MTYPE_F4), &core);
+    core.rank = 4;
+    core.logical_shape = "[1,4,8,8]";
+    qkv_ty = DSL_Builder_Create_Tensor_Type_Core
+                 ("llama_qkv", MTYPE_To_TY(MTYPE_F4), &core);
+    core.logical_shape = "[1,1,8,8]";
+    rope_ty = DSL_Builder_Create_Tensor_Type_Core
+                  ("llama_rope_table", MTYPE_To_TY(MTYPE_F4), &core);
+    core.rank = 3;
+    core.logical_shape = "[1,8,88]";
+    swiglu_ty = DSL_Builder_Create_Tensor_Type_Core
+                    ("llama_swiglu", MTYPE_To_TY(MTYPE_F4), &core);
+
+    pu = DSL_Builder_Create_Minimal_PU("llama2_transformer_expressions");
+    file_id = DSL_Builder_Register_Source_File(pu, __FILE__);
+    source_lines[0] = __LINE__ + 1;
+    values[0] = DSL_Builder_Create_Model_Input("token_ids", token_ty, 0);
+    source_lines[1] = __LINE__ + 1;
+    values[1] = DSL_Builder_Create_Tensor_Constant
+                    ("embedding_weight", embedding_weight_ty, "float32", 2,
+                     "[128,32]", "splat", "1");
+    embedding_attrs[0].name = "attr.padding_idx";
+    embedding_attrs[0].value = "none";
+    embedding_attrs[1].name = "attr.bounds_policy";
+    embedding_attrs[1].value = "runtime_check";
+    kids[0] = values[0];
+    kids[1] = values[1];
+    source_lines[2] = __LINE__ + 1;
+    values[2] = DSL_Builder_Create_Operator
+                    (embedding_id, 1, kids, 2, embedding_attrs, 2);
+
+    source_lines[3] = __LINE__ + 1;
+    values[3] = DSL_Builder_Create_Tensor_Constant
+                    ("rms_scale", scale_ty, "float32", 1, "[32]", "splat",
+                     "1");
+    rms_attrs[0].name = "attr.axis";
+    rms_attrs[0].value = "-1";
+    rms_attrs[1].name = "attr.epsilon";
+    rms_attrs[1].value = "0.00001";
+    rms_attrs[2].name = "attr.accum_dtype";
+    rms_attrs[2].value = "float32";
+    kids[0] = values[2];
+    kids[1] = values[3];
+    source_lines[4] = __LINE__ + 1;
+    values[4] = DSL_Builder_Create_Operator
+                    (rms_id, 1, kids, 2, rms_attrs, 3);
+
+    source_lines[5] = __LINE__ + 1;
+    values[5] = DSL_Builder_Create_Model_Input("query", qkv_ty, 1);
+    source_lines[6] = __LINE__ + 1;
+    values[6] = DSL_Builder_Create_Model_Input("key", qkv_ty, 2);
+    source_lines[7] = __LINE__ + 1;
+    values[7] = DSL_Builder_Create_Model_Input("value", qkv_ty, 3);
+    source_lines[8] = __LINE__ + 1;
+    values[8] = DSL_Builder_Create_Tensor_Constant
+                    ("rope_cos", rope_ty, "float32", 4, "[1,1,8,8]",
+                     "splat", "1");
+    source_lines[9] = __LINE__ + 1;
+    values[9] = DSL_Builder_Create_Tensor_Constant
+                    ("rope_sin", rope_ty, "float32", 4, "[1,1,8,8]",
+                     "splat", "0");
+    rotary_attrs[0].name = "attr.head_layout";
+    rotary_attrs[0].value = "BHSD";
+    rotary_attrs[1].name = "attr.sequence_axis";
+    rotary_attrs[1].value = "2";
+    rotary_attrs[2].name = "attr.feature_axis";
+    rotary_attrs[2].value = "3";
+    rotary_attrs[3].name = "attr.pairing";
+    rotary_attrs[3].value = "half_split";
+    rotary_attrs[4].name = "attr.position_mode";
+    rotary_attrs[4].value = "zero_based_static";
+    rotary_attrs[5].name = "attr.position_offset";
+    rotary_attrs[5].value = "0";
+    kids[0] = values[5];
+    kids[1] = values[8];
+    kids[2] = values[9];
+    source_lines[10] = __LINE__ + 1;
+    values[10] = DSL_Builder_Create_Operator
+                     (rotary_id, 1, kids, 3, rotary_attrs, 6);
+    kids[0] = values[6];
+    source_lines[11] = __LINE__ + 1;
+    values[11] = DSL_Builder_Create_Operator
+                     (rotary_id, 1, kids, 3, rotary_attrs, 6);
+
+    attention_attrs[0].name = "attr.execution_mode";
+    attention_attrs[0].value = "full_sequence";
+    attention_attrs[1].name = "attr.mask_mode";
+    attention_attrs[1].value = "causal";
+    attention_attrs[2].name = "attr.head_layout";
+    attention_attrs[2].value = "BHSD";
+    attention_attrs[3].name = "attr.query_heads";
+    attention_attrs[3].value = "4";
+    attention_attrs[4].name = "attr.kv_heads";
+    attention_attrs[4].value = "4";
+    attention_attrs[5].name = "attr.head_dim";
+    attention_attrs[5].value = "8";
+    attention_attrs[6].name = "attr.scale_mode";
+    attention_attrs[6].value = "inverse_sqrt_head_dim";
+    attention_attrs[7].name = "attr.softmax_axis";
+    attention_attrs[7].value = "-1";
+    attention_attrs[8].name = "attr.softmax_accum_dtype";
+    attention_attrs[8].value = "float32";
+    attention_attrs[9].name = "attr.cache_mode";
+    attention_attrs[9].value = "none";
+    kids[0] = values[10];
+    kids[1] = values[11];
+    kids[2] = values[7];
+    source_lines[12] = __LINE__ + 1;
+    values[12] = DSL_Builder_Create_Operator
+                     (attention_id, 1, kids, 3, attention_attrs, 10);
+
+    source_lines[13] = __LINE__ + 1;
+    values[13] = DSL_Builder_Create_Model_Input("gate_projection", swiglu_ty,
+                                                4);
+    source_lines[14] = __LINE__ + 1;
+    values[14] = DSL_Builder_Create_Model_Input("up_projection", swiglu_ty,
+                                                5);
+    swiglu_attr.name = "attr.activation";
+    swiglu_attr.value = "silu";
+    kids[0] = values[13];
+    kids[1] = values[14];
+    source_lines[15] = __LINE__ + 1;
+    values[15] = DSL_Builder_Create_Operator
+                     (swiglu_id, 1, kids, 2, &swiglu_attr, 1);
+
+    for (UINT32 i = 0; i < sizeof(values) / sizeof(values[0]); ++i) {
+        if (values[i] == NULL || !DSL_Builder_Append_PU_Value(pu, values[i])) {
+            fprintf(stderr, "item-24 builder rejected value %u\n", i);
+            return 1;
+        }
+        DSL_BUILDER_SOURCE_POSITION position;
+        memset(&position, 0, sizeof(position));
+        position.file_id = file_id;
+        position.line = source_lines[i];
+        position.column = 1;
+        position.statement_begin = 1;
+        if (!DSL_Builder_Set_Value_Source_Position(values[i], &position))
+            failed = 1;
+    }
+
+    if (strcmp(TY_tensor_attribute
+                   (DSL_Builder_Get_Value_Type(values[2]),
+                    TY_TENSOR_SCHEMA_SHAPE), "[1,8,32]") != 0 ||
+        DSL_Builder_Get_Value_Type(values[4]) == TY_IDX_ZERO ||
+        strcmp(TY_tensor_attribute
+                   (DSL_Builder_Get_Value_Type(values[12]),
+                    TY_TENSOR_SCHEMA_SHAPE), "[1,4,8,8]") != 0 ||
+        strcmp(TY_tensor_attribute
+                   (DSL_Builder_Get_Value_Type(values[15]),
+                    TY_TENSOR_SCHEMA_SHAPE), "[1,8,88]") != 0) {
+        fprintf(stderr, "item-24 transformer result inference changed\n");
+        failed = 1;
+    }
+
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (!DSL_Builder_Verify_Program(&verify) || verify.error_count != 0) {
+        fprintf(stderr, "item-24 gatekeeper rejected valid graph: %s\n",
+                diagnostic);
+        failed = 1;
+    }
+
+    TY_IDX attention_result_ty = DSL_Builder_Get_Value_Type(values[12]);
+    TY_tensor_bind_attribute
+        (attention_result_ty, TY_TENSOR_SCHEMA_SHAPE, "[1,4,8,7]");
+    memset(&verify, 0, sizeof(verify));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (DSL_Builder_Verify_Program(&verify) || verify.error_count == 0) {
+        fprintf(stderr, "item-24 gatekeeper accepted bad attention result\n");
+        failed = 1;
+    }
+    TY_tensor_bind_attribute
+        (attention_result_ty, TY_TENSOR_SCHEMA_SHAPE, "[1,4,8,8]");
+
+    DSL_BUILDER_OPERATOR_ATTRIBUTE bad_attention[10];
+    memcpy(bad_attention, attention_attrs, sizeof(bad_attention));
+    bad_attention[4].value = "2";
+    kids[0] = values[10];
+    kids[1] = values[11];
+    kids[2] = values[7];
+    if (DSL_Builder_Create_Operator
+            (attention_id, 1, kids, 3, bad_attention, 10) != NULL) {
+        fprintf(stderr, "item-24 builder accepted grouped-query attention\n");
+        failed = 1;
+    }
+    bad_attention[4].value = "4";
+    bad_attention[9].value = "static";
+    if (DSL_Builder_Create_Operator
+            (attention_id, 1, kids, 3, bad_attention, 10) != NULL) {
+        fprintf(stderr, "item-24 builder accepted cache state\n");
+        failed = 1;
+    }
+    DSL_BUILDER_OPERATOR_ATTRIBUTE bad_rms[3];
+    memcpy(bad_rms, rms_attrs, sizeof(bad_rms));
+    bad_rms[1].value = "0";
+    kids[0] = values[2];
+    kids[1] = values[3];
+    if (DSL_Builder_Create_Operator
+            (rms_id, 1, kids, 2, bad_rms, 3) != NULL) {
+        fprintf(stderr, "item-24 builder accepted zero RMS epsilon\n");
+        failed = 1;
+    }
+    DSL_BUILDER_OPERATOR_ATTRIBUTE bad_embedding[2];
+    memcpy(bad_embedding, embedding_attrs, sizeof(bad_embedding));
+    bad_embedding[1].value = "none";
+    kids[0] = values[0];
+    kids[1] = values[1];
+    if (DSL_Builder_Create_Operator
+            (embedding_id, 1, kids, 2, bad_embedding, 2) != NULL) {
+        fprintf(stderr, "item-24 builder accepted missing bounds guard\n");
+        failed = 1;
+    }
+    DSL_BUILDER_OPERATOR_ATTRIBUTE bad_rotary[6];
+    memcpy(bad_rotary, rotary_attrs, sizeof(bad_rotary));
+    bad_rotary[3].value = "interleaved";
+    kids[0] = values[5];
+    kids[1] = values[8];
+    kids[2] = values[9];
+    if (DSL_Builder_Create_Operator
+            (rotary_id, 1, kids, 3, bad_rotary, 6) != NULL) {
+        fprintf(stderr, "item-24 builder accepted unsupported RoPE pairing\n");
+        failed = 1;
+    }
+    DSL_BUILDER_OPERATOR_ATTRIBUTE bad_swiglu = swiglu_attr;
+    bad_swiglu.value = "relu";
+    kids[0] = values[13];
+    kids[1] = values[14];
+    if (DSL_Builder_Create_Operator
+            (swiglu_id, 1, kids, 2, &bad_swiglu, 1) != NULL) {
+        fprintf(stderr, "item-24 builder accepted non-SiLU activation\n");
+        failed = 1;
+    }
+
+    FILE *image_dump = tmpfile();
+    if (image_dump == NULL) {
+        failed = 1;
+    } else {
+        char text[65536];
+        DSL_IR_Image_Print(image_dump);
+        rewind(image_dump);
+        size_t count = fread(text, 1, sizeof(text) - 1, image_dump);
+        text[count] = '\0';
+        fclose(image_dump);
+        if (strstr(text, "operator=OPR_DSLTOKENEMBEDDING version=1") == NULL ||
+            strstr(text, "operator=OPR_DSLRMSNORM version=1") == NULL ||
+            strstr(text, "operator=OPR_DSLROTARYEMBEDDING version=1") == NULL ||
+            strstr(text, "operator=OPR_DSLATTENTION version=1") == NULL ||
+            strstr(text, "operator=OPR_DSLSWIGLU version=1") == NULL ||
+            strstr(text, "OPR_DSL ") != NULL || strstr(text, "MDSL ") != NULL) {
+            fprintf(stderr, "item-24 logical image dump changed\n");
+            failed = 1;
+        }
+    }
+
+    const char *artifact =
+        getenv("OPEN64_DSL_LLAMA2_TRANSFORMER_ARTIFACT");
+    request.path = artifact == NULL || artifact[0] == '\0' ?
+                   "llama2_transformer_expressions.B" : artifact;
+    request.flags = 0;
+    (void) unlink(request.path);
+    if (!DSL_Builder_Finalize_Mapped_Image(&request) ||
+        access(request.path, F_OK) != 0) {
+        fprintf(stderr, "item-24 mapped-image finalization failed\n");
+        failed = 1;
+    }
+    if (artifact == NULL || artifact[0] == '\0')
+        (void) unlink(request.path);
+    return failed;
+}
+
+static int
+Check_Llama2_Transformer_Regions(void)
+{
+    DSL_BUILDER_TENSOR_TYPE_CORE core;
+    DSL_BUILDER_PROGRAM_UNIT pu;
+    DSL_BUILDER_REGION prefill;
+    DSL_BUILDER_REGION decoder;
+    DSL_BUILDER_VALUE external[10];
+    DSL_BUILDER_EXTERNAL_TENSOR_REFERENCE references[9];
+    DSL_BUILDER_VALUE decoder_values[19];
+    DSL_BUILDER_VALUE prefill_values[4];
+    DSL_BUILDER_VALUE kids[3];
+    DSL_BUILDER_OPERATOR_ATTRIBUTE linear_attrs[4] = {
+        { "attr.has_bias", "false" },
+        { "attr.transpose_input", "false" },
+        { "attr.transpose_weight", "true" },
+        { "attr.weight_layout", "OI" }
+    };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE rms_attrs[3] = {
+        { "attr.axis", "-1" },
+        { "attr.epsilon", "0.00001" },
+        { "attr.accum_dtype", "float32" }
+    };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE reshape_head =
+        { "attr.target_shape", "1,8,4,8" };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE reshape_hidden =
+        { "attr.target_shape", "1,8,32" };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE transpose_head =
+        { "attr.permutation", "0,2,1,3" };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE rotary_attrs[6] = {
+        { "attr.head_layout", "BHSD" },
+        { "attr.sequence_axis", "2" },
+        { "attr.feature_axis", "3" },
+        { "attr.pairing", "half_split" },
+        { "attr.position_mode", "zero_based_static" },
+        { "attr.position_offset", "0" }
+    };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE attention_attrs[10] = {
+        { "attr.execution_mode", "full_sequence" },
+        { "attr.mask_mode", "causal" },
+        { "attr.head_layout", "BHSD" },
+        { "attr.query_heads", "4" },
+        { "attr.kv_heads", "4" },
+        { "attr.head_dim", "8" },
+        { "attr.scale_mode", "inverse_sqrt_head_dim" },
+        { "attr.softmax_axis", "-1" },
+        { "attr.softmax_accum_dtype", "float32" },
+        { "attr.cache_mode", "none" }
+    };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE residual_attrs[3] = {
+        { "attr.broadcast_rule", "none" },
+        { "attr.shape_check", "exact" },
+        { "attr.residual_path", "true" }
+    };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE swiglu_attr =
+        { "attr.activation", "silu" };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE embedding_attrs[2] = {
+        { "attr.padding_idx", "none" },
+        { "attr.bounds_policy", "runtime_check" }
+    };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE output_attrs[3] = {
+        { "attr.semantic", "token_logits" },
+        { "attr.sequence_axis", "-2" },
+        { "attr.vocabulary_axis", "-1" }
+    };
+    DSL_BUILDER_VERIFY_RESULT verify;
+    DSL_BUILDER_MAPPED_IMAGE_REQUEST request;
+    DSL_BUILDER_SOURCE_POSITION position;
+    DSL_DOMAIN_ID common_id;
+    DSL_DOMAIN_ID transformer_id;
+    DSL_OPCODE_ID linear;
+    DSL_OPCODE_ID reshape;
+    DSL_OPCODE_ID transpose;
+    DSL_OPCODE_ID residual;
+    DSL_OPCODE_ID output;
+    DSL_OPCODE_ID embedding;
+    DSL_OPCODE_ID rms;
+    DSL_OPCODE_ID rotary;
+    DSL_OPCODE_ID attention;
+    DSL_OPCODE_ID swiglu;
+    TY_IDX token_ty;
+    TY_IDX hidden_ty;
+    TY_IDX embedding_weight_ty;
+    TY_IDX hidden_weight_ty;
+    TY_IDX scale_ty;
+    TY_IDX rope_ty;
+    TY_IDX gate_weight_ty;
+    TY_IDX down_weight_ty;
+    TY_IDX logits_weight_ty;
+    UINT32 file_id;
+    char diagnostic[8192];
+    int failed = 0;
+
+    if (!DSL_Builder_Begin_Program())
+        return 1;
+    DSL_Opcode_Register_Common_Substrate();
+    DSL_Opcode_Register_Transformer_Domain();
+    common_id = DSL_Domain_Find("common");
+    transformer_id = DSL_Domain_Find("transformer");
+    linear = DSL_Opcode_Find(common_id, "common.linear", 3);
+    reshape = DSL_Opcode_Find(common_id, "common.reshape", 1);
+    transpose = DSL_Opcode_Find(common_id, "common.transpose", 1);
+    residual = DSL_Opcode_Find(common_id, "common.residual_add", 2);
+    output = DSL_Opcode_Find(common_id, "common.output_logits", 3);
+    embedding = DSL_Opcode_Find
+                    (transformer_id, "transformer.token_embedding", 1);
+    rms = DSL_Opcode_Find(transformer_id, "transformer.rms_norm", 1);
+    rotary = DSL_Opcode_Find
+                 (transformer_id, "transformer.rotary_embedding", 1);
+    attention = DSL_Opcode_Find
+                   (transformer_id, "transformer.attention", 1);
+    swiglu = DSL_Opcode_Find(transformer_id, "transformer.swiglu", 1);
+    if (linear == DSL_OPCODE_INVALID_ID ||
+        reshape == DSL_OPCODE_INVALID_ID ||
+        transpose == DSL_OPCODE_INVALID_ID ||
+        residual == DSL_OPCODE_INVALID_ID ||
+        output == DSL_OPCODE_INVALID_ID ||
+        embedding == DSL_OPCODE_INVALID_ID ||
+        rms == DSL_OPCODE_INVALID_ID || rotary == DSL_OPCODE_INVALID_ID ||
+        attention == DSL_OPCODE_INVALID_ID ||
+        swiglu == DSL_OPCODE_INVALID_ID)
+        return 1;
+
+    memset(&core, 0, sizeof(core));
+    core.kind = "tensor";
+    core.dtype = "int64";
+    core.rank = 2;
+    core.logical_shape = "[1,8]";
+    token_ty = DSL_Builder_Create_Tensor_Type_Core
+                   ("region_token", MTYPE_To_TY(MTYPE_I8), &core);
+    core.dtype = "float32";
+    core.rank = 3;
+    core.logical_shape = "[1,8,32]";
+    hidden_ty = DSL_Builder_Create_Tensor_Type_Core
+                    ("region_hidden", MTYPE_To_TY(MTYPE_F4), &core);
+    core.rank = 2;
+    core.logical_shape = "[128,32]";
+    embedding_weight_ty = DSL_Builder_Create_Tensor_Type_Core
+                              ("region_embedding_weight",
+                               MTYPE_To_TY(MTYPE_F4), &core);
+    core.logical_shape = "[32,32]";
+    hidden_weight_ty = DSL_Builder_Create_Tensor_Type_Core
+                           ("region_hidden_weight",
+                            MTYPE_To_TY(MTYPE_F4), &core);
+    core.rank = 1;
+    core.logical_shape = "[32]";
+    scale_ty = DSL_Builder_Create_Tensor_Type_Core
+                   ("region_scale", MTYPE_To_TY(MTYPE_F4), &core);
+    core.rank = 4;
+    core.logical_shape = "[1,1,8,8]";
+    rope_ty = DSL_Builder_Create_Tensor_Type_Core
+                  ("region_rope", MTYPE_To_TY(MTYPE_F4), &core);
+    core.rank = 2;
+    core.logical_shape = "[88,32]";
+    gate_weight_ty = DSL_Builder_Create_Tensor_Type_Core
+                         ("region_gate_weight", MTYPE_To_TY(MTYPE_F4),
+                          &core);
+    core.logical_shape = "[32,88]";
+    down_weight_ty = DSL_Builder_Create_Tensor_Type_Core
+                         ("region_down_weight", MTYPE_To_TY(MTYPE_F4),
+                          &core);
+    core.logical_shape = "[128,32]";
+    logits_weight_ty = DSL_Builder_Create_Tensor_Type_Core
+                           ("region_logits_weight", MTYPE_To_TY(MTYPE_F4),
+                            &core);
+    if (token_ty == TY_IDX_ZERO || hidden_ty == TY_IDX_ZERO ||
+        embedding_weight_ty == TY_IDX_ZERO ||
+        hidden_weight_ty == TY_IDX_ZERO || scale_ty == TY_IDX_ZERO ||
+        rope_ty == TY_IDX_ZERO || gate_weight_ty == TY_IDX_ZERO ||
+        down_weight_ty == TY_IDX_ZERO || logits_weight_ty == TY_IDX_ZERO)
+        return 1;
+
+    pu = DSL_Builder_Create_Minimal_PU("llama2_transformer_regions");
+    file_id = DSL_Builder_Register_Source_File
+                  (pu, "/tmp/llama2_transformer_regions.py");
+    external[0] = DSL_Builder_Create_Model_Input("tokens", token_ty, 0);
+    const char *tensor_keys[9] = {
+        "tok_embeddings.weight", "layers.0.attention_norm.weight",
+        "layers.0.attention.wq.weight", "rope.cos", "rope.sin",
+        "layers.0.feed_forward.w1.weight",
+        "layers.0.feed_forward.w3.weight",
+        "layers.0.feed_forward.w2.weight", "output.weight"
+    };
+    const UINT64 byte_offsets[9] = {
+        0, 16384, 16512, 20608, 20864, 21120, 32384, 43648, 54912
+    };
+    const UINT64 byte_lengths[9] = {
+        16384, 128, 4096, 256, 256, 11264, 11264, 11264, 16384
+    };
+    const char *external_names[9] = {
+        "embedding_weight", "rms_scale", "hidden_weight", "rope_cos",
+        "rope_sin", "gate_weight", "up_weight", "down_weight",
+        "logits_weight"
+    };
+    TY_IDX external_types[9] = {
+        embedding_weight_ty, scale_ty, hidden_weight_ty, rope_ty, rope_ty,
+        gate_weight_ty, gate_weight_ty, down_weight_ty, logits_weight_ty
+    };
+    for (UINT32 i = 0; i < 9; ++i) {
+        TY_tensor_bind_attribute
+            (external_types[i], TY_TENSOR_SCHEMA_LAYOUT, "row_major");
+        TY_tensor_bind_attribute
+            (external_types[i], TY_TENSOR_SCHEMA_PLACEMENT, "side_file");
+        TY_tensor_bind_attribute
+            (external_types[i], TY_TENSOR_SCHEMA_MEMORY, "external_data");
+        references[i].storage_format = "safetensors";
+        references[i].side_file = "llama2.safetensors";
+        references[i].tensor_key = tensor_keys[i];
+        references[i].byte_offset = byte_offsets[i];
+        references[i].byte_length = byte_lengths[i];
+        references[i].checksum = "";
+        external[i + 1] = DSL_Builder_Create_External_Tensor_Constant
+                              (external_names[i], external_types[i],
+                               &references[i]);
+    }
+    memset(&position, 0, sizeof(position));
+    position.file_id = file_id;
+    position.column = 1;
+    position.statement_begin = 1;
+    for (UINT32 i = 0; i < 10; ++i) {
+        position.line = 10 + i;
+        if (external[i] == NULL ||
+            !DSL_Builder_Set_Value_Source_Position(external[i], &position) ||
+            !DSL_Builder_Append_PU_Value(pu, external[i]))
+            return 1;
+    }
+
+    prefill = DSL_Builder_Create_Region
+                  (pu, NULL, "transformer.prefill", 1);
+    decoder = DSL_Builder_Create_Region
+                  (pu, prefill, "transformer.decoder_layer", 1);
+    position.line = 30;
+    position.basic_block_begin = 1;
+    if (prefill == NULL || decoder == NULL ||
+        !DSL_Builder_Set_Region_Source_Position(prefill, &position) ||
+        !DSL_Builder_Set_Region_Metadata
+             (prefill, "module_path", "TinyLlama.forward"))
+        return 1;
+    position.line = 40;
+    if (!DSL_Builder_Set_Region_Source_Position(decoder, &position) ||
+        !DSL_Builder_Set_Region_Metadata
+             (decoder, "module_path", "layers.0") ||
+        !DSL_Builder_Set_Region_Metadata(decoder, "layer_ordinal", "0"))
+        return 1;
+
+    kids[0] = external[0];
+    kids[1] = external[1];
+    prefill_values[0] = DSL_Builder_Create_Operator
+                            (embedding, 1, kids, 2, embedding_attrs, 2);
+    if (prefill_values[0] == NULL)
+        return 1;
+    TY_IDX embedding_result_ty =
+        DSL_Builder_Get_Value_Type(prefill_values[0]);
+    const char *embedding_placement = TY_tensor_attribute
+        (embedding_result_ty, TY_TENSOR_SCHEMA_PLACEMENT);
+    const char *embedding_memory = TY_tensor_attribute
+        (embedding_result_ty, TY_TENSOR_SCHEMA_MEMORY);
+    if ((embedding_placement != NULL &&
+         strcmp(embedding_placement, "side_file") == 0) ||
+        (embedding_memory != NULL &&
+         strcmp(embedding_memory, "external_data") == 0)) {
+        fprintf(stderr, "item-26 external storage escaped into activation\n");
+        return 1;
+    }
+    kids[0] = prefill_values[0];
+    kids[1] = external[2];
+    decoder_values[0] = DSL_Builder_Create_Operator
+                            (rms, 1, kids, 2, rms_attrs, 3);
+    for (UINT32 i = 1; i <= 3; ++i) {
+        kids[0] = decoder_values[0];
+        kids[1] = external[3];
+        decoder_values[i] = DSL_Builder_Create_Operator
+                                (linear, 3, kids, 2, linear_attrs, 4);
+    }
+    kids[0] = decoder_values[1];
+    decoder_values[4] = DSL_Builder_Create_Operator
+                            (reshape, 1, kids, 1, &reshape_head, 1);
+    kids[0] = decoder_values[4];
+    decoder_values[5] = DSL_Builder_Create_Operator
+                            (transpose, 1, kids, 1, &transpose_head, 1);
+    kids[0] = decoder_values[5];
+    kids[1] = external[4];
+    kids[2] = external[5];
+    decoder_values[6] = DSL_Builder_Create_Operator
+                            (rotary, 1, kids, 3, rotary_attrs, 6);
+    decoder_values[7] = DSL_Builder_Create_Operator
+                            (rotary, 1, kids, 3, rotary_attrs, 6);
+    kids[0] = decoder_values[6];
+    kids[1] = decoder_values[7];
+    kids[2] = decoder_values[5];
+    decoder_values[8] = DSL_Builder_Create_Operator
+                            (attention, 1, kids, 3, attention_attrs, 10);
+    kids[0] = decoder_values[8];
+    decoder_values[9] = DSL_Builder_Create_Operator
+                            (transpose, 1, kids, 1, &transpose_head, 1);
+    kids[0] = decoder_values[9];
+    decoder_values[10] = DSL_Builder_Create_Operator
+                             (reshape, 1, kids, 1, &reshape_hidden, 1);
+    kids[0] = decoder_values[10];
+    kids[1] = external[3];
+    decoder_values[11] = DSL_Builder_Create_Operator
+                             (linear, 3, kids, 2, linear_attrs, 4);
+    kids[0] = prefill_values[0];
+    kids[1] = decoder_values[11];
+    decoder_values[12] = DSL_Builder_Create_Operator
+                             (residual, 2, kids, 2, residual_attrs, 3);
+    kids[0] = decoder_values[12];
+    kids[1] = external[2];
+    decoder_values[13] = DSL_Builder_Create_Operator
+                             (rms, 1, kids, 2, rms_attrs, 3);
+    kids[0] = decoder_values[13];
+    kids[1] = external[6];
+    decoder_values[14] = DSL_Builder_Create_Operator
+                             (linear, 3, kids, 2, linear_attrs, 4);
+    kids[1] = external[7];
+    decoder_values[15] = DSL_Builder_Create_Operator
+                             (linear, 3, kids, 2, linear_attrs, 4);
+    kids[0] = decoder_values[14];
+    kids[1] = decoder_values[15];
+    decoder_values[16] = DSL_Builder_Create_Operator
+                             (swiglu, 1, kids, 2, &swiglu_attr, 1);
+    kids[0] = decoder_values[16];
+    kids[1] = external[8];
+    decoder_values[17] = DSL_Builder_Create_Operator
+                             (linear, 3, kids, 2, linear_attrs, 4);
+    kids[0] = decoder_values[12];
+    kids[1] = decoder_values[17];
+    decoder_values[18] = DSL_Builder_Create_Operator
+                             (residual, 2, kids, 2, residual_attrs, 3);
+    kids[0] = decoder_values[18];
+    kids[1] = external[2];
+    prefill_values[1] = DSL_Builder_Create_Operator
+                            (rms, 1, kids, 2, rms_attrs, 3);
+    kids[0] = prefill_values[1];
+    kids[1] = external[9];
+    prefill_values[2] = DSL_Builder_Create_Operator
+                            (linear, 3, kids, 2, linear_attrs, 4);
+    kids[0] = prefill_values[2];
+    prefill_values[3] = DSL_Builder_Create_Operator
+                            (output, 3, kids, 1, output_attrs, 3);
+
+    position.basic_block_begin = 0;
+    position.line = 31;
+    if (prefill_values[0] == NULL ||
+        !DSL_Builder_Set_Value_Source_Position(prefill_values[0], &position) ||
+        !DSL_Builder_Append_Region_Value(prefill, prefill_values[0]))
+        return 1;
+    for (UINT32 i = 0; i < 19; ++i) {
+        position.line = 41 + i;
+        if (decoder_values[i] == NULL ||
+            !DSL_Builder_Set_Value_Source_Position
+                 (decoder_values[i], &position) ||
+            !DSL_Builder_Append_Region_Value(decoder, decoder_values[i]))
+            return 1;
+    }
+    if (!DSL_Builder_Append_Child_Region(prefill, decoder))
+        return 1;
+    for (UINT32 i = 1; i < 4; ++i) {
+        position.line = 61 + i;
+        if (prefill_values[i] == NULL ||
+            !DSL_Builder_Set_Value_Source_Position
+                 (prefill_values[i], &position) ||
+            !DSL_Builder_Append_Region_Value(prefill, prefill_values[i]))
+            return 1;
+    }
+
+    DSL_BUILDER_VALUE decoder_inputs[8] = {
+        prefill_values[0], external[2], external[3], external[4],
+        external[5], external[6], external[7], external[8]
+    };
+    for (UINT32 i = 0; i < 8; ++i) {
+        if (!DSL_Builder_Declare_Region_Value
+                 (decoder, decoder_inputs[i], DSL_REGION_VALUE_INPUT,
+                  i, 0))
+            return 1;
+    }
+    if (!DSL_Builder_Declare_Region_Value
+             (decoder, decoder_values[18],
+              DSL_REGION_VALUE_OUTPUT | DSL_REGION_VALUE_RESULT, 0, 0))
+        return 1;
+    for (UINT32 i = 0; i < 10; ++i) {
+        if (!DSL_Builder_Declare_Region_Value
+                 (prefill, external[i], DSL_REGION_VALUE_INPUT, i, 0))
+            return 1;
+    }
+    if (!DSL_Builder_Declare_Region_Value
+             (prefill, prefill_values[3],
+              DSL_REGION_VALUE_OUTPUT | DSL_REGION_VALUE_RESULT, 0, 0) ||
+        !DSL_Builder_Append_PU_Region(pu, prefill))
+        return 1;
+
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (!DSL_Builder_Verify_Program(&verify) || verify.error_count != 0) {
+        fprintf(stderr, "item-25 verifier rejected valid prefill: %s\n",
+                diagnostic);
+        failed = 1;
+    }
+
+    ST_IDX result_st =
+        DSL_Builder_Get_Value_Result_Symbol(prefill_values[3]);
+    ST_tensor_bind_attribute
+        (result_st, TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_NO_ALIAS),
+         "false");
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (DSL_Builder_Verify_Program(&verify) || verify.error_count == 0 ||
+        strstr(diagnostic, "DOPC_LLAMA_TOPOLOGY") == NULL) {
+        fprintf(stderr, "item-25 verifier accepted aliased region result\n");
+        failed = 1;
+    }
+    ST_tensor_bind_attribute
+        (result_st, TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_NO_ALIAS),
+         "true");
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (!DSL_Builder_Verify_Program(&verify) || verify.error_count != 0) {
+        fprintf(stderr, "item-25 verifier did not accept restored result: "
+                "%s\n", diagnostic);
+        failed = 1;
+    }
+
+    WN *decoder_body = WN_region_body(DSL_Region_WN(decoder));
+    WN *first_decoder_value = WN_first(decoder_body);
+    WN *second_decoder_value = WN_next(first_decoder_value);
+    WN_EXTRACT_FromBlock(decoder_body, first_decoder_value);
+    WN_INSERT_BlockAfter
+        (decoder_body, second_decoder_value, first_decoder_value);
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (DSL_Builder_Verify_Program(&verify) || verify.error_count == 0 ||
+        strstr(diagnostic, "DOPC_LLAMA_TOPOLOGY") == NULL) {
+        fprintf(stderr, "item-25 verifier accepted reordered decoder body\n");
+        failed = 1;
+    }
+    WN_EXTRACT_FromBlock(decoder_body, first_decoder_value);
+    WN_INSERT_BlockFirst(decoder_body, first_decoder_value);
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (!DSL_Builder_Verify_Program(&verify) || verify.error_count != 0) {
+        fprintf(stderr, "item-25 verifier did not accept restored topology: "
+                "%s\n", diagnostic);
+        failed = 1;
+    }
+
+    FILE *dump = tmpfile();
+    if (dump == NULL) {
+        failed = 1;
+    } else {
+        char text[16384];
+        DSL_Region_Print_PU(dump, pu);
+        rewind(dump);
+        size_t count = fread(text, 1, sizeof(text) - 1, dump);
+        text[count] = '\0';
+        fclose(dump);
+        if (strstr(text, "contract=transformer.prefill.v1") == NULL ||
+            strstr(text, "contract=transformer.decoder_layer.v1") == NULL ||
+            strstr(text, "METADATA module_path:TinyLlama.forward") == NULL ||
+            strstr(text, "METADATA module_path:layers.0") == NULL ||
+            strstr(text, "METADATA layer_ordinal:0") == NULL ||
+            strstr(text, "roles=0xa") == NULL) {
+            fprintf(stderr, "item-25 logical region inspection changed\n");
+            failed = 1;
+        }
+    }
+
+    const char *artifact = getenv("OPEN64_DSL_LLAMA2_REGION_ARTIFACT");
+    request.path = artifact == NULL || artifact[0] == '\0' ?
+                   "llama2_transformer_regions.B" : artifact;
+    request.flags = 0;
+    (void) unlink(request.path);
+    if (!DSL_Builder_Finalize_Mapped_Image(&request) ||
+        access(request.path, F_OK) != 0) {
+        fprintf(stderr, "item-25 mapped-image finalization failed\n");
+        failed = 1;
+    }
+    if (artifact == NULL || artifact[0] == '\0')
+        (void) unlink(request.path);
+    return failed;
+}
+
+static int
 Check_Structured_Region_Builder(void)
 {
     DSL_BUILDER_TENSOR_DESCRIPTOR descriptor;
@@ -1719,6 +2828,14 @@ main(void)
     Initialize_Test_Context();
     if (getenv("OPEN64_DSL_INGESTION_API_ONLY") != NULL)
         return Check_Upgraded_Ingestion_APIs();
+    if (getenv("OPEN64_DSL_LLAMA2_COMMON_ONLY") != NULL)
+        return Check_Llama2_Common_Substrate();
+    if (getenv("OPEN64_DSL_LLAMA2_TRANSFORMER_ONLY") != NULL)
+        return Check_Llama2_Transformer_Expressions();
+    if (getenv("OPEN64_DSL_LLAMA2_REGIONS_ONLY") != NULL)
+        return Check_Llama2_Transformer_Regions();
+    if (getenv("OPEN64_DSL_STRUCTURED_REGION_ONLY") != NULL)
+        return Check_Structured_Region_Builder();
 
     failed |= Check_Tensor_Type_And_Descriptor();
     failed |= Check_Symbol_Metadata();
@@ -1726,6 +2843,9 @@ main(void)
     failed |= Check_Mapped_Image_Finalizer();
     failed |= Check_Program_Unit_Value_Attach();
     failed |= Check_Production_Native_Builder();
+    failed |= Check_Llama2_Common_Substrate();
+    failed |= Check_Llama2_Transformer_Expressions();
+    failed |= Check_Llama2_Transformer_Regions();
     failed |= Check_Structured_Region_Builder();
     failed |= Check_Native_DSL_Node_Layout();
     failed |= Check_DSL_IR_Image_Tables();

--- a/osprey/common/com/tests/dsl_common_add_print_test.cxx
+++ b/osprey/common/com/tests/dsl_common_add_print_test.cxx
@@ -868,7 +868,8 @@ Check_DSL_Logical_ResNet_Contracts(void)
             DSL_Operator_Find_Current(contract.stable_name,
                                       strlen(contract.stable_name)) !=
                 contract.dsl_operator ||
-            !DSL_Operator_Get_Info(contract.dsl_operator, &info) ||
+            !DSL_Operator_Get_Info_Version
+                 (contract.dsl_operator, contract.version, &info) ||
             strcmp(info.logical_name, contract.logical_name) != 0 ||
             strcmp(info.stable_name, contract.stable_name) != 0 ||
             info.version != contract.version ||
@@ -890,7 +891,7 @@ Check_DSL_Logical_ResNet_Contracts(void)
 static int
 Check_DSL_Opcode_Registry(void)
 {
-    const UINT32 common_seed_count = 68;
+    const UINT32 common_seed_count = 71;
     const UINT32 wrapper_seed_count = 12;
     DSL_DOMAIN_ID common_id;
     DSL_DOMAIN_ID cnn_id;

--- a/osprey/common/com/tests/dsl_llama2_artifact_compat_test.sh
+++ b/osprey/common/com/tests/dsl_llama2_artifact_compat_test.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Inspect the staged Llama 2 DSL artifacts and optional older WHIRL images.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+contract_test="${OPEN64_DSL_CONTRACT_TEST:-$repo_root/build/osprey/targdir/ir_tools/dsl_builder_contract_test}"
+ir_b2a="${OPEN64_IR_B2A:-$repo_root/build/osprey/targdir/ir_tools/ir_b2a}"
+work_dir="${OPEN64_DSL_LLAMA2_COMPAT_DIR:-${TMPDIR:-/tmp}/open64-llama2-compat.$$}"
+
+require_executable()
+{
+  if [[ ! -x "$1" ]]; then
+    echo "missing executable: $1" >&2
+    exit 1
+  fi
+}
+
+require_text()
+{
+  local file="$1"
+  local pattern="$2"
+
+  if ! grep -Fq "$pattern" "$file"; then
+    echo "missing artifact evidence '$pattern' in $file" >&2
+    exit 1
+  fi
+}
+
+reject_text()
+{
+  local file="$1"
+  local pattern="$2"
+
+  if grep -Eq "$pattern" "$file"; then
+    echo "private physical DSL evidence '$pattern' leaked into $file" >&2
+    exit 1
+  fi
+}
+
+inspect_image()
+{
+  local image="$1"
+  local trace="$2"
+
+  "$ir_b2a" -st -src "$image" > "$trace"
+  require_text "$trace" "Symbols:"
+  require_text "$trace" "Types:"
+}
+
+require_executable "$contract_test"
+require_executable "$ir_b2a"
+mkdir -p "$work_dir"
+
+OPEN64_DSL_LLAMA2_COMMON_ONLY=1 \
+OPEN64_DSL_LLAMA2_COMMON_ARTIFACT="$work_dir/llama2_common_substrate.B" \
+  "$contract_test"
+OPEN64_DSL_LLAMA2_TRANSFORMER_ONLY=1 \
+OPEN64_DSL_LLAMA2_TRANSFORMER_ARTIFACT="$work_dir/llama2_transformer_expressions.B" \
+  "$contract_test"
+OPEN64_DSL_LLAMA2_REGIONS_ONLY=1 \
+OPEN64_DSL_LLAMA2_REGION_ARTIFACT="$work_dir/llama2_transformer_regions.B" \
+  "$contract_test"
+
+inspect_image "$work_dir/llama2_common_substrate.B" \
+              "$work_dir/llama2_common_substrate.T"
+inspect_image "$work_dir/llama2_transformer_expressions.B" \
+              "$work_dir/llama2_transformer_expressions.T"
+inspect_image "$work_dir/llama2_transformer_regions.B" \
+              "$work_dir/llama2_transformer_regions.T"
+
+common_trace="$work_dir/llama2_common_substrate.T"
+transformer_trace="$work_dir/llama2_transformer_expressions.T"
+region_trace="$work_dir/llama2_transformer_regions.T"
+
+for evidence in \
+  "operator=OPR_DSLRESHAPE version=1" \
+  "operator=OPR_DSLTRANSPOSE version=1" \
+  "operator=OPR_DSLLINEAR version=3" \
+  "operator=OPR_DSLMATMUL version=2" \
+  "operator=OPR_DSLOUTPUTLOGITS version=3"; do
+  require_text "$common_trace" "$evidence"
+done
+
+for evidence in \
+  "operator=OPR_DSLTOKENEMBEDDING version=1" \
+  "operator=OPR_DSLRMSNORM version=1" \
+  "operator=OPR_DSLROTARYEMBEDDING version=1" \
+  "operator=OPR_DSLATTENTION version=1" \
+  "operator=OPR_DSLSWIGLU version=1"; do
+  require_text "$transformer_trace" "$evidence"
+done
+
+for evidence in \
+  "DSL IR Image: version=1" \
+  "DSL Opcode Descriptor Table:" \
+  "DSL Node Table:" \
+  "DSL Attribute Table:" \
+  "DSL Value Table:" \
+  "DSL Value Reference Table:" \
+  "TensorDescriptorIR view:" \
+  "REGION id=1 parent=0 depth=1 kind=0 contract=transformer.prefill.v1" \
+  "REGION id=2 parent=1 depth=2 kind=0 contract=transformer.decoder_layer.v1" \
+  "contract=transformer.prefill.v1" \
+  "contract=transformer.decoder_layer.v1" \
+  "METADATA module_path:TinyLlama.forward" \
+  "METADATA module_path:layers.0" \
+  "METADATA layer_ordinal:0" \
+  "storage_format = safetensors" \
+  "storage_file = llama2.safetensors" \
+  "storage_tensor_key = tok_embeddings.weight" \
+  "value_kind=external_data" \
+  "LOC 0 40"; do
+  require_text "$region_trace" "$evidence"
+done
+
+if [[ "$(grep -Fc "storage_format = safetensors" "$region_trace")" -ne 9 ]]; then
+  echo "external tensor reference count changed in $region_trace" >&2
+  exit 1
+fi
+
+for trace in "$common_trace" "$transformer_trace" "$region_trace"; do
+  reject_text "$trace" "(^|[[:space:]])OPR_DSL([[:space:]]|$)"
+  reject_text "$trace" "(^|[[:space:]])MDSL([[:space:]]|$)"
+done
+
+if [[ -n "${OPEN64_DSL_OLD_IMAGE:-}" ]]; then
+  inspect_image "$OPEN64_DSL_OLD_IMAGE" "$work_dir/old_image.T"
+  require_text "$work_dir/old_image.T" "FUNC_ENTRY"
+  if grep -Fq "DSL REGION TABLE:" "$work_dir/old_image.T"; then
+    echo "older image unexpectedly acquired a REGION table" >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "${OPEN64_DSL_RESNET_IMAGE:-}" ]]; then
+  inspect_image "$OPEN64_DSL_RESNET_IMAGE" "$work_dir/resnet.T"
+  require_text "$work_dir/resnet.T" "common.model_input"
+  require_text "$work_dir/resnet.T" "common.residual_add"
+  reject_text "$work_dir/resnet.T" "(^|[[:space:]])OPR_DSL([[:space:]]|$)"
+  reject_text "$work_dir/resnet.T" "(^|[[:space:]])MDSL([[:space:]]|$)"
+fi
+
+echo "Llama 2 artifact compatibility fixture passed"
+echo "review artifacts: $work_dir"

--- a/osprey/common/com/tests/dsl_llama2_prefill_process_test.sh
+++ b/osprey/common/com/tests/dsl_llama2_prefill_process_test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# Preserve process-boundary evidence for the tiny Llama 2 prefill contract.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+build_dir="${OPEN64_BUILD_DIR:-$repo_root/build}"
+mode="${OPEN64_DSL_LLAMA2_CERT_MODE:-full}"
+artifact_dir="${OPEN64_DSL_LLAMA2_CERT_DIR:-$repo_root/artifacts/item28}"
+producer="${OPEN64_DSL_CONTRACT_TEST:-$build_dir/osprey/targdir/ir_tools/dsl_builder_contract_test}"
+ir_b2a="${OPEN64_IR_B2A:-$build_dir/osprey/targdir/ir_tools/ir_b2a}"
+openpy="${OPEN64_OPENPY:-$build_dir/osprey/targdir/driver/openpy}"
+frontend="${OPEN64_TORCH2WHIRL:-$build_dir/osprey/targdir/torch2whirl/torch2whirl}"
+model="${OPEN64_DSL_LLAMA2_MODEL:-$repo_root/osprey/torch2whirl/python/tests/models/llama2_model.py}"
+
+require_executable()
+{
+  if [[ ! -x "$1" ]]; then
+    echo "missing executable: $1" >&2
+    exit 1
+  fi
+}
+
+require_file()
+{
+  if [[ ! -s "$1" ]]; then
+    echo "missing or empty artifact: $1" >&2
+    exit 1
+  fi
+}
+
+require_text()
+{
+  local file="$1"
+  local pattern="$2"
+
+  if ! grep -Fq "$pattern" "$file"; then
+    echo "missing artifact evidence '$pattern' in $file" >&2
+    exit 1
+  fi
+}
+
+reject_text()
+{
+  local file="$1"
+  local pattern="$2"
+
+  if grep -Eq "$pattern" "$file"; then
+    echo "private or unlowered evidence '$pattern' leaked into $file" >&2
+    exit 1
+  fi
+}
+
+inspect_prefill()
+{
+  local image="$1"
+  local trace="$2"
+
+  "$ir_b2a" -st -src "$image" > "$trace"
+  for evidence in \
+    "operator=OPR_DSLTOKENEMBEDDING version=1" \
+    "operator=OPR_DSLRMSNORM version=1" \
+    "operator=OPR_DSLROTARYEMBEDDING version=1" \
+    "operator=OPR_DSLATTENTION version=1" \
+    "operator=OPR_DSLSWIGLU version=1" \
+    "operator=OPR_DSLLINEAR version=3" \
+    "operator=OPR_DSLOUTPUTLOGITS version=3" \
+    "contract=transformer.prefill.v1" \
+    "contract=transformer.decoder_layer.v1" \
+    "storage_format = safetensors" \
+    "storage_file = llama2.safetensors" \
+    "value_kind=external_data" \
+    "LOC 0"; do
+    require_text "$trace" "$evidence"
+  done
+  reject_text "$trace" "(^|[[:space:]])OPR_DSL([[:space:]]|$)"
+  reject_text "$trace" "(^|[[:space:]])MDSL([[:space:]]|$)"
+}
+
+case "$mode" in
+  native|full)
+    ;;
+  *)
+    echo "unknown certification mode: $mode (expected native or full)" >&2
+    exit 1
+    ;;
+esac
+
+require_executable "$producer"
+require_executable "$ir_b2a"
+mkdir -p "$artifact_dir"
+find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -delete
+
+OPEN64_DSL_LLAMA2_REGIONS_ONLY=1 \
+OPEN64_DSL_LLAMA2_REGION_ARTIFACT="$artifact_dir/llama2.B" \
+  "$producer" > "$artifact_dir/native-producer.log" 2>&1
+require_file "$artifact_dir/llama2.B"
+inspect_prefill "$artifact_dir/llama2.B" "$artifact_dir/llama2.T"
+
+cat > "$artifact_dir/certification.txt" <<EOF
+mode=$mode
+native_builder=passed
+gatekeeper_positive=passed
+gatekeeper_stable_rejections=passed
+mapped_image_reopen=passed
+ir_b2a_st_src=passed
+source_correlation=passed
+external_tensor_references=passed
+region_interfaces=passed
+EOF
+
+if [[ "$mode" == "native" ]]; then
+  echo "native Llama 2 process-boundary preflight passed"
+  echo "review artifacts: $artifact_dir"
+  exit 0
+fi
+
+require_executable "$openpy"
+require_executable "$frontend"
+require_file "$model"
+
+cp "$model" "$artifact_dir/llama2.py"
+rm -f "$artifact_dir/llama2.B" "$artifact_dir/llama2.T"
+(
+  cd "$artifact_dir"
+  "$openpy" -run-build="$build_dir" -keep -O0 llama2.py
+) > "$artifact_dir/openpy.log" 2>&1
+
+require_file "$artifact_dir/llama2.B"
+require_file "$artifact_dir/llama2.safetensors"
+require_file "$artifact_dir/llama2.t"
+inspect_prefill "$artifact_dir/llama2.B" "$artifact_dir/llama2.T"
+
+for runtime in \
+  "__open64_dsl_transformer_token_embedding_v1" \
+  "__open64_dsl_transformer_rms_norm_v1" \
+  "__open64_dsl_transformer_rotary_embedding_v1" \
+  "__open64_dsl_transformer_attention_v1" \
+  "__open64_dsl_transformer_swiglu_v1"; do
+  require_text "$artifact_dir/llama2.t" "$runtime"
+done
+reject_text "$artifact_dir/llama2.t" "OPR_DSL[A-Z]"
+
+cat >> "$artifact_dir/certification.txt" <<EOF
+python_frontend=passed
+safetensors_side_file=passed
+openpy_keep=passed
+vho_dsl_lower_o0=passed
+EOF
+
+echo "full Llama 2 process-boundary certification passed"
+echo "review artifacts: $artifact_dir"

--- a/osprey/common/com/tests/dsl_llama2_prefill_process_test.sh
+++ b/osprey/common/com/tests/dsl_llama2_prefill_process_test.sh
@@ -91,7 +91,7 @@ esac
 require_executable "$producer"
 require_executable "$ir_b2a"
 mkdir -p "$artifact_dir"
-find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -delete
+find "$artifact_dir" -mindepth 1 -delete
 
 OPEN64_DSL_LLAMA2_REGIONS_ONLY=1 \
 OPEN64_DSL_LLAMA2_REGION_ARTIFACT="$artifact_dir/llama2.B" \

--- a/osprey/common/com/tests/dsl_llama2_prefill_process_test.sh
+++ b/osprey/common/com/tests/dsl_llama2_prefill_process_test.sh
@@ -131,17 +131,19 @@ rm -f "$artifact_dir/llama2.B" "$artifact_dir/llama2.T"
 require_file "$artifact_dir/llama2.B"
 require_file "$artifact_dir/llama2.safetensors"
 require_file "$artifact_dir/llama2.t"
-inspect_prefill "$artifact_dir/llama2.B" "$artifact_dir/llama2.T"
+mkdir -p "$artifact_dir/binary" "$artifact_dir/lowered"
+mv "$artifact_dir/llama2.t" "$artifact_dir/lowered/llama2.t"
+inspect_prefill "$artifact_dir/llama2.B" "$artifact_dir/binary/llama2.T"
 
 for runtime in \
-  "__open64_dsl_transformer_token_embedding_v1" \
-  "__open64_dsl_transformer_rms_norm_v1" \
-  "__open64_dsl_transformer_rotary_embedding_v1" \
-  "__open64_dsl_transformer_attention_v1" \
-  "__open64_dsl_transformer_swiglu_v1"; do
-  require_text "$artifact_dir/llama2.t" "$runtime"
+  "__open64_dsl_token_embedding_v1" \
+  "__open64_dsl_rms_norm_v1" \
+  "__open64_dsl_rotary_embedding_v1" \
+  "__open64_dsl_attention_v1" \
+  "__open64_dsl_swiglu_v1"; do
+  require_text "$artifact_dir/lowered/llama2.t" "$runtime"
 done
-reject_text "$artifact_dir/llama2.t" "OPR_DSL[A-Z]"
+reject_text "$artifact_dir/lowered/llama2.t" "OPR_DSL[A-Z]"
 
 cat >> "$artifact_dir/certification.txt" <<EOF
 python_frontend=passed

--- a/osprey/common/com/wn.cxx
+++ b/osprey/common/com/wn.cxx
@@ -2423,8 +2423,7 @@ DSL_WN_Create_Native
     const size_t extra_kids = operand_count > 2 ? operand_count - 2 : 0;
     DSL_OPERATOR_INFO info;
 
-    if (!DSL_Operator_Get_Info(dsl_operator, &info) ||
-        info.version != version ||
+    if (!DSL_Operator_Get_Info_Version(dsl_operator, version, &info) ||
         (info.nkids >= 0 && (UINT32)info.nkids != operand_count) ||
         extra_kids > (INT16_MAX - fixed_size) / sizeof(WN *) ||
         (operand_count != 0 && operands == NULL))
@@ -2455,8 +2454,7 @@ DSL_WN_Create_Logical_Opcode
 {
     DSL_OPERATOR_INFO info;
 
-    if (!DSL_Operator_Get_Info(dsl_operator, &info) ||
-        info.version != version ||
+    if (!DSL_Operator_Get_Info_Version(dsl_operator, version, &info) ||
         (info.nkids >= 0 && (UINT32)info.nkids != operand_count) ||
         (operand_count != 0 && operands == NULL))
         return NULL;
@@ -3024,6 +3022,7 @@ DSL_WN_Get_Logical_Opcode
     DSL_WHIRL_NODE_RECORD record;
     DSL_OPERATOR dsl_operator;
     DSL_OPERATOR_INFO info;
+    DSL_OPERATOR_INFO current_info;
     BOOL operator_known;
     DSL_OPCODE_VERSION_DISPOSITION disposition =
         DSL_OPCODE_VERSION_INVALID;
@@ -3046,14 +3045,18 @@ DSL_WN_Get_Logical_Opcode
     dsl_operator = DSL_Operator_Find_Current(record.opcode_name,
                                               record.opcode_name_len);
     operator_known = dsl_operator != OPR_DSLUNKNOWN &&
-                     DSL_Operator_Get_Info(dsl_operator, &info);
+                     DSL_Operator_Get_Info_Version
+                         (dsl_operator, record.version, &info);
     if (!operator_known) {
-        dsl_operator = OPR_DSLUNKNOWN;
-        disposition = DSL_OPCODE_VERSION_REJECTED_UNKNOWN_OPERATOR;
-    } else if (record.version < info.version) {
-        disposition = DSL_OPCODE_VERSION_REJECTED_OLDER;
-    } else if (record.version > info.version) {
-        disposition = DSL_OPCODE_VERSION_REJECTED_NEWER;
+        if (dsl_operator == OPR_DSLUNKNOWN ||
+            !DSL_Operator_Get_Info(dsl_operator, &current_info)) {
+            dsl_operator = OPR_DSLUNKNOWN;
+            disposition = DSL_OPCODE_VERSION_REJECTED_UNKNOWN_OPERATOR;
+        } else if (record.version < current_info.version) {
+            disposition = DSL_OPCODE_VERSION_REJECTED_OLDER;
+        } else {
+            disposition = DSL_OPCODE_VERSION_REJECTED_NEWER;
+        }
     } else {
         disposition = DSL_OPCODE_VERSION_EXACT;
     }
@@ -3062,7 +3065,8 @@ DSL_WN_Get_Logical_Opcode
         logical_opcode->dsl_operator = dsl_operator;
         logical_opcode->source_version = record.version;
         logical_opcode->effective_version =
-            operator_known ? info.version : 0;
+            operator_known ? record.version :
+            (dsl_operator == OPR_DSLUNKNOWN ? 0 : current_info.version);
         logical_opcode->payload = record.payload == NULL ? "" : record.payload;
         logical_opcode->carrier = record.carrier;
         logical_opcode->version_disposition = disposition;

--- a/osprey/include/open64_dsl_runtime_abi.h
+++ b/osprey/include/open64_dsl_runtime_abi.h
@@ -94,7 +94,8 @@ typedef enum {
 
 typedef enum {
     OPEN64_DSL_OUTPUT_SEMANTIC_UNSPECIFIED = 0,
-    OPEN64_DSL_OUTPUT_SEMANTIC_LOGITS = 1
+    OPEN64_DSL_OUTPUT_SEMANTIC_LOGITS = 1,
+    OPEN64_DSL_OUTPUT_SEMANTIC_TOKEN_LOGITS = 2
 } OPEN64_DSL_RUNTIME_OUTPUT_SEMANTIC;
 
 typedef enum {
@@ -248,6 +249,40 @@ OPEN64_DSL_TENSOR_HANDLE __open64_dsl_global_avg_pool2d_v1
                                  uint32_t output_h,
                                  uint32_t output_w,
                                  uint32_t reduction_axes);
+OPEN64_DSL_TENSOR_HANDLE __open64_dsl_reshape_v1
+                                (OPEN64_DSL_TENSOR_HANDLE kid0,
+                                 const OPEN64_DSL_TENSOR_DESCRIPTOR_V1 *result);
+OPEN64_DSL_TENSOR_HANDLE __open64_dsl_transpose_v1
+                                (OPEN64_DSL_TENSOR_HANDLE kid0,
+                                 const OPEN64_DSL_TENSOR_DESCRIPTOR_V1 *result,
+                                 const char *permutation);
+OPEN64_DSL_TENSOR_HANDLE __open64_dsl_token_embedding_v1
+                                (OPEN64_DSL_TENSOR_HANDLE token_ids,
+                                 OPEN64_DSL_TENSOR_HANDLE weight,
+                                 const OPEN64_DSL_TENSOR_DESCRIPTOR_V1 *result);
+OPEN64_DSL_TENSOR_HANDLE __open64_dsl_rms_norm_v1
+                                (OPEN64_DSL_TENSOR_HANDLE kid0,
+                                 OPEN64_DSL_TENSOR_HANDLE scale,
+                                 const OPEN64_DSL_TENSOR_DESCRIPTOR_V1 *result,
+                                 uint64_t epsilon_bits,
+                                 int32_t axis);
+OPEN64_DSL_TENSOR_HANDLE __open64_dsl_rotary_embedding_v1
+                                (OPEN64_DSL_TENSOR_HANDLE kid0,
+                                 OPEN64_DSL_TENSOR_HANDLE cosine,
+                                 OPEN64_DSL_TENSOR_HANDLE sine,
+                                 const OPEN64_DSL_TENSOR_DESCRIPTOR_V1 *result);
+OPEN64_DSL_TENSOR_HANDLE __open64_dsl_attention_v1
+                                (OPEN64_DSL_TENSOR_HANDLE query,
+                                 OPEN64_DSL_TENSOR_HANDLE key,
+                                 OPEN64_DSL_TENSOR_HANDLE value,
+                                 const OPEN64_DSL_TENSOR_DESCRIPTOR_V1 *result,
+                                 uint32_t query_heads,
+                                 uint32_t kv_heads,
+                                 uint32_t head_dim);
+OPEN64_DSL_TENSOR_HANDLE __open64_dsl_swiglu_v1
+                                (OPEN64_DSL_TENSOR_HANDLE gate,
+                                 OPEN64_DSL_TENSOR_HANDLE up,
+                                 const OPEN64_DSL_TENSOR_DESCRIPTOR_V1 *result);
 
 #ifdef __cplusplus
 }

--- a/osprey/ir_tools/Makefile.gbase
+++ b/osprey/ir_tools/Makefile.gbase
@@ -155,6 +155,7 @@ BE_VHO_DIR= $(BUILD_TOT)/be/vho
 BE_OPT_DIR= $(BUILD_TOT)/be/opt
 
 LDIRT = $(TARGETS)
+LDIRT += dsl_builder_contract_test dsl_builder_contract_test.o
 
 LCINCS = -I$(BUILD_BASE) -I$(COMMON_COM_DIR) -I$(COMMON_COM_TARG_DIR) \
 	-I$(COMMON_UTIL_DIR) -I$(BE_COM_DIR) -I$(BE_VHO_DIR) -I$(BE_OPT_DIR) $(XINC)  \
@@ -278,6 +279,14 @@ ir_size: $(OBJECTS) ir_size.o ir_b2a
 
 ir_walker: $(OBJECTS) ir_walker.o
 	$(link.c++f) -o ir_walker ir_walker.o $(OBJECTS) $(LDFLAGS)
+
+dsl_builder_contract_test: $(OBJECTS) controls.o dsl_builder_contract_test.o
+	$(link.c++f) -o $@ dsl_builder_contract_test.o controls.o \
+		$(OBJECTS) $(LDFLAGS)
+
+dsl_builder_contract_test.o: \
+	$(COMMON_COM_DIR)/tests/dsl_builder_contract_test.cxx
+	$(cxx) -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
 uwasm_nwrap: $(OBJECTS) uwasm_nwrap.o
 	$(link.c++f) -o  uwasm_nwrap uwasm_nwrap.o $(OBJECTS) $(LDFLAGS)


### PR DESCRIPTION
## Summary

This PR adds the native DSL WHIRL infrastructure required for Llama 2 prefill ingestion and lowering.

It extends the existing additive DSL WHIRL model with reviewed common and transformer contracts while preserving the physical `OPR_DSL` escape representation, logical operator abstraction, mapped-image compatibility, and opaque frontend value handles.

## Key changes

- Add the Llama 2 prefill operator and region contracts needed by the frontend.
- Extend native DSL builder APIs for transformer inputs, operators, attributes, results, and region structure.
- Strengthen gatekeeper verification for operand descriptors, attributes, region contracts, and result values.
- Extend VHO DSL lowering and runtime ABI contracts for the certified Llama process boundary.
- Preserve logical DSL operator names in diagnostics and traces without exposing physical `OPR_DSL` decoding.
- Keep DSL image records compatible with the existing ELF/mapped-image WHIRL path.
- Add producer, artifact-compatibility, lowering-contract, and separate-process tests.
- Update the DSL infrastructure plan with the completed staging and compatibility requirements.

## Compatibility

- Existing WHIRL opcode and node encodings remain valid.
- `OPR_DSL` remains a private escape tag; compiler-facing APIs and ASCII inspection expose logical DSL operators.
- Existing DSL image revisions and compatibility checks remain enforced.
- No Python, torch2whirl, backend code-generation, or target-kernel dependency is introduced into `common/com`.

## Validation

- Native `common/com` builder and gatekeeper contract tests passed.
- VHO DSL lowering and runtime ABI contract tests passed.
- Llama 2 artifact compatibility test passed.
- Separate-process Llama prefill production, binary WHIRL reopening, gatekeeper inspection, and lowering certification passed.
- End-to-end `openpy -keep -O0` certification retained reviewable binary and lowered traces.
- `ir_b2a -st -src` review preserves the generated trace artifacts.

## Coordinated frontend work

Provides the native DSL WHIRL infrastructure required by the coordinated
Llama 2 torch2whirl frontend PR: #75

The infrastructure PR must merge before the frontend PR is retargeted to `develop`.
