### PR TITLE
Preserve and print DSL symbol source locations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,10 @@ only when the current task needs detail.
    conventions.
 4. When editing existing Open64 C/C++ code, match the surrounding indentation
    style with spaces rather than reformatting unrelated code.
+5. Builder interfaces that create a symbol must make every reasonable attempt
+   to set its declaration source position with `Set_ST_Srcpos()`. When a
+   builder creates both a defining WN and a result ST, propagate the same
+   complete source position, including file, line, and column, to both objects.
 
 ## Driver And Phase Option Convention
 

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -2424,6 +2424,9 @@ DSL_Builder_Set_Value_Source_Position
     USRCPOS_stmt_begin(position) = source_position->statement_begin != 0;
     USRCPOS_bb_begin(position) = source_position->basic_block_begin != 0;
     WN_Set_Linenum(record->assignment, USRCPOS_srcpos(position));
+    if (ST_IDX_index(record->result_st) != 0)
+        Set_ST_Srcpos(St_Table[record->result_st],
+                      USRCPOS_srcpos(position));
     return TRUE;
 }
 

--- a/osprey/common/com/symtab.cxx
+++ b/osprey/common/com/symtab.cxx
@@ -2651,6 +2651,20 @@ static void
 Print_tensor_descriptor_record (FILE *f,
                                 const TENSOR_DESCRIPTOR_RECORD &record);
 
+static void
+Print_tensor_symbol_storage (FILE *f, ST_IDX st, TY_IDX ty)
+{
+    const char *placement = TY_tensor_attribute
+                                (ty, TY_TENSOR_SCHEMA_PLACEMENT);
+    if (placement == NULL || strcmp(placement, "side_file") != 0)
+        return;
+    const char *side_file = ST_tensor_metadata(st, "storage_file");
+    fprintf (f, "\t\tTensor storage: placement = side_file");
+    if (side_file != NULL && side_file[0] != '\0')
+        fprintf (f, " (%s)", side_file);
+    fprintf (f, "\n");
+}
+
 void
 ST::Print (FILE *f, BOOL verbose) const
 {
@@ -2990,6 +3004,8 @@ ST::Print (FILE *f, BOOL verbose) const
 	}
 
 	fprintf (f, "\n\t\tSclass: %s\n", Sclass_Name (storage_class));
+        if (TY_IDX_index(ty_idx) != 0 && TY_is_tensor_extension(ty_idx))
+            Print_tensor_symbol_storage(f, st_idx, ty_idx);
 	if(vtable_ty_idx)
 	{
 	  if(flags_ext & ST_IS_VTABLE)
@@ -3748,56 +3764,6 @@ Print_tensor_descriptor_slot (FILE *f, const char *name, STR_IDX str)
     fprintf (f, "        %s = %s\n", name, Tensor_descriptor_str (str));
 }
 
-static const char *
-Tensor_side_file_for_type (TY_IDX ty, BOOL *multiple)
-{
-    const char *side_file = NULL;
-    *multiple = FALSE;
-    for (UINT32 i = 0; i < St_tensor_metadata.Size(); ++i) {
-        const ST_TENSOR_METADATA_STORE &metadata = St_tensor_metadata[i];
-        TY_IDX metadata_ty = ST_type(St_Table[metadata.st]);
-        BOOL same_type = metadata_ty == ty;
-        if (!same_type && TY_is_tensor_extension(metadata_ty)) {
-            same_type = TY_tensor_element_ty(metadata_ty) ==
-                            TY_tensor_element_ty(ty) &&
-                        TY_tensor_rank(metadata_ty) == TY_tensor_rank(ty) &&
-                        TY_tensor_attributes_are_equivalent(metadata_ty, ty);
-        }
-        if (!same_type)
-            continue;
-        const char *candidate = ST_tensor_metadata
-                                    (metadata.st, "storage_file");
-        if (candidate == NULL || candidate[0] == '\0')
-            continue;
-        if (side_file == NULL)
-            side_file = candidate;
-        else if (strcmp(side_file, candidate) != 0) {
-            *multiple = TRUE;
-            return NULL;
-        }
-    }
-    return side_file;
-}
-
-static void
-Print_tensor_placement_slot
-        (FILE *f,
-         const TENSOR_DESCRIPTOR_RECORD &record)
-{
-    const char *placement = Tensor_descriptor_str(record.placement);
-    fprintf (f, "        placement = %s", placement);
-    if (strcmp(placement, "side_file") == 0) {
-        BOOL multiple;
-        const char *side_file = Tensor_side_file_for_type
-                                    (record.ty, &multiple);
-        if (side_file != NULL)
-            fprintf (f, " (%s)", side_file);
-        else if (multiple)
-            fprintf (f, " (<multiple files>)");
-    }
-    fprintf (f, "\n");
-}
-
 static void
 Print_tensor_descriptor_record (FILE *f, const TENSOR_DESCRIPTOR_RECORD &record)
 {
@@ -3819,7 +3785,7 @@ Print_tensor_descriptor_record (FILE *f, const TENSOR_DESCRIPTOR_RECORD &record)
     fprintf (f, "      TensorRepresentationDescriptor:\n");
     Print_tensor_descriptor_slot (f, "layout", record.layout);
     Print_tensor_descriptor_slot (f, "sharding", record.sharding);
-    Print_tensor_placement_slot (f, record);
+    Print_tensor_descriptor_slot (f, "placement", record.placement);
     Print_tensor_descriptor_slot (f, "memory", record.memory);
     Print_tensor_descriptor_slot (f, "quantization", record.quantization);
     Print_tensor_descriptor_slot (f, "runtime_state", record.runtime_state);

--- a/osprey/common/com/symtab.cxx
+++ b/osprey/common/com/symtab.cxx
@@ -3748,6 +3748,56 @@ Print_tensor_descriptor_slot (FILE *f, const char *name, STR_IDX str)
     fprintf (f, "        %s = %s\n", name, Tensor_descriptor_str (str));
 }
 
+static const char *
+Tensor_side_file_for_type (TY_IDX ty, BOOL *multiple)
+{
+    const char *side_file = NULL;
+    *multiple = FALSE;
+    for (UINT32 i = 0; i < St_tensor_metadata.Size(); ++i) {
+        const ST_TENSOR_METADATA_STORE &metadata = St_tensor_metadata[i];
+        TY_IDX metadata_ty = ST_type(St_Table[metadata.st]);
+        BOOL same_type = metadata_ty == ty;
+        if (!same_type && TY_is_tensor_extension(metadata_ty)) {
+            same_type = TY_tensor_element_ty(metadata_ty) ==
+                            TY_tensor_element_ty(ty) &&
+                        TY_tensor_rank(metadata_ty) == TY_tensor_rank(ty) &&
+                        TY_tensor_attributes_are_equivalent(metadata_ty, ty);
+        }
+        if (!same_type)
+            continue;
+        const char *candidate = ST_tensor_metadata
+                                    (metadata.st, "storage_file");
+        if (candidate == NULL || candidate[0] == '\0')
+            continue;
+        if (side_file == NULL)
+            side_file = candidate;
+        else if (strcmp(side_file, candidate) != 0) {
+            *multiple = TRUE;
+            return NULL;
+        }
+    }
+    return side_file;
+}
+
+static void
+Print_tensor_placement_slot
+        (FILE *f,
+         const TENSOR_DESCRIPTOR_RECORD &record)
+{
+    const char *placement = Tensor_descriptor_str(record.placement);
+    fprintf (f, "        placement = %s", placement);
+    if (strcmp(placement, "side_file") == 0) {
+        BOOL multiple;
+        const char *side_file = Tensor_side_file_for_type
+                                    (record.ty, &multiple);
+        if (side_file != NULL)
+            fprintf (f, " (%s)", side_file);
+        else if (multiple)
+            fprintf (f, " (<multiple files>)");
+    }
+    fprintf (f, "\n");
+}
+
 static void
 Print_tensor_descriptor_record (FILE *f, const TENSOR_DESCRIPTOR_RECORD &record)
 {
@@ -3769,7 +3819,7 @@ Print_tensor_descriptor_record (FILE *f, const TENSOR_DESCRIPTOR_RECORD &record)
     fprintf (f, "      TensorRepresentationDescriptor:\n");
     Print_tensor_descriptor_slot (f, "layout", record.layout);
     Print_tensor_descriptor_slot (f, "sharding", record.sharding);
-    Print_tensor_descriptor_slot (f, "placement", record.placement);
+    Print_tensor_placement_slot (f, record);
     Print_tensor_descriptor_slot (f, "memory", record.memory);
     Print_tensor_descriptor_slot (f, "quantization", record.quantization);
     Print_tensor_descriptor_slot (f, "runtime_state", record.runtime_state);

--- a/osprey/common/com/symtab.cxx
+++ b/osprey/common/com/symtab.cxx
@@ -75,6 +75,10 @@
 #include "targ_sim.h"
 #include "config_asm.h"
 
+extern void IR_Srcpos_Filename (SRCPOS srcpos,
+                                const char **fname,
+                                const char **dirname);
+
 // global tables
 FILE_INFO	Default_File_info;
 FILE_INFO	*File_info_ptr = &Default_File_info;
@@ -2859,9 +2863,16 @@ ST::Print (FILE *f, BOOL verbose) const
 	    fprintf (f, "Alignment: %d bytes", TY_align (ty_idx));
 	}
 	fprintf (f, "\n");
-	extern char *Orig_Src_File_Name, *Src_File_Name;
-	fprintf (f, "\t\tlocation: file %s, line %d\n", 
-	         (Orig_Src_File_Name ? Orig_Src_File_Name : Src_File_Name), SRCPOS_linenum(spos));
+        extern char *Orig_Src_File_Name, *Src_File_Name;
+        const char *fname = Orig_Src_File_Name ? Orig_Src_File_Name :
+                                                Src_File_Name;
+        if (fname == NULL) {
+            const char *dname;
+            IR_Srcpos_Filename(spos, &fname, &dname);
+        }
+        fprintf (f, "\t\tlocation: file %s, line %d\n",
+                 fname == NULL ? "(null)" : fname,
+                 SRCPOS_linenum(spos));
 
 	fprintf (f, "\t\tFlags:\t0x%08x", flags);
 	if (flags) {

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -252,10 +252,16 @@ Check_Upgraded_Ingestion_APIs(void)
     }
 
     observed_position.srcpos = WN_Get_Linenum(add);
+    USRCPOS observed_symbol_position;
+    observed_symbol_position.srcpos = ST_Srcpos(add_st);
     if (USRCPOS_filenum(observed_position) != file_id ||
         USRCPOS_linenum(observed_position) != 27 ||
         USRCPOS_column(observed_position) != 9 ||
         !USRCPOS_stmt_begin(observed_position) ||
+        USRCPOS_filenum(observed_symbol_position) != file_id ||
+        USRCPOS_linenum(observed_symbol_position) != 27 ||
+        USRCPOS_column(observed_symbol_position) != 9 ||
+        !USRCPOS_stmt_begin(observed_symbol_position) ||
         !ST_tensor_metadata_is_bound(add_st, "source_layer_name") ||
         strcmp(ST_tensor_metadata(add_st, "source_layer_name"),
                "residual_add") != 0 ||

--- a/osprey/common/com/tests/dsl_llama2_artifact_compat_test.sh
+++ b/osprey/common/com/tests/dsl_llama2_artifact_compat_test.sh
@@ -110,6 +110,7 @@ for evidence in \
   "METADATA layer_ordinal:0" \
   "storage_format = safetensors" \
   "storage_file = llama2.safetensors" \
+  "placement = side_file (llama2.safetensors)" \
   "storage_tensor_key = tok_embeddings.weight" \
   "value_kind=external_data" \
   "LOC 0 40"; do

--- a/osprey/common/com/tests/dsl_llama2_artifact_compat_test.sh
+++ b/osprey/common/com/tests/dsl_llama2_artifact_compat_test.sh
@@ -110,7 +110,7 @@ for evidence in \
   "METADATA layer_ordinal:0" \
   "storage_format = safetensors" \
   "storage_file = llama2.safetensors" \
-  "placement = side_file (llama2.safetensors)" \
+  "Tensor storage: placement = side_file (llama2.safetensors)" \
   "storage_tensor_key = tok_embeddings.weight" \
   "value_kind=external_data" \
   "LOC 0 40"; do

--- a/osprey/common/com/tests/dsl_llama2_artifact_compat_test.sh
+++ b/osprey/common/com/tests/dsl_llama2_artifact_compat_test.sh
@@ -111,7 +111,7 @@ for evidence in \
   "storage_format = safetensors" \
   "storage_file = llama2.safetensors" \
   "Tensor storage: placement = side_file (llama2.safetensors)" \
-  "location: file (null), line 11" \
+  "location: file llama2_transformer_regions.py, line 11" \
   "storage_tensor_key = tok_embeddings.weight" \
   "value_kind=external_data" \
   "LOC 0 40"; do

--- a/osprey/common/com/tests/dsl_llama2_artifact_compat_test.sh
+++ b/osprey/common/com/tests/dsl_llama2_artifact_compat_test.sh
@@ -111,6 +111,7 @@ for evidence in \
   "storage_format = safetensors" \
   "storage_file = llama2.safetensors" \
   "Tensor storage: placement = side_file (llama2.safetensors)" \
+  "location: file (null), line 11" \
   "storage_tensor_key = tok_embeddings.weight" \
   "value_kind=external_data" \
   "LOC 0 40"; do


### PR DESCRIPTION
## Summary

- propagate each DSL value source position to both its defining WN and result ST
- resolve symbol filenames from the `ST_Srcpos` file ordinal and mapped DST tables when frontend filename globals are unavailable
- show external tensor side-file names directly in affected symbol records
- keep `placement = side_file` as a type-level representation property
- add an `AGENTS.md` rule requiring builders to call `Set_ST_Srcpos()` when creating symbols
- preserve the tensor type table, raw tensor KV output, and binary WHIRL layout

## Example

```text
[2]: embedding_weight <2,2>
        Variable of type region_embedding_weight (#54, KIND_TENSOR)
        location: file llama2_transformer_regions.py, line 11
        Sclass: AUTO
        Tensor storage: placement = side_file (llama2.safetensors)
```

## Filename Resolution

`ST::Print()` continues to prefer `Orig_Src_File_Name` or `Src_File_Name`
when a frontend driver provides them. Tools such as `ir_b2a` do not initialize
those globals, so the printer now falls back to `IR_Srcpos_Filename()`, which
uses the file ordinal in `ST_Srcpos` and the mapped DST file table.

## Validation

- rebuilt `ir_b2a` and `dsl_builder_contract_test` in Linux/amd64 Docker
- focused ingestion test verifies identical file, line, column, and statement-begin fields on WN and ST
- all seven independently selectable builder contract lanes passed
- passed `dsl_llama2_artifact_compat_test.sh`
- reopened a newly generated `.B` and verified `location: file llama2_transformer_regions.py, line 11`
- `git diff --check` passed

An older retained `llama2_decode.B` still has zero symbol positions because it
was created before this builder fix; `ir_b2a` correctly cannot recover data
that is absent from that older artifact.
