### PR TITLE
Preserve torch2whirl Docker review artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ cscope.out
 autoconf/aclocal.m4
 autoconf/autom4te.cache
 /compile_commands.json
+/artifacts
 # Visual Studio built-in CMake configuration
 /CMakeSettings.json
 # CLion project configuration

--- a/osprey/driver/tests/openpy_resnet_artifact_test.sh
+++ b/osprey/driver/tests/openpy_resnet_artifact_test.sh
@@ -46,9 +46,15 @@ if [ "$status" -ne 0 ]; then
 fi
 
 mv "$work_dir/resnet.B" "$binary_dir/resnet.B"
-mv "$work_dir/LocalResNet.safetensors" \
-    "$binary_dir/LocalResNet.safetensors"
-mv "$work_dir/resnet.I" "$lowered_dir/resnet.I"
+side_file=$(find "$work_dir" -maxdepth 1 -type f -name '*.safetensors' -print)
+if [ -z "$side_file" ] || [ "$(printf '%s\n' "$side_file" | wc -l)" -ne 1 ]; then
+    echo "openpy did not produce exactly one SafeTensors side file" >&2
+    exit 1
+fi
+mv "$side_file" "$binary_dir/$(basename "$side_file")"
+if [ -f "$work_dir/resnet.I" ]; then
+    mv "$work_dir/resnet.I" "$lowered_dir/resnet.I"
+fi
 mv "$work_dir/resnet.t" "$lowered_dir/resnet.t"
 mv "$work_dir/resnet.s" "$lowered_dir/resnet.s"
 
@@ -59,8 +65,6 @@ for artifact in \
     "$driver_log" \
     "$binary_dir/resnet.B" \
     "$binary_dir/resnet.T" \
-    "$binary_dir/LocalResNet.safetensors" \
-    "$lowered_dir/resnet.I" \
     "$lowered_dir/resnet.t" \
     "$lowered_dir/resnet.s"; do
     if [ ! -s "$artifact" ]; then
@@ -68,6 +72,11 @@ for artifact in \
         exit 1
     fi
 done
+if ! find "$binary_dir" -maxdepth 1 -type f -name '*.safetensors' \
+    -size +0c | grep -q .; then
+    echo "openpy did not retain a nonempty SafeTensors side file" >&2
+    exit 1
+fi
 
 grep -q 'source files:' "$binary_dir/resnet.T"
 grep -q 'resnet.py' "$binary_dir/resnet.T"

--- a/osprey/driver/tests/openpy_resnet_artifact_test.sh
+++ b/osprey/driver/tests/openpy_resnet_artifact_test.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+src_root=$(CDPATH= cd -- "$script_dir/../../.." && pwd)
+build_dir=${OPEN64_BUILD_DIR:-$src_root/build}
+artifact_root=${OPEN64_TORCH2WHIRL_ARTIFACT_DIR:-$src_root/artifacts/torch2whirl}
+openpy=$build_dir/osprey/targdir/driver/openpy
+ir_b2a=$build_dir/osprey/targdir/ir_tools/ir_b2a
+source_model=$src_root/osprey/torch2whirl/python/tests/models/resnet_model.py
+work_dir=$artifact_root/openpy/resnet
+binary_dir=$work_dir/binary
+lowered_dir=$work_dir/lowered
+
+for executable in "$openpy" "$ir_b2a"; do
+    if [ ! -x "$executable" ]; then
+        echo "required executable not found: $executable" >&2
+        exit 1
+    fi
+done
+
+mkdir -p "$work_dir"
+find "$work_dir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+mkdir -p "$binary_dir" "$lowered_dir"
+cp "$source_model" "$work_dir/resnet.py"
+
+set +e
+(
+    cd "$work_dir"
+    "$openpy" -run-build="$build_dir" -keep -O0 resnet.py
+) > "$work_dir/openpy_driver.log" 2>&1
+status=$?
+set -e
+
+driver_log=$work_dir/openpy_driver.log
+driver_log_tmp=$work_dir/openpy_driver.log.tmp
+{
+    echo "exit_status=$status"
+    cat "$driver_log"
+} > "$driver_log_tmp"
+mv "$driver_log_tmp" "$driver_log"
+if [ "$status" -ne 0 ]; then
+    cat "$driver_log" >&2
+    exit "$status"
+fi
+
+mv "$work_dir/resnet.B" "$binary_dir/resnet.B"
+mv "$work_dir/LocalResNet.safetensors" \
+    "$binary_dir/LocalResNet.safetensors"
+mv "$work_dir/resnet.I" "$lowered_dir/resnet.I"
+mv "$work_dir/resnet.t" "$lowered_dir/resnet.t"
+mv "$work_dir/resnet.s" "$lowered_dir/resnet.s"
+
+"$ir_b2a" -st -src "$binary_dir/resnet.B" "$binary_dir/resnet.T"
+
+for artifact in \
+    "$work_dir/resnet.py" \
+    "$driver_log" \
+    "$binary_dir/resnet.B" \
+    "$binary_dir/resnet.T" \
+    "$binary_dir/LocalResNet.safetensors" \
+    "$lowered_dir/resnet.I" \
+    "$lowered_dir/resnet.t" \
+    "$lowered_dir/resnet.s"; do
+    if [ ! -s "$artifact" ]; then
+        echo "openpy did not retain nonempty artifact: $artifact" >&2
+        exit 1
+    fi
+done
+
+grep -q 'source files:' "$binary_dir/resnet.T"
+grep -q 'resnet.py' "$binary_dir/resnet.T"
+grep -q 'cnn.conv2d' "$binary_dir/resnet.T"
+grep -q 'common.residual_add' "$binary_dir/resnet.T"
+grep -q 'Types:' "$binary_dir/resnet.T"
+grep -q 'cnn.conv2d' "$lowered_dir/resnet.t"
+
+echo "retained openpy ResNet artifacts: $work_dir"
+echo "openpy ResNet artifact test passed"

--- a/osprey/torch2whirl/AGENTS.md
+++ b/osprey/torch2whirl/AGENTS.md
@@ -57,8 +57,8 @@ native emission becomes available.
   that do not claim process-boundary artifact certification.
 - Apply the same contract to the combined `openpy -keep` pipeline. Keep the
   source and driver log at the model-family root, the frontend `.B`, `.T`, and
-  side payload under `binary`, and post-VHO `.t`, `.I`, and `.s` under
-  `lowered`. This separation prevents `.T` and `.t` collisions on
+  side payload under `binary`, and post-VHO `.t`, assembly, and any optional
+  driver intermediates under `lowered`. This separation prevents `.T` and `.t` collisions on
   case-insensitive filesystems.
 
 ## Verification Matrix

--- a/osprey/torch2whirl/AGENTS.md
+++ b/osprey/torch2whirl/AGENTS.md
@@ -55,6 +55,11 @@ native emission becomes available.
 - Do not use a container-only path or a temporary directory for final review
   evidence. Temporary directories remain appropriate for isolated unit tests
   that do not claim process-boundary artifact certification.
+- Apply the same contract to the combined `openpy -keep` pipeline. Keep the
+  source and driver log at the model-family root, the frontend `.B`, `.T`, and
+  side payload under `binary`, and post-VHO `.t`, `.I`, and `.s` under
+  `lowered`. This separation prevents `.T` and `.t` collisions on
+  case-insensitive filesystems.
 
 ## Verification Matrix
 
@@ -97,6 +102,13 @@ metadata changes:
 
 ```sh
 osprey/torch2whirl/scripts/run_torch_docker_test.sh
+```
+
+For the combined `openpy -keep -O0` ResNet pipeline from a full Open64 build:
+
+```sh
+OPEN64_OPENPY_BUILD_DIR=/path/to/open64/build \
+  osprey/torch2whirl/scripts/run_openpy_docker_test.sh
 ```
 
 Use `OPEN64_TORCH2WHIRL_REBUILD_IMAGE=1` when the torch Dockerfile or pinned

--- a/osprey/torch2whirl/AGENTS.md
+++ b/osprey/torch2whirl/AGENTS.md
@@ -42,6 +42,20 @@ logical opcode allocation, WN representation, mapped-image, or lowering
 decisions authoritative.  Keep census/mock tests as drift detectors after
 native emission becomes available.
 
+## Reviewable Artifacts
+
+- Artifact-producing integration and certification tests must honor
+  `OPEN64_DSL_TEST_ARTIFACT_DIR` and retain their outputs when it is set.
+- Keep each model family in a distinct directory. Preserve the source fixture,
+  `.B`, `ir_b2a -st -src` `.T`, external payloads, driver diagnostics, and
+  lowered files produced by that lane.
+- The Docker validation script defaults to
+  `<open64-source-root>/artifacts/torch2whirl`, verifies the host bind mount,
+  cleans stale evidence before a run, and writes `MANIFEST.txt` after the run.
+- Do not use a container-only path or a temporary directory for final review
+  evidence. Temporary directories remain appropriate for isolated unit tests
+  that do not claim process-boundary artifact certification.
+
 ## Verification Matrix
 
 Run the smallest relevant set first, then broaden when the change affects a

--- a/osprey/torch2whirl/LLAMA2-INGESTION-PLAN.md
+++ b/osprey/torch2whirl/LLAMA2-INGESTION-PLAN.md
@@ -299,9 +299,9 @@ Second frontend batch status, L2-L7:
 Retained standalone evidence from this batch:
 
 ```text
-/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-frontend/llama2.B
-/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-frontend/llama2.safetensors
-/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-frontend/llama2.T
+<open64-source-root>/artifacts/torch2whirl/llama2-frontend/llama2.B
+<open64-source-root>/artifacts/torch2whirl/llama2-frontend/llama2.safetensors
+<open64-source-root>/artifacts/torch2whirl/llama2-frontend/llama2.T
 ```
 
 ### Required Status Updates
@@ -601,11 +601,11 @@ stable diagnostic, preserves the failure log, and checks that no partial
 Retained decode evidence from the Docker lane:
 
 ```text
-/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-decode/llama2_decode.B
-/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-decode/llama2_decode.safetensors
-/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-decode/llama2_decode.T
-/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-decode/llama2_decode_driver.log
-/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-decode/llama2_decode_bad_gqa.log
+<open64-source-root>/artifacts/torch2whirl/llama2-decode/llama2_decode.B
+<open64-source-root>/artifacts/torch2whirl/llama2-decode/llama2_decode.safetensors
+<open64-source-root>/artifacts/torch2whirl/llama2-decode/llama2_decode.T
+<open64-source-root>/artifacts/torch2whirl/llama2-decode/llama2_decode_driver.log
+<open64-source-root>/artifacts/torch2whirl/llama2-decode/llama2_decode_bad_gqa.log
 ```
 
 Exit gate: stateful decode is an additive, versioned extension to the certified

--- a/osprey/torch2whirl/LLAMA2-INGESTION-PLAN.md
+++ b/osprey/torch2whirl/LLAMA2-INGESTION-PLAN.md
@@ -299,9 +299,10 @@ Second frontend batch status, L2-L7:
 Retained standalone evidence from this batch:
 
 ```text
-<open64-source-root>/artifacts/torch2whirl/llama2-frontend/llama2.B
-<open64-source-root>/artifacts/torch2whirl/llama2-frontend/llama2.safetensors
-<open64-source-root>/artifacts/torch2whirl/llama2-frontend/llama2.T
+<open64-source-root>/artifacts/torch2whirl/llama2-prefill/llama2_model.py
+<open64-source-root>/artifacts/torch2whirl/llama2-prefill/llama2.B
+<open64-source-root>/artifacts/torch2whirl/llama2-prefill/llama2.safetensors
+<open64-source-root>/artifacts/torch2whirl/llama2-prefill/llama2.T
 ```
 
 ### Required Status Updates

--- a/osprey/torch2whirl/Makefile.gbase
+++ b/osprey/torch2whirl/Makefile.gbase
@@ -136,8 +136,9 @@ TORCH2WHIRL_CXX_SRCS = \
 OBJECTS = $(TORCH2WHIRL_CXX_SRCS:.cxx=.o)
 
 .PHONY: default all clean clobber install make_deps python_test \
-  driver_native_ir_tools_smoke driver_opencc_smoke driver_torch_test \
-  llama2_decode_native_ir_tools_smoke \
+  driver_native_ir_tools_smoke resnet_native_ir_tools_smoke \
+  driver_opencc_smoke driver_torch_test \
+  llama2_prefill_native_ir_tools_smoke llama2_decode_native_ir_tools_smoke \
   python_torch_test \
   python_native_check python_native_deps python_native_extension \
   python_native_ir_tools_deps python_native_ir_tools_smoke \
@@ -172,14 +173,25 @@ driver_torch_test: $(TARGETS) python_native_stage
 	    TORCH2WHIRL_DRIVER=$(TORCH2WHIRL_DRIVER) \
 	    $(PYTHON) $(BUILD_BASE)/python/tests/driver_torch_smoke.py
 
-driver_native_ir_tools_smoke: $(TARGETS) python_native_extension \
+driver_native_ir_tools_smoke: resnet_native_ir_tools_smoke
+
+resnet_native_ir_tools_smoke: $(TARGETS) python_native_extension \
   python_native_ir_tools_deps
 	PYTHONDONTWRITEBYTECODE=1 \
 	    OPEN64_IR_B2A="$(OPEN64_IR_B2A)" \
-	    OPEN64_DSL_TEST_ARTIFACT_DIR="$(OPEN64_DSL_TEST_ARTIFACT_DIR)/driver-native" \
+	    OPEN64_DSL_TEST_ARTIFACT_DIR="$(OPEN64_DSL_TEST_ARTIFACT_DIR)/resnet" \
 	    PYTHONPATH=$(TORCH2WHIRL_PYTHONPATH) \
 	    TORCH2WHIRL_DRIVER=$(TORCH2WHIRL_DRIVER) \
 	    $(PYTHON) $(BUILD_BASE)/python/tests/driver_native_ir_tools_smoke.py
+
+llama2_prefill_native_ir_tools_smoke: $(TARGETS) python_native_extension \
+  python_native_ir_tools_deps
+	PYTHONDONTWRITEBYTECODE=1 \
+	    OPEN64_IR_B2A="$(OPEN64_IR_B2A)" \
+	    OPEN64_DSL_TEST_ARTIFACT_DIR="$(OPEN64_DSL_TEST_ARTIFACT_DIR)/llama2-prefill" \
+	    PYTHONPATH=$(TORCH2WHIRL_PYTHONPATH) \
+	    TORCH2WHIRL_DRIVER=$(TORCH2WHIRL_DRIVER) \
+	    $(PYTHON) $(BUILD_BASE)/python/tests/llama2_prefill_native_ir_tools_smoke.py
 
 llama2_decode_native_ir_tools_smoke: $(TARGETS) python_native_extension \
   python_native_ir_tools_deps

--- a/osprey/torch2whirl/README.md
+++ b/osprey/torch2whirl/README.md
@@ -175,6 +175,11 @@ defaults to the persistent host directory
 The completed run writes `MANIFEST.txt` at the artifact root. Model evidence is
 grouped under `resnet`, `llama2-prefill`, and `llama2-decode`; native common
 operator probes are grouped under `python-native`.
+Llama artifact families retain local imported model modules under
+`source/models`, including the `TinyRMSNorm` definition used by decode. The
+model `.B` is the complete compilation artifact and contains each instantiated
+logical operator; imported Python classes are source definitions and do not
+produce separate `.B` files.
 Set
 `OPEN64_TORCH2WHIRL_RUN_IR_TOOLS=0` only when running the shorter PyTorch lane.
 

--- a/osprey/torch2whirl/README.md
+++ b/osprey/torch2whirl/README.md
@@ -193,11 +193,13 @@ artifacts/torch2whirl/openpy/resnet/resnet.py
 artifacts/torch2whirl/openpy/resnet/openpy_driver.log
 artifacts/torch2whirl/openpy/resnet/binary/resnet.B
 artifacts/torch2whirl/openpy/resnet/binary/resnet.T
-artifacts/torch2whirl/openpy/resnet/binary/LocalResNet.safetensors
-artifacts/torch2whirl/openpy/resnet/lowered/resnet.I
+artifacts/torch2whirl/openpy/resnet/binary/resnet.safetensors
 artifacts/torch2whirl/openpy/resnet/lowered/resnet.t
 artifacts/torch2whirl/openpy/resnet/lowered/resnet.s
 ```
+
+Driver-specific intermediates such as `resnet.I` are retained under `lowered`
+when produced, but are not required by the cross-version artifact contract.
 
 Binary and lowered traces use separate directories because `.T` and `.t`
 refer to the same filename on the default case-insensitive macOS filesystem.

--- a/osprey/torch2whirl/README.md
+++ b/osprey/torch2whirl/README.md
@@ -178,6 +178,30 @@ operator probes are grouped under `python-native`.
 Set
 `OPEN64_TORCH2WHIRL_RUN_IR_TOOLS=0` only when running the shorter PyTorch lane.
 
+To certify the combined driver and retain its review artifacts, use a full
+Open64 build tree:
+
+```sh
+OPEN64_OPENPY_BUILD_DIR=/path/to/open64/build \
+  osprey/torch2whirl/scripts/run_openpy_docker_test.sh
+```
+
+This runs `openpy -keep -O0` on the ResNet fixture and retains:
+
+```text
+artifacts/torch2whirl/openpy/resnet/resnet.py
+artifacts/torch2whirl/openpy/resnet/openpy_driver.log
+artifacts/torch2whirl/openpy/resnet/binary/resnet.B
+artifacts/torch2whirl/openpy/resnet/binary/resnet.T
+artifacts/torch2whirl/openpy/resnet/binary/LocalResNet.safetensors
+artifacts/torch2whirl/openpy/resnet/lowered/resnet.I
+artifacts/torch2whirl/openpy/resnet/lowered/resnet.t
+artifacts/torch2whirl/openpy/resnet/lowered/resnet.s
+```
+
+Binary and lowered traces use separate directories because `.T` and `.t`
+refer to the same filename on the default case-insensitive macOS filesystem.
+
 For Linux Docker native extension validation from a configured build tree:
 
 ```sh

--- a/osprey/torch2whirl/README.md
+++ b/osprey/torch2whirl/README.md
@@ -166,8 +166,12 @@ base images are not resolved through a remote registry.
 The script mounts the host directory
 `$OPEN64_TORCH2WHIRL_ARTIFACT_DIR` at `/artifacts`, cleans it at startup, runs
 both native `ir_b2a -st -src` smoke lanes, and leaves the resulting artifacts after
-Docker exits.  It defaults to
-`$OPEN64_TORCH2WHIRL_BUILD_DIR/test-artifacts`.  Set
+Docker exits. It verifies the bind mount before starting validation and
+defaults to the persistent host directory
+`<open64-source-root>/artifacts/torch2whirl`. For example, this checkout uses
+`/Users/shinmingliu/open64/artifacts/torch2whirl`. Set
+`OPEN64_TORCH2WHIRL_ARTIFACT_DIR` to choose another persistent host directory.
+Set
 `OPEN64_TORCH2WHIRL_RUN_IR_TOOLS=0` only when running the shorter PyTorch lane.
 
 For Linux Docker native extension validation from a configured build tree:

--- a/osprey/torch2whirl/README.md
+++ b/osprey/torch2whirl/README.md
@@ -165,12 +165,16 @@ script defaults `OPEN64_TORCH2WHIRL_DOCKER_BUILDKIT=0` so local-only Open64
 base images are not resolved through a remote registry.
 The script mounts the host directory
 `$OPEN64_TORCH2WHIRL_ARTIFACT_DIR` at `/artifacts`, cleans it at startup, runs
-both native `ir_b2a -st -src` smoke lanes, and leaves the resulting artifacts after
-Docker exits. It verifies the bind mount before starting validation and
+the native `ir_b2a -st -src` model certification lanes, and leaves source,
+`.B`, `.T`, side payloads, and diagnostic logs after Docker exits. It verifies
+the bind mount before starting validation and
 defaults to the persistent host directory
 `<open64-source-root>/artifacts/torch2whirl`. For example, this checkout uses
 `/Users/shinmingliu/open64/artifacts/torch2whirl`. Set
 `OPEN64_TORCH2WHIRL_ARTIFACT_DIR` to choose another persistent host directory.
+The completed run writes `MANIFEST.txt` at the artifact root. Model evidence is
+grouped under `resnet`, `llama2-prefill`, and `llama2-decode`; native common
+operator probes are grouped under `python-native`.
 Set
 `OPEN64_TORCH2WHIRL_RUN_IR_TOOLS=0` only when running the shorter PyTorch lane.
 

--- a/osprey/torch2whirl/python/tests/driver_native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/driver_native_ir_tools_smoke.py
@@ -141,6 +141,7 @@ def _run_valid_driver(driver: Path, model_path: Path, artifact: Path) -> int:
 def _check_invalid_graph_rejected(driver: Path, tmpdir: Path) -> int:
     model_path = tmpdir / "invalid_model.py"
     artifact = tmpdir / "invalid_model.B"
+    log_path = tmpdir / "invalid_model.log"
     _write_invalid_add_model(model_path)
 
     completed = _run_driver(
@@ -148,6 +149,11 @@ def _check_invalid_graph_rejected(driver: Path, tmpdir: Path) -> int:
         model_path,
         artifact,
         ("shape:1,3", "shape:1,4"),
+    )
+    log_path.write_text(
+        f"exit_status={completed.returncode}\n" +
+        completed.stdout + completed.stderr,
+        encoding="utf-8",
     )
     if completed.returncode == 0:
         print("driver accepted verifier-invalid add graph", file=sys.stderr)
@@ -200,10 +206,10 @@ def _inspect_artifact(ir_b2a: Path, artifact: Path, text_dump: Path) -> int:
         "attr.stride=2,2",
         "attr.padding=3,3",
         "attr.semantic=logits",
-        "value=safetensors://driver_native_model.safetensors#conv1.weight",
+        "value=safetensors://resnet.safetensors#conv1.weight",
         "value_kind=implicit_zero",
         "source files:",
-        "model.py",
+        "resnet_model.py",
         "Symbols:",
         "Types:",
     ]
@@ -233,12 +239,14 @@ def _inspect_artifact(ir_b2a: Path, artifact: Path, text_dump: Path) -> int:
 
 def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
     work_dir.mkdir(parents=True, exist_ok=True)
-    model_path = work_dir / "model.py"
-    artifact = work_dir / "driver_native_model.B"
-    text_dump = work_dir / "driver_native_model.T"
-    side_file = work_dir / "driver_native_model.safetensors"
+    model_path = work_dir / "resnet_model.py"
+    artifact = work_dir / "resnet.B"
+    text_dump = work_dir / "resnet.T"
+    side_file = work_dir / "resnet.safetensors"
     invalid_model = work_dir / "invalid_model.py"
     invalid_artifact = work_dir / "invalid_model.B"
+    driver_log = work_dir / "resnet_driver.log"
+    invalid_log = work_dir / "invalid_model.log"
     for path in (
         model_path,
         artifact,
@@ -246,14 +254,28 @@ def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
         side_file,
         invalid_model,
         invalid_artifact,
+        driver_log,
+        invalid_log,
     ):
         if path.exists():
             path.unlink()
     _write_resnet_model(model_path)
 
-    driver_status = _run_valid_driver(driver, model_path, artifact)
-    if driver_status != 0:
-        return driver_status
+    completed = _run_driver(
+        driver,
+        model_path,
+        artifact,
+        ("shape:1,3,64,64",),
+    )
+    driver_log.write_text(
+        f"exit_status={completed.returncode}\n" +
+        completed.stdout + completed.stderr,
+        encoding="utf-8",
+    )
+    if completed.returncode != 0:
+        print(completed.stdout, file=sys.stderr)
+        print(completed.stderr, file=sys.stderr)
+        return completed.returncode
     if not artifact.exists() or artifact.stat().st_size == 0:
         print("driver native WHIRL artifact was not created", file=sys.stderr)
         return 1

--- a/osprey/torch2whirl/python/tests/llama2_decode_native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/llama2_decode_native_ir_tools_smoke.py
@@ -197,6 +197,7 @@ def _inspect_artifact(ir_b2a: Path, artifact: Path, text_dump: Path) -> int:
 
     count_expectations = {
         "contract=transformer.decoder_layer.v2": 2,
+        "OPR_DSLRMSNORM # OPR_DSLRMSNORM version=1": 5,
         "OPR_DSLROTARYEMBEDDING # OPR_DSLROTARYEMBEDDING version=2": 4,
         "OPR_DSLATTENTION # OPR_DSLATTENTION version=2": 2,
         "roles=0x4 flags=0x1b": 4,
@@ -277,8 +278,10 @@ def _inspect_artifact(ir_b2a: Path, artifact: Path, text_dump: Path) -> int:
 
 def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
     work_dir.mkdir(parents=True, exist_ok=True)
-    model_path = _test_root() / "models" / "llama2_decode_model.py"
+    source_models = _test_root() / "models"
+    model_path = source_models / "llama2_decode_model.py"
     retained_model = work_dir / "llama2_decode_model.py"
+    retained_source_models = work_dir / "source" / "models"
     artifact = work_dir / "llama2_decode.B"
     text_dump = work_dir / "llama2_decode.T"
     side_file = work_dir / "llama2_decode.safetensors"
@@ -297,6 +300,14 @@ def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
             path.unlink()
 
     shutil.copy2(model_path, retained_model)
+    if retained_source_models.parent.exists():
+        shutil.rmtree(retained_source_models.parent)
+    retained_source_models.mkdir(parents=True)
+    for source_name in ("llama2_decode_model.py", "llama2_model.py"):
+        shutil.copy2(
+            source_models / source_name,
+            retained_source_models / source_name,
+        )
 
     completed = _run_driver(driver, retained_model, artifact)
     driver_log.write_text(

--- a/osprey/torch2whirl/python/tests/llama2_decode_native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/llama2_decode_native_ir_tools_smoke.py
@@ -129,6 +129,7 @@ def _check_failed_run_cleans_partial_artifact(
 
     completed = _run_driver(driver, bad_model, bad_artifact)
     bad_log.write_text(
+        f"exit_status={completed.returncode}\n" +
         completed.stdout + completed.stderr,
         encoding="utf-8",
     )
@@ -277,11 +278,13 @@ def _inspect_artifact(ir_b2a: Path, artifact: Path, text_dump: Path) -> int:
 def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
     work_dir.mkdir(parents=True, exist_ok=True)
     model_path = _test_root() / "models" / "llama2_decode_model.py"
+    retained_model = work_dir / "llama2_decode_model.py"
     artifact = work_dir / "llama2_decode.B"
     text_dump = work_dir / "llama2_decode.T"
     side_file = work_dir / "llama2_decode.safetensors"
     driver_log = work_dir / "llama2_decode_driver.log"
     for path in (
+        retained_model,
         artifact,
         text_dump,
         side_file,
@@ -293,8 +296,11 @@ def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
         if path.exists():
             path.unlink()
 
-    completed = _run_driver(driver, model_path, artifact)
+    shutil.copy2(model_path, retained_model)
+
+    completed = _run_driver(driver, retained_model, artifact)
     driver_log.write_text(
+        f"exit_status={completed.returncode}\n" +
         completed.stdout + completed.stderr,
         encoding="utf-8",
     )

--- a/osprey/torch2whirl/python/tests/llama2_prefill_native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/llama2_prefill_native_ir_tools_smoke.py
@@ -1,0 +1,192 @@
+"""Native process-boundary certification for tiny Llama 2 prefill."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Optional
+
+
+def _require_torch() -> None:
+    try:
+        import torch  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "torch is required for llama2_prefill_native_ir_tools_smoke.py"
+        ) from exc
+
+
+def _find_executable(variable: str, name: str) -> Optional[Path]:
+    configured = os.environ.get(variable, "")
+    if configured:
+        path = Path(configured)
+        if path.is_file() and os.access(str(path), os.X_OK):
+            return path
+        print(f"skip: {name} is not executable: {path}")
+        return None
+
+    found = shutil.which(name)
+    if found:
+        return Path(found)
+
+    print(f"skip: {name} not found; set {variable} to enable smoke test")
+    return None
+
+
+def _test_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _run_driver(
+    driver: Path,
+    model_path: Path,
+    artifact: Path,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            str(driver),
+            str(model_path),
+            "--entry",
+            "forward",
+            "--sample-input",
+            "int-shape:1,8",
+            "--backend",
+            "native",
+            "--output",
+            str(artifact),
+        ],
+        check=False,
+        env=os.environ.copy(),
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _inspect_artifact(ir_b2a: Path, artifact: Path, text_dump: Path) -> int:
+    completed = subprocess.run(
+        [str(ir_b2a), "-st", "-src", str(artifact), str(text_dump)],
+        check=False,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        print(completed.stdout, file=sys.stderr)
+        print(completed.stderr, file=sys.stderr)
+        return completed.returncode
+
+    text = text_dump.read_text(encoding="utf-8", errors="replace")
+    required = [
+        "llama2_model.py",
+        "FUNC_ENTRY",
+        "contract=transformer.prefill.v1",
+        "contract=transformer.decoder_layer.v1",
+        "transformer.token_embedding",
+        "transformer.rms_norm",
+        "transformer.rotary_embedding",
+        "transformer.attention",
+        "transformer.swiglu",
+        "common.output_logits",
+        "attr.execution_mode=full_sequence",
+        "attr.mask_mode=causal",
+        "attr.cache_mode=none",
+        "DSL REGION TABLE:",
+        "Symbols:",
+        "Types:",
+        "{line: 1/",
+    ]
+    missing = [needle for needle in required if needle not in text]
+    if missing:
+        print(
+            "prefill ir_b2a -st -src output missed expected text: " +
+            ", ".join(missing),
+            file=sys.stderr,
+        )
+        return 1
+
+    if text.count("contract=transformer.decoder_layer.v1") != 2:
+        print("prefill trace did not expose two decoder layers", file=sys.stderr)
+        return 1
+
+    forbidden = ["OPR_DSL ", "MDSL ", "OPC_MDSL"]
+    exposed = [needle for needle in forbidden if needle in text]
+    if exposed:
+        print(
+            "prefill ir_b2a exposed physical DSL storage text: " +
+            ", ".join(exposed),
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    source_model = _test_root() / "models" / "llama2_model.py"
+    model_path = work_dir / "llama2_model.py"
+    artifact = work_dir / "llama2.B"
+    text_dump = work_dir / "llama2.T"
+    side_file = work_dir / "llama2.safetensors"
+    driver_log = work_dir / "llama2_driver.log"
+    for path in (model_path, artifact, text_dump, side_file, driver_log):
+        if path.exists():
+            path.unlink()
+
+    shutil.copy2(source_model, model_path)
+    completed = _run_driver(driver, model_path, artifact)
+    driver_log.write_text(
+        f"exit_status={completed.returncode}\n" +
+        completed.stdout + completed.stderr,
+        encoding="utf-8",
+    )
+    if completed.returncode != 0:
+        print(completed.stdout, file=sys.stderr)
+        print(completed.stderr, file=sys.stderr)
+        return completed.returncode
+    if not artifact.is_file() or artifact.stat().st_size == 0:
+        print("prefill WHIRL artifact was not created", file=sys.stderr)
+        return 1
+    if not side_file.is_file() or side_file.stat().st_size == 0:
+        print("prefill safetensors side file was not created", file=sys.stderr)
+        return 1
+
+    inspect_status = _inspect_artifact(ir_b2a, artifact, text_dump)
+    if inspect_status != 0:
+        return inspect_status
+
+    print(f"retained Llama prefill artifacts: {work_dir}")
+    return 0
+
+
+def main() -> int:
+    ir_b2a = _find_executable("OPEN64_IR_B2A", "ir_b2a")
+    if ir_b2a is None:
+        return 0
+    driver = _find_executable("TORCH2WHIRL_DRIVER", "torch2whirl")
+    if driver is None:
+        return 0
+    _require_torch()
+
+    artifact_dir = os.environ.get("OPEN64_DSL_TEST_ARTIFACT_DIR", "")
+    if artifact_dir:
+        status = _run_smoke(ir_b2a, driver, Path(artifact_dir))
+    else:
+        with tempfile.TemporaryDirectory(
+            prefix="torch2whirl-llama2-prefill-native-"
+        ) as tmp:
+            status = _run_smoke(ir_b2a, driver, Path(tmp))
+    if status != 0:
+        return status
+
+    print("Llama prefill native ir_b2a smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/osprey/torch2whirl/python/tests/llama2_prefill_native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/llama2_prefill_native_ir_tools_smoke.py
@@ -130,6 +130,9 @@ def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
     work_dir.mkdir(parents=True, exist_ok=True)
     source_model = _test_root() / "models" / "llama2_model.py"
     model_path = work_dir / "llama2_model.py"
+    retained_source_model = (
+        work_dir / "source" / "models" / "llama2_model.py"
+    )
     artifact = work_dir / "llama2.B"
     text_dump = work_dir / "llama2.T"
     side_file = work_dir / "llama2.safetensors"
@@ -139,6 +142,8 @@ def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
             path.unlink()
 
     shutil.copy2(source_model, model_path)
+    retained_source_model.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_model, retained_source_model)
     completed = _run_driver(driver, model_path, artifact)
     driver_log.write_text(
         f"exit_status={completed.returncode}\n" +

--- a/osprey/torch2whirl/python/tests/models/resnet_model.py
+++ b/osprey/torch2whirl/python/tests/models/resnet_model.py
@@ -1,0 +1,101 @@
+"""Dependency-light ResNet fixture for torch2whirl certification."""
+
+import torch
+import torch.fx
+
+
+def residual_add(lhs, rhs):
+    return lhs + rhs
+
+
+torch.fx.wrap("residual_add")
+
+
+class BasicBlock(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, stride=1):
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(
+            in_channels,
+            out_channels,
+            kernel_size=3,
+            stride=stride,
+            padding=1,
+            bias=False,
+        )
+        self.bn1 = torch.nn.BatchNorm2d(out_channels)
+        self.relu = torch.nn.ReLU()
+        self.conv2 = torch.nn.Conv2d(
+            out_channels,
+            out_channels,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            bias=False,
+        )
+        self.bn2 = torch.nn.BatchNorm2d(out_channels)
+        if stride != 1 or in_channels != out_channels:
+            self.downsample = torch.nn.Sequential(
+                torch.nn.Conv2d(
+                    in_channels,
+                    out_channels,
+                    kernel_size=1,
+                    stride=stride,
+                    bias=False,
+                ),
+                torch.nn.BatchNorm2d(out_channels),
+            )
+        else:
+            self.downsample = None
+
+    def forward(self, value):
+        if self.downsample is None:
+            identity = value
+        else:
+            identity = self.downsample(value)
+        out = self.conv1(value)
+        out = self.bn1(out)
+        out = self.relu(out)
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = residual_add(out, identity)
+        return self.relu(out)
+
+
+class LocalResNet(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv1 = torch.nn.Conv2d(
+            3,
+            8,
+            kernel_size=7,
+            stride=2,
+            padding=3,
+            bias=False,
+        )
+        self.bn1 = torch.nn.BatchNorm2d(8)
+        self.relu = torch.nn.ReLU()
+        self.maxpool = torch.nn.MaxPool2d(
+            kernel_size=3,
+            stride=2,
+            padding=1,
+        )
+        self.layer1 = torch.nn.Sequential(BasicBlock(8, 8))
+        self.layer2 = torch.nn.Sequential(BasicBlock(8, 16, stride=2))
+        self.avgpool = torch.nn.AdaptiveAvgPool2d((1, 1))
+        self.flatten = torch.nn.Flatten(1)
+        self.fc = torch.nn.Linear(16, 10)
+
+    def forward(self, value):
+        out = self.conv1(value)
+        out = self.bn1(out)
+        out = self.relu(out)
+        out = self.maxpool(out)
+        out = self.layer1(out)
+        out = self.layer2(out)
+        out = self.avgpool(out)
+        out = self.flatten(out)
+        return self.fc(out)
+
+
+def create_model():
+    return LocalResNet().eval()

--- a/osprey/torch2whirl/python/tests/native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/native_ir_tools_smoke.py
@@ -314,12 +314,15 @@ def _find_ir_b2a() -> Optional[Path]:
 
 def _run_smoke(ir_b2a: Path, work_dir: Path) -> int:
     work_dir.mkdir(parents=True, exist_ok=True)
+    retained_source = work_dir / "native_ir_tools_smoke.py"
     artifact = work_dir / "python_native_model.B"
     text_dump = work_dir / "python_native_model.T"
     side_file = work_dir / "python_native_model.safetensors"
-    for path in (artifact, text_dump, side_file):
+    for path in (retained_source, artifact, text_dump, side_file):
         if path.exists():
             path.unlink()
+
+    shutil.copy2(Path(__file__), retained_source)
 
     module = export_to_whirl(
         DummyModel(),

--- a/osprey/torch2whirl/scripts/run_openpy_docker_test.sh
+++ b/osprey/torch2whirl/scripts/run_openpy_docker_test.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+src_root=$(CDPATH= cd -- "$script_dir/../../.." && pwd)
+build_dir=${OPEN64_OPENPY_BUILD_DIR:-$src_root/build}
+artifact_dir=${OPEN64_TORCH2WHIRL_ARTIFACT_DIR:-$src_root/artifacts/torch2whirl}
+torch_image=${OPEN64_TORCH2WHIRL_TORCH_IMAGE:-open64:torch2whirl-torch-test}
+
+if [ ! -x "$build_dir/osprey/targdir/driver/openpy" ]; then
+    echo "full openpy build not found: $build_dir" >&2
+    echo "set OPEN64_OPENPY_BUILD_DIR to a full Open64 build tree" >&2
+    exit 1
+fi
+
+mkdir -p "$artifact_dir"
+artifact_dir=$(CDPATH= cd -- "$artifact_dir" && pwd)
+if [ "$artifact_dir" = / ] || [ "$artifact_dir" = "$src_root" ]; then
+    echo "refusing unsafe artifact directory: $artifact_dir" >&2
+    exit 1
+fi
+touch "$artifact_dir/.open64-artifact-bind"
+
+docker run --rm --platform linux/amd64 \
+    -v "$src_root:/src" \
+    -v "$build_dir:/build" \
+    -v "$artifact_dir:/artifacts" \
+    -e OPEN64_BUILD_DIR=/build \
+    -e OPEN64_TORCH2WHIRL_ARTIFACT_DIR=/artifacts \
+    "$torch_image" \
+    /src/osprey/driver/tests/openpy_resnet_artifact_test.sh
+
+find "$artifact_dir" -type f \
+    ! -name MANIFEST.txt ! -name .open64-artifact-bind \
+    | sed "s|^$artifact_dir/||" \
+    | LC_ALL=C sort > "$artifact_dir/MANIFEST.txt"
+echo "retained openpy artifacts: $artifact_dir/openpy"

--- a/osprey/torch2whirl/scripts/run_torch_docker_test.sh
+++ b/osprey/torch2whirl/scripts/run_torch_docker_test.sh
@@ -75,8 +75,14 @@ if [ "$run_ir_tools" = 1 ]; then
         -w /build/osprey/targdir/torch2whirl \
         "$torch_image" \
         make OPEN64_DSL_TEST_ARTIFACT_DIR=/artifacts \
-            python_native_ir_tools_smoke driver_native_ir_tools_smoke \
+            python_native_ir_tools_smoke resnet_native_ir_tools_smoke \
+            llama2_prefill_native_ir_tools_smoke \
             llama2_decode_native_ir_tools_smoke
 fi
 
+find "$artifact_dir" -type f \
+    ! -name MANIFEST.txt ! -name .open64-artifact-bind \
+    | sed "s|^$artifact_dir/||" \
+    | LC_ALL=C sort > "$artifact_dir/MANIFEST.txt"
 echo "retained test artifacts: $artifact_dir"
+echo "artifact manifest: $artifact_dir/MANIFEST.txt"

--- a/osprey/torch2whirl/scripts/run_torch_docker_test.sh
+++ b/osprey/torch2whirl/scripts/run_torch_docker_test.sh
@@ -14,11 +14,17 @@ torch_version=${OPEN64_TORCH2WHIRL_TORCH_VERSION:-2.4.1}
 docker_buildkit=${OPEN64_TORCH2WHIRL_DOCKER_BUILDKIT:-0}
 rebuild_image=${OPEN64_TORCH2WHIRL_REBUILD_IMAGE:-0}
 run_ir_tools=${OPEN64_TORCH2WHIRL_RUN_IR_TOOLS:-1}
-artifact_dir=${OPEN64_TORCH2WHIRL_ARTIFACT_DIR:-$build_dir/test-artifacts}
+artifact_dir=${OPEN64_TORCH2WHIRL_ARTIFACT_DIR:-$src_root/artifacts/torch2whirl}
 
 mkdir -p "$build_dir"
 mkdir -p "$artifact_dir"
+artifact_dir=$(CDPATH= cd -- "$artifact_dir" && pwd)
+if [ "$artifact_dir" = / ] || [ "$artifact_dir" = "$src_root" ]; then
+    echo "refusing unsafe artifact directory: $artifact_dir" >&2
+    exit 1
+fi
 find "$artifact_dir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+touch "$artifact_dir/.open64-artifact-bind"
 
 if [ "$rebuild_image" = 1 ] ||
         ! docker image inspect "$torch_image" >/dev/null 2>&1; then
@@ -31,6 +37,11 @@ if [ "$rebuild_image" = 1 ] ||
 else
     echo "reusing existing Docker image: $torch_image"
 fi
+
+docker run --rm \
+    -v "$artifact_dir:/artifacts" \
+    "$torch_image" \
+    test -f /artifacts/.open64-artifact-bind
 
 docker run --rm \
     -v "$src_root:/src" \


### PR DESCRIPTION
## Summary

- retain torch2whirl Docker artifacts under the source checkout by default
- verify the host bind mount before validation starts
- retain model-specific source, `.B`, `.T`, side payloads, and diagnostics
- add persistent ResNet, Llama 2 prefill, and Llama 2 decode families
- preserve `driver_native_ir_tools_smoke` as a compatibility alias for ResNet
- write a sorted `MANIFEST.txt` after the Docker validation lane
- retain combined `openpy -keep -O0` artifacts through a full ResNet pipeline
- separate binary `.T` and post-VHO `.t` traces for case-insensitive macOS
- document the durable artifact location and review contract
- ignore generated artifacts in Git

## Validation

- `sh -n osprey/torch2whirl/scripts/run_torch_docker_test.sh`
- `git diff --check`
- no-tab scan for touched torch2whirl files
- Docker bind-mount survival check: a container wrote
  `docker-bind-survival.txt`, exited under `--rm`, and the host file remained
  readable
- `make OPEN64_DSL_TEST_ARTIFACT_DIR=/artifacts resnet_native_ir_tools_smoke`
- `make OPEN64_DSL_TEST_ARTIFACT_DIR=/artifacts llama2_prefill_native_ir_tools_smoke`
- retained ResNet trace contains CNN operators, basic-block regions,
  residual adds, source references, symbol tables, and type tables
- `OPEN64_OPENPY_BUILD_DIR=/Users/shinmingliu/open64/build osprey/torch2whirl/scripts/run_openpy_docker_test.sh`
- openpy retained source, driver log, `.B`, `.T`, SafeTensors, `.t`, `.s`, and
  optional driver intermediates after Docker exited
- fresh x86_64 DEBUG compiler build completed for driver, torch2whirl, BE, CG,
  WOPT, LNO, clang2whirl, and ir_tools
- runtime libraries completed with the repository-documented
  `LIB_BUILD_COMPILER=GNU` Rosetta workaround
- fresh-build `openpy -keep -O0` ResNet certification passed and retained
  native CNN operators, two basic-block regions, symbols, types, binary trace,
  post-VHO trace, SafeTensors, and assembly

The current retained ResNet and Llama 2 `.B`, `.T`, source, side payload, and
logs were copied to
`/Users/shinmingliu/open64/artifacts/torch2whirl` for immediate review.
