### PR TITLE
Preserve Python callable and model-class context

### DIFF
--- a/osprey/torch2whirl/python/open64_dsc/__init__.py
+++ b/osprey/torch2whirl/python/open64_dsc/__init__.py
@@ -4,6 +4,11 @@ from .builder import WhirlBuilder, load_builder
 from .export import export_to_whirl, save_as_whirl
 from .module import WhirlModule
 from .options import WhirlExportOptions
+from .python_classes import (
+    PythonClassDefinition,
+    PythonClassInstance,
+    collect_python_model_classes,
+)
 from .python_imports import (
     PythonImportedCallable,
     collect_imported_python_callables,
@@ -11,12 +16,15 @@ from .python_imports import (
 from .verifier import WhirlVerificationError, verify_module
 
 __all__ = [
+    "PythonClassDefinition",
+    "PythonClassInstance",
     "PythonImportedCallable",
     "WhirlBuilder",
     "WhirlExportOptions",
     "WhirlVerificationError",
     "WhirlModule",
     "collect_imported_python_callables",
+    "collect_python_model_classes",
     "export_to_whirl",
     "load_builder",
     "save_as_whirl",

--- a/osprey/torch2whirl/python/open64_dsc/__init__.py
+++ b/osprey/torch2whirl/python/open64_dsc/__init__.py
@@ -4,13 +4,19 @@ from .builder import WhirlBuilder, load_builder
 from .export import export_to_whirl, save_as_whirl
 from .module import WhirlModule
 from .options import WhirlExportOptions
+from .python_imports import (
+    PythonImportedCallable,
+    collect_imported_python_callables,
+)
 from .verifier import WhirlVerificationError, verify_module
 
 __all__ = [
+    "PythonImportedCallable",
     "WhirlBuilder",
     "WhirlExportOptions",
     "WhirlVerificationError",
     "WhirlModule",
+    "collect_imported_python_callables",
     "export_to_whirl",
     "load_builder",
     "save_as_whirl",

--- a/osprey/torch2whirl/python/open64_dsc/interpreter.py
+++ b/osprey/torch2whirl/python/open64_dsc/interpreter.py
@@ -37,6 +37,7 @@ from .module import (
     WhirlValueRecord,
 )
 from .options import WhirlExportOptions
+from .python_imports import collect_imported_python_callables
 
 
 @dataclass(frozen=True)
@@ -179,6 +180,7 @@ class WhirlExportInterpreter:
                 )
             )
 
+        model_module = inspect.getmodule(type(model))
         return WhirlModule(
             options=self._options,
             model_name=model_name,
@@ -194,6 +196,10 @@ class WhirlExportInterpreter:
             values=values,
             tensor_payloads=tensor_payloads,
             graph_operators=graph_operators,
+            python_imports=(
+                collect_imported_python_callables(model_module)
+                if model_module is not None else ()
+            ),
         )
 
     def _is_tiny_llama2_prefill_model(self, model: Any) -> bool:

--- a/osprey/torch2whirl/python/open64_dsc/interpreter.py
+++ b/osprey/torch2whirl/python/open64_dsc/interpreter.py
@@ -95,7 +95,8 @@ class WhirlExportInterpreter:
     ) -> WhirlModule:
         inputs = list(example_inputs)
         model_name = self._model_name(model)
-        entry_pu = self.builder().minimal_program_unit(self._options.entry)
+        entry_name = self._model_class_name(model)
+        entry_pu = self.builder().minimal_program_unit(entry_name)
         tensor_types, values, handles = self._build_input_placeholders(inputs)
         tensor_payloads: List[WhirlTensorPayloadRecord] = []
         graph_operators: List[WhirlOperatorRecord] = []
@@ -186,7 +187,7 @@ class WhirlExportInterpreter:
             model_name=model_name,
             input_count=len(inputs),
             entry_function=WhirlProgramUnitRecord(
-                name=self._options.entry,
+                name=entry_name,
                 handle=entry_pu.value,
                 body_markers=body_markers,
             ),
@@ -3178,6 +3179,11 @@ class WhirlExportInterpreter:
     def _model_name(self, model: Any) -> str:
         if self._options.model_name:
             return self._options.model_name
+        if hasattr(model, "__class__"):
+            return model.__class__.__name__
+        return type(model).__name__
+
+    def _model_class_name(self, model: Any) -> str:
         if hasattr(model, "__class__"):
             return model.__class__.__name__
         return type(model).__name__

--- a/osprey/torch2whirl/python/open64_dsc/interpreter.py
+++ b/osprey/torch2whirl/python/open64_dsc/interpreter.py
@@ -37,6 +37,7 @@ from .module import (
     WhirlValueRecord,
 )
 from .options import WhirlExportOptions
+from .python_classes import collect_python_model_classes
 from .python_imports import collect_imported_python_callables
 
 
@@ -182,6 +183,7 @@ class WhirlExportInterpreter:
             )
 
         model_module = inspect.getmodule(type(model))
+        class_definitions, class_instances = collect_python_model_classes(model)
         return WhirlModule(
             options=self._options,
             model_name=model_name,
@@ -201,6 +203,8 @@ class WhirlExportInterpreter:
                 collect_imported_python_callables(model_module)
                 if model_module is not None else ()
             ),
+            python_class_definitions=class_definitions,
+            python_class_instances=class_instances,
         )
 
     def _is_tiny_llama2_prefill_model(self, model: Any) -> bool:

--- a/osprey/torch2whirl/python/open64_dsc/module.py
+++ b/osprey/torch2whirl/python/open64_dsc/module.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Mapping, Sequence
 
 from .options import WhirlExportOptions
+from .python_imports import PythonImportedCallable
 
 
 @dataclass(frozen=True)
@@ -117,6 +118,9 @@ class WhirlModule:
         default_factory=list
     )
     graph_operators: Sequence[WhirlOperatorRecord] = field(default_factory=list)
+    python_imports: Sequence[PythonImportedCallable] = field(
+        default_factory=list
+    )
 
     def to_manifest(self) -> Mapping[str, object]:
         return {
@@ -139,6 +143,10 @@ class WhirlModule:
             "graph_operators": [
                 operator.to_manifest()
                 for operator in self.graph_operators
+            ],
+            "python_imports": [
+                imported.to_manifest()
+                for imported in self.python_imports
             ],
         }
 

--- a/osprey/torch2whirl/python/open64_dsc/module.py
+++ b/osprey/torch2whirl/python/open64_dsc/module.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Mapping, Sequence
 
 from .options import WhirlExportOptions
+from .python_classes import PythonClassDefinition, PythonClassInstance
 from .python_imports import PythonImportedCallable
 
 
@@ -121,6 +122,12 @@ class WhirlModule:
     python_imports: Sequence[PythonImportedCallable] = field(
         default_factory=list
     )
+    python_class_definitions: Sequence[PythonClassDefinition] = field(
+        default_factory=list
+    )
+    python_class_instances: Sequence[PythonClassInstance] = field(
+        default_factory=list
+    )
 
     def to_manifest(self) -> Mapping[str, object]:
         return {
@@ -147,6 +154,14 @@ class WhirlModule:
             "python_imports": [
                 imported.to_manifest()
                 for imported in self.python_imports
+            ],
+            "python_class_definitions": [
+                definition.to_manifest()
+                for definition in self.python_class_definitions
+            ],
+            "python_class_instances": [
+                instance.to_manifest()
+                for instance in self.python_class_instances
             ],
         }
 

--- a/osprey/torch2whirl/python/open64_dsc/python_classes.py
+++ b/osprey/torch2whirl/python/open64_dsc/python_classes.py
@@ -1,0 +1,164 @@
+"""Class definitions and concrete instance state discovered from a model."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+import hashlib
+import inspect
+import os
+import textwrap
+from typing import Any, Dict, List, Mapping, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class PythonClassDefinition:
+    canonical_name: str
+    class_name: str
+    source_file: str
+    source_line: int
+    implementation_method: str
+    implementation_signature: str
+    implementation_fingerprint: str
+
+    def to_manifest(self) -> Mapping[str, object]:
+        return {
+            "canonical_name": self.canonical_name,
+            "class_name": self.class_name,
+            "source_file": self.source_file,
+            "source_line": self.source_line,
+            "implementation_method": self.implementation_method,
+            "implementation_signature": self.implementation_signature,
+            "implementation_fingerprint": self.implementation_fingerprint,
+        }
+
+
+@dataclass(frozen=True)
+class PythonClassInstance:
+    instance_path: str
+    canonical_class_name: str
+    parameters: Sequence[str]
+    buffers: Sequence[str]
+    scalar_state: Mapping[str, str]
+    submodules: Sequence[str]
+
+    def to_manifest(self) -> Mapping[str, object]:
+        return {
+            "instance_path": self.instance_path,
+            "canonical_class_name": self.canonical_class_name,
+            "parameters": list(self.parameters),
+            "buffers": list(self.buffers),
+            "scalar_state": dict(self.scalar_state),
+            "submodules": list(self.submodules),
+        }
+
+
+def _canonical_class_name(instance: Any) -> str:
+    instance_class = type(instance)
+    return f"{instance_class.__module__}.{instance_class.__qualname__}"
+
+
+def _implementation_identity(
+    implementation: object,
+) -> Tuple[str, int, str, str]:
+    try:
+        source_file = inspect.getsourcefile(implementation) or ""
+    except (OSError, TypeError):
+        source_file = ""
+    if source_file:
+        source_file = os.path.realpath(source_file)
+
+    try:
+        lines, source_line = inspect.getsourcelines(implementation)
+        source = textwrap.dedent("".join(lines))
+    except (OSError, TypeError):
+        source_line = 0
+        source = ""
+    try:
+        normalized = ast.dump(
+            ast.parse(source),
+            annotate_fields=True,
+            include_attributes=False,
+        )
+    except SyntaxError:
+        normalized = source
+
+    try:
+        signature = str(inspect.signature(implementation))
+    except (TypeError, ValueError):
+        signature = ""
+    fingerprint = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return source_file, source_line, signature, fingerprint
+
+
+def _direct_names(instance: Any, method_name: str) -> Sequence[str]:
+    method = getattr(instance, method_name, None)
+    if not callable(method):
+        return ()
+    try:
+        return tuple(name for name, unused in method(recurse=False))
+    except TypeError:
+        return ()
+
+
+def _scalar_state(instance: Any) -> Mapping[str, str]:
+    state: Dict[str, str] = {}
+    for name, value in vars(instance).items():
+        if name.startswith("_"):
+            continue
+        if isinstance(value, (bool, float, int, str)):
+            state[name] = str(value)
+    return state
+
+
+def collect_python_model_classes(
+    model: Any,
+) -> Tuple[Sequence[PythonClassDefinition], Sequence[PythonClassInstance]]:
+    """Collect model class definitions and per-instance state declarations."""
+
+    named_modules = getattr(model, "named_modules", None)
+    if not callable(named_modules):
+        modules = (("", model),)
+    else:
+        modules = tuple(named_modules())
+
+    definitions: Dict[str, PythonClassDefinition] = {}
+    instances: List[PythonClassInstance] = []
+    for path, instance in modules:
+        canonical_name = _canonical_class_name(instance)
+        implementation = getattr(type(instance), "forward", None)
+        if inspect.isfunction(implementation):
+            source_file, source_line, signature, fingerprint = (
+                _implementation_identity(implementation)
+            )
+            if source_line != 0:
+                definitions[canonical_name] = PythonClassDefinition(
+                    canonical_name=canonical_name,
+                    class_name=type(instance).__name__,
+                    source_file=source_file,
+                    source_line=source_line,
+                    implementation_method="forward",
+                    implementation_signature=signature,
+                    implementation_fingerprint=fingerprint,
+                )
+
+        submodules = getattr(instance, "_modules", {})
+        instances.append(
+            PythonClassInstance(
+                instance_path=str(path) or "<model>",
+                canonical_class_name=canonical_name,
+                parameters=_direct_names(instance, "named_parameters"),
+                buffers=_direct_names(instance, "named_buffers"),
+                scalar_state=_scalar_state(instance),
+                submodules=tuple(
+                    str(name)
+                    for name, submodule in submodules.items()
+                    if submodule is not None
+                ),
+            )
+        )
+
+    return (
+        tuple(definitions[name] for name in sorted(definitions)),
+        tuple(instances),
+    )

--- a/osprey/torch2whirl/python/open64_dsc/python_imports.py
+++ b/osprey/torch2whirl/python/open64_dsc/python_imports.py
@@ -1,0 +1,148 @@
+"""Discovery records for Python callables made visible by imports."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+import hashlib
+import inspect
+import os
+import textwrap
+from types import ModuleType
+from typing import Dict, List, Mapping, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class PythonImportedCallable:
+    canonical_name: str
+    import_names: Sequence[str]
+    kind: str
+    module_name: str
+    qualified_name: str
+    source_file: str
+    source_line: int
+    signature: str
+    implementation_fingerprint: str
+
+    def to_manifest(self) -> Mapping[str, object]:
+        return {
+            "canonical_name": self.canonical_name,
+            "import_names": list(self.import_names),
+            "kind": self.kind,
+            "module_name": self.module_name,
+            "qualified_name": self.qualified_name,
+            "source_file": self.source_file,
+            "source_line": self.source_line,
+            "signature": self.signature,
+            "implementation_fingerprint": self.implementation_fingerprint,
+        }
+
+
+def _source_identity(function: object) -> Tuple[str, int, str]:
+    try:
+        source_file = inspect.getsourcefile(function) or ""
+    except (OSError, TypeError):
+        source_file = ""
+    if source_file:
+        source_file = os.path.realpath(source_file)
+
+    try:
+        source_lines, source_line = inspect.getsourcelines(function)
+        source = textwrap.dedent("".join(source_lines))
+    except (OSError, TypeError):
+        source_line = 0
+        source = ""
+
+    try:
+        normalized = ast.dump(
+            ast.parse(source),
+            annotate_fields=True,
+            include_attributes=False,
+        )
+    except SyntaxError:
+        normalized = source
+    fingerprint = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return source_file, source_line, fingerprint
+
+
+def _signature(function: object) -> str:
+    try:
+        return str(inspect.signature(function))
+    except (TypeError, ValueError):
+        return ""
+
+
+def _function_record(
+    function: object,
+    import_names: Sequence[str],
+    kind: str,
+) -> PythonImportedCallable:
+    module_name = str(getattr(function, "__module__", ""))
+    qualified_name = str(getattr(function, "__qualname__", ""))
+    source_file, source_line, fingerprint = _source_identity(function)
+    return PythonImportedCallable(
+        canonical_name=f"{module_name}.{qualified_name}",
+        import_names=tuple(sorted(import_names)),
+        kind=kind,
+        module_name=module_name,
+        qualified_name=qualified_name,
+        source_file=source_file,
+        source_line=source_line,
+        signature=_signature(function),
+        implementation_fingerprint=fingerprint,
+    )
+
+
+def _class_functions(
+    import_name: str,
+    imported_class: type,
+) -> List[Tuple[str, object]]:
+    functions: List[Tuple[str, object]] = []
+    for member_name, member in vars(imported_class).items():
+        function = member
+        if isinstance(member, (classmethod, staticmethod)):
+            function = member.__func__
+        if inspect.isfunction(function):
+            functions.append((f"{import_name}.{member_name}", function))
+    return functions
+
+
+def collect_imported_python_callables(
+    module: ModuleType,
+) -> Sequence[PythonImportedCallable]:
+    """Collect Python-defined callables bound from another module.
+
+    This is a declaration catalog, not yet the certified reachable-PU graph.
+    Multiple aliases are folded into one canonical definition record.
+    """
+
+    aliases: Dict[Tuple[str, str], List[str]] = {}
+    definitions: Dict[Tuple[str, str], Tuple[object, str]] = {}
+
+    for import_name, imported in vars(module).items():
+        defining_module = str(getattr(imported, "__module__", ""))
+        if not defining_module or defining_module == module.__name__:
+            continue
+
+        candidates: List[Tuple[str, object, str]] = []
+        if inspect.isfunction(imported):
+            candidates.append((import_name, imported, "function"))
+        elif inspect.isclass(imported):
+            candidates.extend(
+                (name, function, "method")
+                for name, function in _class_functions(import_name, imported)
+            )
+
+        for alias, function, kind in candidates:
+            key = (
+                str(getattr(function, "__module__", "")),
+                str(getattr(function, "__qualname__", "")),
+            )
+            aliases.setdefault(key, []).append(alias)
+            definitions[key] = (function, kind)
+
+    records = [
+        _function_record(definitions[key][0], names, definitions[key][1])
+        for key, names in aliases.items()
+    ]
+    return tuple(sorted(records, key=lambda record: record.canonical_name))

--- a/osprey/torch2whirl/python/tests/llama2_decode_native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/llama2_decode_native_ir_tools_smoke.py
@@ -194,6 +194,13 @@ def _inspect_artifact(ir_b2a: Path, artifact: Path, text_dump: Path) -> int:
         print(text, file=sys.stderr)
         return 1
 
+    if re.search(
+        r"FUNC_ENTRY <[^>]*TinyLlama2DecodeForCausalLM>",
+        text,
+    ) is None:
+        print("decode trace retained a generic FUNC_ENTRY name", file=sys.stderr)
+        return 1
+
     count_expectations = {
         "contract=transformer.decoder_layer.v2": 2,
         "OPR_DSLROTARYEMBEDDING # OPR_DSLROTARYEMBEDDING version=2": 4,

--- a/osprey/torch2whirl/python/tests/test_llama2_capture_optional.py
+++ b/osprey/torch2whirl/python/tests/test_llama2_capture_optional.py
@@ -203,6 +203,7 @@ class TinyLlama2WhirlExportOptionalTest(unittest.TestCase):
         )
 
         self.assertEqual(module.graph_source, "torch.fx+llama2_semantic")
+        self.assertEqual(module.entry_function.name, "TinyLlama2ForCausalLM")
         self.assertEqual(module.input_count, 1)
         self.assertIn("transformer.token_embedding", module.operators)
         self.assertIn("transformer.rms_norm", module.operators)

--- a/osprey/torch2whirl/python/tests/test_llama2_capture_optional.py
+++ b/osprey/torch2whirl/python/tests/test_llama2_capture_optional.py
@@ -204,6 +204,36 @@ class TinyLlama2WhirlExportOptionalTest(unittest.TestCase):
 
         self.assertEqual(module.graph_source, "torch.fx+llama2_semantic")
         self.assertEqual(module.entry_function.name, "TinyLlama2ForCausalLM")
+        definitions = {
+            definition.canonical_name: definition
+            for definition in module.python_class_definitions
+        }
+        instances = list(module.python_class_instances)
+        self.assertIn("models.llama2_model.TinyLlama2Attention", definitions)
+        self.assertIn(
+            "models.llama2_model.TinyLlama2FeedForward",
+            definitions,
+        )
+        self.assertIn("models.llama2_model.TinyRMSNorm", definitions)
+        rms_norm_instances = [
+            instance for instance in instances
+            if instance.canonical_class_name ==
+               "models.llama2_model.TinyRMSNorm"
+        ]
+        self.assertEqual(len(rms_norm_instances), 5)
+        self.assertEqual(
+            [instance.instance_path for instance in rms_norm_instances],
+            [
+                "layers.0.attention_norm",
+                "layers.0.ffn_norm",
+                "layers.1.attention_norm",
+                "layers.1.ffn_norm",
+                "norm",
+            ],
+        )
+        for instance in rms_norm_instances:
+            self.assertEqual(tuple(instance.parameters), ("weight",))
+            self.assertEqual(instance.scalar_state["eps"], "1e-05")
         self.assertEqual(module.input_count, 1)
         self.assertIn("transformer.token_embedding", module.operators)
         self.assertIn("transformer.rms_norm", module.operators)

--- a/osprey/torch2whirl/python/tests/test_llama2_decode_capture_optional.py
+++ b/osprey/torch2whirl/python/tests/test_llama2_decode_capture_optional.py
@@ -237,6 +237,33 @@ class TinyLlama2DecodeWhirlEmissionOptionalTest(unittest.TestCase):
         interpreter = WhirlExportInterpreter(WhirlExportOptions())
         return interpreter.export(model, sample_decode_inputs(config))
 
+    def test_decode_collects_imported_callable_declarations(self) -> None:
+        module = self._export_decode()
+        by_name = {
+            imported.canonical_name: imported
+            for imported in module.python_imports
+        }
+
+        rms_norm = by_name["models.llama2_model.TinyRMSNorm.forward"]
+        self.assertEqual(
+            tuple(rms_norm.import_names),
+            ("TinyRMSNorm.forward",),
+        )
+        self.assertEqual(rms_norm.kind, "method")
+        self.assertEqual(len(rms_norm.implementation_fingerprint), 64)
+        self.assertIn(
+            "models.llama2_model.TinyLlama2FeedForward.forward",
+            by_name,
+        )
+        self.assertIn(
+            "models.llama2_model.initialize_tiny_llama2",
+            by_name,
+        )
+        self.assertEqual(
+            len(module.to_manifest()["python_imports"]),
+            len(module.python_imports),
+        )
+
     def test_decode_emits_v2_rope_and_attention_contracts(self) -> None:
         module = self._export_decode()
         verify_module(module)

--- a/osprey/torch2whirl/python/tests/test_llama2_decode_capture_optional.py
+++ b/osprey/torch2whirl/python/tests/test_llama2_decode_capture_optional.py
@@ -239,6 +239,10 @@ class TinyLlama2DecodeWhirlEmissionOptionalTest(unittest.TestCase):
 
     def test_decode_collects_imported_callable_declarations(self) -> None:
         module = self._export_decode()
+        self.assertEqual(
+            module.entry_function.name,
+            "TinyLlama2DecodeForCausalLM",
+        )
         by_name = {
             imported.canonical_name: imported
             for imported in module.python_imports

--- a/osprey/torch2whirl/python/tests/test_open64_dsc_fx_capture_optional.py
+++ b/osprey/torch2whirl/python/tests/test_open64_dsc_fx_capture_optional.py
@@ -138,7 +138,7 @@ class Open64DscFxCaptureOptionalTest(unittest.TestCase):
                 format=mock
                 model_name=AddModule
                 entry=forward
-                entry_function=forward
+                entry_function=AddModule
                 graph_source=torch.fx
                 input_count=2
                 entry_body_marker.0=input0
@@ -203,7 +203,7 @@ class Open64DscFxCaptureOptionalTest(unittest.TestCase):
                 format=mock
                 model_name=MatmulModule
                 entry=forward
-                entry_function=forward
+                entry_function=MatmulModule
                 graph_source=torch.fx
                 input_count=2
                 entry_body_marker.0=input0
@@ -1391,7 +1391,7 @@ class Open64DscFxCaptureOptionalTest(unittest.TestCase):
 
         self.assertIn("format=mock", text)
         self.assertIn("model_name=AddModel", text)
-        self.assertIn("entry_function=forward", text)
+        self.assertIn("entry_function=AddModel", text)
         self.assertIn("operator.0=common.add", text)
         self.assertIn("graph_operator.0=common.add:input0,input0", text)
 

--- a/osprey/torch2whirl/python/tests/test_open64_dsc_skeleton.py
+++ b/osprey/torch2whirl/python/tests/test_open64_dsc_skeleton.py
@@ -258,7 +258,7 @@ class Open64DscSkeletonTest(unittest.TestCase):
         self.assertEqual(module.model_name, "DummyModel")
         self.assertEqual(module.input_count, 2)
         self.assertEqual(module.options.backend, "mock")
-        self.assertEqual(module.entry_function.name, "forward")
+        self.assertEqual(module.entry_function.name, "DummyModel")
         self.assertGreater(module.entry_function.handle, 0)
         self.assertEqual(
             module.entry_function.body_markers,
@@ -2266,7 +2266,7 @@ class Open64DscSkeletonTest(unittest.TestCase):
 
         self.assertIn("format=mock", text)
         self.assertIn("model_name=unit_model", text)
-        self.assertIn("entry_function=forward", text)
+        self.assertIn("entry_function=DummyModel", text)
         self.assertIn("entry_body_marker.0=input0", text)
         self.assertIn("entry_body_marker.1=input1", text)
         self.assertIn("entry_body_marker.2=common.add", text)

--- a/osprey/torch2whirl/python/tests/test_python_classes.py
+++ b/osprey/torch2whirl/python/tests/test_python_classes.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import unittest
+
+from open64_dsc.python_classes import collect_python_model_classes
+
+
+class _Model:
+    def __init__(self) -> None:
+        self.training = False
+
+    def forward(self, value):
+        return value
+
+
+class PythonClassDiscoveryTest(unittest.TestCase):
+    def test_plain_model_has_class_definition_and_instance_state(self) -> None:
+        definitions, instances = collect_python_model_classes(_Model())
+
+        self.assertEqual(len(definitions), 1)
+        self.assertEqual(definitions[0].class_name, "_Model")
+        self.assertEqual(definitions[0].implementation_method, "forward")
+        self.assertEqual(len(definitions[0].implementation_fingerprint), 64)
+        self.assertEqual(len(instances), 1)
+        self.assertEqual(instances[0].instance_path, "<model>")
+        self.assertEqual(instances[0].scalar_state, {"training": "False"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/osprey/torch2whirl/python/tests/test_python_imports.py
+++ b/osprey/torch2whirl/python/tests/test_python_imports.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+from open64_dsc.python_imports import collect_imported_python_callables
+
+
+class PythonImportDiscoveryTest(unittest.TestCase):
+    def test_aliases_share_one_canonical_definition(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "dependency.py").write_text(
+                """
+def helper(value):
+    return value + 1
+
+
+class Layer:
+    def __init__(self, scale):
+        self.scale = scale
+
+    def forward(self, value):
+        return value * self.scale
+""".lstrip(),
+                encoding="utf-8",
+            )
+            (root / "consumer.py").write_text(
+                """
+from dependency import helper
+from dependency import helper as helper_alias
+from dependency import Layer as ImportedLayer
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            sys.path.insert(0, str(root))
+            try:
+                consumer = importlib.import_module("consumer")
+                records = collect_imported_python_callables(consumer)
+            finally:
+                sys.path.remove(str(root))
+                sys.modules.pop("consumer", None)
+                sys.modules.pop("dependency", None)
+
+        by_name = {record.canonical_name: record for record in records}
+        helper = by_name["dependency.helper"]
+        self.assertEqual(
+            tuple(helper.import_names),
+            ("helper", "helper_alias"),
+        )
+        self.assertEqual(helper.kind, "function")
+        self.assertEqual(helper.signature, "(value)")
+        self.assertNotEqual(helper.source_line, 0)
+        self.assertEqual(len(helper.implementation_fingerprint), 64)
+
+        forward = by_name["dependency.Layer.forward"]
+        self.assertEqual(tuple(forward.import_names), ("ImportedLayer.forward",))
+        self.assertEqual(forward.kind, "method")
+        self.assertEqual(forward.signature, "(self, value)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- collect imported Python-defined callables using canonical identities, aliases, signatures, source locations, and normalized implementation fingerprints
- collect model class definitions and concrete instance state, including parameters, buffers, scalar values, and submodule bindings
- name the top-level WHIRL FUNC_ENTRY after the model class while retaining forward as the selected source method
- verify that Llama 2 RMSNorm uses one class definition across five calling contexts with distinct instance state
- add --single-pu across the C++ driver and Python frontend, recording pu_mode=single for future correctness and performance comparisons

## Current boundary

This checkpoint deliberately preserves the existing computation layout. The single class-named FUNC_ENTRY still contains the complete Llama forward computation. It does not yet emit separate PUs for attention, RMSNorm, MLP, decoder layers, or imported library classes.

Single-PU emission remains the default today. When class-PU construction becomes available, its mode can become the default while --single-pu continues selecting this flattened baseline.

The follow-up infrastructure change must add correct per-PU local symbol-table and map-table ownership to the common DSL builder before redistributing the body into class implementation PUs and explicit calls.

## Validation

- make -C osprey/torch2whirl -f Makefile.gbase python_test: 135 tests passed, 66 optional skips
- macOS C++17 driver build passed without warnings and help exposes --single-pu
- Docker C++-to-Python driver smoke passed with --single-pu
- Docker Llama prefill and decode suites: 24 tests passed
- native ir_b2a -st -src evidence verified class-named entries for TinyLlama2ForCausalLM and TinyLlama2DecodeForCausalLM
- git diff --check and no-tab checks passed