### PR TITLE
Add native multiple-PU call interfaces

### DIFF
--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -952,6 +952,63 @@ producer compatibility.  A frontend calls `DSL_Builder_Begin_Program` before
 each model, including the model following successful finalization, and calls
 `DSL_Builder_Abort_Program` after capture or construction failure.
 
+#### Multiple-PU Python callable contract
+
+Reachable Python-defined class callables are represented by real WHIRL program
+units.  Their public identity is class-centric rather than the generic Python
+method name `forward`.  Repeated calls to one definition are context-sensitive
+calls to the same PU; they do not create operator versions or duplicate the
+definition merely because the arguments or instance paths differ.
+
+The native builder publishes the following opaque interfaces:
+
+- `DSL_Builder_Select_PU(pu)` selects a builder-owned PU and restores its local
+  symbol and map tables.
+- `DSL_Builder_Declare_PU_Formal(pu, name, ordinal, ty, source_position)`
+  creates an ordered typed `SCLASS_FORMAL` and returns an opaque value handle.
+- `DSL_Builder_Declare_PU_Result(pu, name, ordinal, ty, role,
+  source_position)` creates an ordered typed `SCLASS_FORMAL_REF` result slot.
+  The initial roles are tensor result and abstract-state result.
+- `DSL_Builder_Return_PU_Values(pu, values, value_count)` copies each defining
+  value into its corresponding result slot and emits the standard WHIRL
+  `RETURN` statement.
+- `DSL_Builder_Create_PU_Call(caller, callee, arguments, argument_count,
+  result_names, result_count, callsite)` emits a standard WHIRL `CALL`, creates
+  fresh caller-owned result temporaries, and records canonical class, instance
+  path, context identity, call ordinal, and source position.
+- `DSL_Builder_Get_PU_Call_Result(call, ordinal, value)` returns only an opaque
+  caller-local value handle.  A callee-local value handle never crosses the PU
+  boundary.
+
+Tensor inputs are passed through standard `PARM` nodes marked
+`BY_REFERENCE|READ_ONLY|PASSED_NOT_SAVED`.  Result slots are passed through
+`BY_REFERENCE|OUT|PASSED_NOT_SAVED`; the caller owns their unique no-alias
+storage.  This is the VHO callable contract, not a target ABI commitment.  A
+later lowering step may pack or otherwise adapt results for a selected runtime
+ABI.
+
+Python tuple returns, including decode activation plus K/V cache state, are
+modeled as ordered named and typed semantic result slots.  They are not a
+generic tuple type and do not turn one expression operator into an
+unclassified multiple-result operator.  Each slot has a reviewed semantic role
+and can participate independently in tensor, ownership, and abstract-state
+verification.
+
+The builder retains a high-level `__WHIRL_DSL_CALL__` comment projection with
+callee, class, instance, context, and ordinal evidence.  `ir_b2a -st -src`
+therefore exposes the logical relationship alongside standard `FUNC_ENTRY`,
+`IDNAME`, `CALL`, `PARM`, symbol class, and source-position evidence.  Compiler
+clients do not inspect private physical DSL opcode storage to recover calls.
+
+This contract adds no WHIRL operator value, ELF section, mapped-image record,
+or record-size change.  Function entries, formals, calls, parameters, returns,
+symbols, types, and source positions use baseline WHIRL structures.  Existing
+DSL value records use their metadata field to retain a stable `owner_pu` name,
+because local `ST_IDX` values can repeat across PU scopes.  The gatekeeper
+rejects wrong formal/result counts, noncontiguous ordinals, cross-PU value
+reuse, missing returns, and call parameters whose read-only/out flags disagree
+with the published interface.
+
 #### Structured regions
 
 1. Add opaque `DSL_BUILDER_REGION` and region-classifier handles.

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -178,6 +178,16 @@ DSL_Builder_Select_PU (DSL_BUILDER_PROGRAM_UNIT pu)
     return TRUE;
 }
 
+static BOOL
+DSL_Builder_Select_Value_PU (DSL_BUILDER_VALUE_RECORD *record)
+{
+    if (record == NULL)
+        return FALSE;
+    if (record->pu != NULL)
+        return DSL_Builder_Select_PU(record->pu);
+    return DSL_Builder_Active_PU == NULL && DSL_Builder_PU_Root == NULL;
+}
+
 static dsl_builder_state *
 DSL_Builder_Find_State (DSL_BUILDER_STATE state)
 {
@@ -1607,7 +1617,7 @@ DSL_Builder_Create_Native_Value
     ST_IDX result_st;
     DSL_IR_VALUE_ID image_value_id;
 
-    if (DSL_Builder_Active_PU == NULL ||
+    if ((DSL_Builder_Active_PU == NULL && DSL_Builder_PU_Root != NULL) ||
         !TY_is_tensor_extension(result_ty) ||
         (kid_count != 0 && kids == NULL) ||
         (attr_count != 0 && attrs == NULL))
@@ -2406,7 +2416,7 @@ DSL_Builder_Attach_Value_Metadata
 {
     DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
 
-    return record != NULL && DSL_Builder_Select_PU(record->pu) &&
+    return DSL_Builder_Select_Value_PU(record) &&
            DSL_Builder_Attach_Metadata
                (record->result_st, metadata, metadata_count);
 }
@@ -2418,7 +2428,7 @@ DSL_Builder_Attach_Value_Lineage
 {
     DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
 
-    if (record == NULL || !DSL_Builder_Select_PU(record->pu) ||
+    if (!DSL_Builder_Select_Value_PU(record) ||
         lineage == NULL || lineage[0] == '\0')
         return FALSE;
     ST_tensor_bind_attribute
@@ -2919,7 +2929,7 @@ DSL_Builder_Set_Value_Source_Position
     DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
     USRCPOS position;
 
-    if (record == NULL || !DSL_Builder_Select_PU(record->pu) ||
+    if (!DSL_Builder_Select_Value_PU(record) ||
         source_position == NULL ||
         source_position->file_id == 0 ||
         source_position->file_id > DSL_builder_source_files.size() ||

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -33,12 +33,14 @@
 
 static PU_Info *DSL_Builder_PU_Root = NULL;
 static PU_Info *DSL_Builder_PU_Last = NULL;
+static PU_Info *DSL_Builder_Active_PU = NULL;
 static UINT32 DSL_Builder_Result_Number = 0;
 static DST_INFO_IDX DSL_Builder_CU_DST = DST_INVALID_INIT;
 static std::vector<std::string> DSL_builder_source_files;
 static std::vector<std::string> DSL_builder_source_directories;
 
 typedef struct {
+    DSL_BUILDER_PROGRAM_UNIT pu;
     WN *assignment;
     WN *expression;
     ST_IDX result_st;
@@ -56,18 +58,73 @@ struct dsl_builder_state {
 
 static std::vector<dsl_builder_state *> DSL_builder_state_registry;
 
+struct dsl_builder_pu_interface_value {
+    DSL_BUILDER_VALUE value;
+    ST_IDX st;
+    TY_IDX ty;
+    UINT32 ordinal;
+    DSL_BUILDER_PU_RESULT_ROLE role;
+};
+
+struct dsl_builder_pu_interface {
+    DSL_BUILDER_PROGRAM_UNIT pu;
+    std::vector<dsl_builder_pu_interface_value> formals;
+    std::vector<dsl_builder_pu_interface_value> results;
+    BOOL has_return;
+};
+
+struct dsl_builder_call_record {
+    DSL_BUILDER_CALL call;
+    DSL_BUILDER_PROGRAM_UNIT caller;
+    DSL_BUILDER_PROGRAM_UNIT callee;
+    std::vector<DSL_BUILDER_VALUE> results;
+};
+
+static std::vector<dsl_builder_pu_interface *> DSL_builder_pu_interfaces;
+static std::vector<dsl_builder_call_record *> DSL_builder_call_registry;
+
 static void
 DSL_Builder_Reset_Program (void)
 {
     for (UINT32 i = 0; i < DSL_builder_state_registry.size(); ++i)
         delete DSL_builder_state_registry[i];
+    for (UINT32 i = 0; i < DSL_builder_pu_interfaces.size(); ++i)
+        delete DSL_builder_pu_interfaces[i];
+    for (UINT32 i = 0; i < DSL_builder_call_registry.size(); ++i)
+        delete DSL_builder_call_registry[i];
     DSL_Builder_PU_Root = NULL;
     DSL_Builder_PU_Last = NULL;
+    DSL_Builder_Active_PU = NULL;
     DSL_Builder_Result_Number = 0;
+    DSL_Builder_CU_DST = DST_INVALID_IDX;
+    DSL_builder_source_files.clear();
+    DSL_builder_source_directories.clear();
     DSL_builder_value_registry.clear();
     DSL_builder_state_registry.clear();
+    DSL_builder_pu_interfaces.clear();
+    DSL_builder_call_registry.clear();
     DSL_IR_Image_Reset();
     DSL_Region_Reset();
+}
+
+static dsl_builder_pu_interface *
+DSL_Builder_Find_PU_Interface (DSL_BUILDER_PROGRAM_UNIT pu)
+{
+    for (UINT32 i = 0; i < DSL_builder_pu_interfaces.size(); ++i) {
+        if (DSL_builder_pu_interfaces[i]->pu == pu)
+            return DSL_builder_pu_interfaces[i];
+    }
+    return NULL;
+}
+
+static dsl_builder_call_record *
+DSL_Builder_Find_Call_Record (DSL_BUILDER_CALL call)
+{
+    for (UINT32 i = 0; i < DSL_builder_call_registry.size(); ++i) {
+        if (DSL_builder_call_registry[i]->call == call)
+            return DSL_builder_call_registry[i];
+    }
+    return NULL;
 }
 
 static DSL_BUILDER_VALUE_RECORD *
@@ -85,11 +142,40 @@ static DSL_BUILDER_VALUE_RECORD *
 DSL_Builder_Find_Value_Record_By_ST (ST_IDX st)
 {
     for (UINT32 i = 0; i < DSL_builder_value_registry.size(); ++i) {
-        if (DSL_builder_value_registry[i].result_st == st)
+        if (DSL_builder_value_registry[i].pu == DSL_Builder_Active_PU &&
+            DSL_builder_value_registry[i].result_st == st)
             return &DSL_builder_value_registry[i];
     }
 
     return NULL;
+}
+
+static BOOL
+DSL_Builder_PU_Is_Registered (DSL_BUILDER_PROGRAM_UNIT pu)
+{
+    for (PU_Info *current = DSL_Builder_PU_Root; current != NULL;
+         current = PU_Info_next(current)) {
+        if (current == pu)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_Builder_Select_PU (DSL_BUILDER_PROGRAM_UNIT pu)
+{
+    if (!DSL_Builder_PU_Is_Registered(pu) ||
+        PU_Info_state(pu, WT_SYMTAB) != Subsect_InMem ||
+        PU_Info_symtab_ptr(pu) == NULL)
+        return FALSE;
+
+    ST_IDX proc_st = PU_Info_proc_sym(pu);
+    Current_pu = &Pu_Table[ST_pu(St_Table[proc_st])];
+    Current_scope = Current_pu->lexical_level;
+    Restore_Local_Symtab(pu);
+    Current_Map_Tab = PU_Info_maptab(pu);
+    DSL_Builder_Active_PU = pu;
+    return TRUE;
 }
 
 static dsl_builder_state *
@@ -140,6 +226,108 @@ DSL_Builder_PU_Body (DSL_BUILDER_PROGRAM_UNIT pu)
         return NULL;
 
     return body;
+}
+
+static BOOL
+DSL_Builder_Source_Position_Valid
+        (const DSL_BUILDER_SOURCE_POSITION *source_position)
+{
+    return source_position != NULL && source_position->file_id != 0 &&
+           source_position->file_id <= DSL_builder_source_files.size() &&
+           source_position->line >= 0 && source_position->column <= 4095;
+}
+
+static SRCPOS
+DSL_Builder_Source_Position
+        (const DSL_BUILDER_SOURCE_POSITION *source_position)
+{
+    USRCPOS position;
+    USRCPOS_clear(position);
+    USRCPOS_filenum(position) = source_position->file_id;
+    USRCPOS_linenum(position) = source_position->line;
+    USRCPOS_column(position) = source_position->column;
+    USRCPOS_stmt_begin(position) = source_position->statement_begin != 0;
+    USRCPOS_bb_begin(position) = source_position->basic_block_begin != 0;
+    return USRCPOS_srcpos(position);
+}
+
+static DSL_IR_VALUE_ID
+DSL_Builder_Add_Image_Symbol_Value
+        (ST_IDX st,
+         TY_IDX ty,
+         UINT32 value_kind)
+{
+    DSL_IR_VALUE_RECORD record;
+    DSL_IR_Value_Record_Init(&record);
+    record.value_kind = value_kind;
+    record.ty = ty;
+    record.st = st;
+    record.name = Save_Str(ST_name(St_Table[st]));
+    if (DSL_Builder_Active_PU != NULL) {
+        std::string metadata = "owner_pu=";
+        metadata += ST_name
+                        (St_Table[PU_Info_proc_sym(DSL_Builder_Active_PU)]);
+        record.metadata = Save_Str(metadata.c_str());
+    }
+    return DSL_IR_Image_Add_Value(&record);
+}
+
+static TY_IDX
+DSL_Builder_Create_PU_Function_Type
+        (const dsl_builder_pu_interface *interface_record)
+{
+    TY_IDX function_ty;
+    TY &function = New_TY(function_ty);
+    TY_Init(function, 0, KIND_FUNCTION, MTYPE_UNKNOWN, 0);
+    Set_TY_align(function_ty, 1);
+
+    TYLIST_IDX tylist_idx;
+    Set_TYLIST_type(New_TYLIST(tylist_idx), MTYPE_To_TY(MTYPE_V));
+    Set_TY_tylist(function_ty, tylist_idx);
+    for (UINT32 i = 0; i < interface_record->formals.size(); ++i)
+        Set_TYLIST_type(New_TYLIST(tylist_idx),
+                        interface_record->formals[i].ty);
+    for (UINT32 i = 0; i < interface_record->results.size(); ++i)
+        Set_TYLIST_type(New_TYLIST(tylist_idx),
+                        Make_Pointer_Type(interface_record->results[i].ty));
+    Set_TYLIST_type(New_TYLIST(tylist_idx), TY_IDX_ZERO);
+    return function_ty;
+}
+
+static BOOL
+DSL_Builder_Rebuild_PU_Entry (dsl_builder_pu_interface *interface_record)
+{
+    if (interface_record == NULL ||
+        !DSL_Builder_Select_PU(interface_record->pu))
+        return FALSE;
+
+    WN *old_entry = PU_Info_tree_ptr(interface_record->pu);
+    if (old_entry == NULL || WN_operator(old_entry) != OPR_FUNC_ENTRY)
+        return FALSE;
+    UINT32 formal_count = interface_record->formals.size();
+    UINT32 result_count = interface_record->results.size();
+    if (formal_count + result_count > 32767)
+        return FALSE;
+
+    WN *entry = WN_CreateEntry
+                    ((INT16)(formal_count + result_count),
+                     PU_Info_proc_sym(interface_record->pu),
+                     WN_func_body(old_entry), WN_func_pragmas(old_entry),
+                     WN_func_varrefs(old_entry));
+    for (UINT32 i = 0; i < formal_count; ++i)
+        WN_formal(entry, i) = WN_CreateIdname
+                                  (0, interface_record->formals[i].st);
+    for (UINT32 i = 0; i < result_count; ++i)
+        WN_formal(entry, formal_count + i) = WN_CreateIdname
+                                                 (0,
+                                                  interface_record->results[i].st);
+
+    ST_IDX proc_st = PU_Info_proc_sym(interface_record->pu);
+    TY_IDX function_ty =
+        DSL_Builder_Create_PU_Function_Type(interface_record);
+    Set_PU_prototype(Pu_Table[ST_pu(St_Table[proc_st])], function_ty);
+    Set_PU_Info_tree_ptr(interface_record->pu, entry);
+    return TRUE;
 }
 
 static const char *
@@ -1384,6 +1572,12 @@ DSL_Builder_Add_Image_Node
     value_record.ty = result_ty;
     value_record.st = result_st;
     value_record.name = Save_Str(ST_name(St_Table[result_st]));
+    if (DSL_Builder_Active_PU != NULL) {
+        std::string metadata = "owner_pu=";
+        metadata += ST_name
+                        (St_Table[PU_Info_proc_sym(DSL_Builder_Active_PU)]);
+        value_record.metadata = Save_Str(metadata.c_str());
+    }
     *result_value_id = DSL_IR_Image_Add_Value(&value_record);
     if (*result_value_id == DSL_IR_VALUE_INVALID_ID)
         return FALSE;
@@ -1413,7 +1607,8 @@ DSL_Builder_Create_Native_Value
     ST_IDX result_st;
     DSL_IR_VALUE_ID image_value_id;
 
-    if (!TY_is_tensor_extension(result_ty) ||
+    if (DSL_Builder_Active_PU == NULL ||
+        !TY_is_tensor_extension(result_ty) ||
         (kid_count != 0 && kids == NULL) ||
         (attr_count != 0 && attrs == NULL))
         return NULL;
@@ -1423,7 +1618,8 @@ DSL_Builder_Create_Native_Value
         operands = new WN *[kid_count];
         for (UINT32 i = 0; i < kid_count; ++i) {
             operand_records[i] = DSL_Builder_Find_Value_Record(kids[i]);
-            if (operand_records[i] == NULL) {
+            if (operand_records[i] == NULL ||
+                operand_records[i]->pu != DSL_Builder_Active_PU) {
                 delete [] operands;
                 delete [] operand_records;
                 return NULL;
@@ -1462,6 +1658,7 @@ DSL_Builder_Create_Native_Value
     delete [] operand_records;
 
     DSL_BUILDER_VALUE_RECORD record;
+    record.pu = DSL_Builder_Active_PU;
     record.assignment = assignment;
     record.expression = expression;
     record.result_st = result_st;
@@ -2209,7 +2406,7 @@ DSL_Builder_Attach_Value_Metadata
 {
     DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
 
-    return record != NULL &&
+    return record != NULL && DSL_Builder_Select_PU(record->pu) &&
            DSL_Builder_Attach_Metadata
                (record->result_st, metadata, metadata_count);
 }
@@ -2221,7 +2418,8 @@ DSL_Builder_Attach_Value_Lineage
 {
     DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
 
-    if (record == NULL || lineage == NULL || lineage[0] == '\0')
+    if (record == NULL || !DSL_Builder_Select_PU(record->pu) ||
+        lineage == NULL || lineage[0] == '\0')
         return FALSE;
     ST_tensor_bind_attribute
         (record->result_st,
@@ -2247,6 +2445,8 @@ BOOL
 DSL_Builder_Begin_Program (void)
 {
     DSL_Builder_Reset_Program();
+    Current_DST = New_DST();
+    DST_Init(NULL, 0);
     return TRUE;
 }
 
@@ -2272,15 +2472,16 @@ DSL_Builder_Create_Minimal_PU (const char *name)
 
     if (name == NULL || name[0] == '\0')
         return NULL;
-    /*
-     * Keep the first PU bridge to one entry function.  Multiple top-level PUs
-     * need explicit local-scope ownership before Python should expose them.
-     */
     if (DSL_Builder_PU_Root != NULL) {
-        ST_IDX current_st = PU_Info_proc_sym(DSL_Builder_PU_Root);
-        if (strcmp(ST_name(St_Table[current_st]), name) == 0)
-            return DSL_Builder_PU_Root;
-        DSL_Builder_Reset_Program();
+        for (PU_Info *current = DSL_Builder_PU_Root; current != NULL;
+             current = PU_Info_next(current)) {
+            ST_IDX current_st = PU_Info_proc_sym(current);
+            if (strcmp(ST_name(St_Table[current_st]), name) == 0) {
+                if (!DSL_Builder_Select_PU(current))
+                    return NULL;
+                return current;
+            }
+        }
     } else if (!DSL_builder_value_registry.empty() ||
                DSL_IR_Image_Has_Records()) {
         DSL_Builder_Reset_Program();
@@ -2322,9 +2523,9 @@ DSL_Builder_Create_Minimal_PU (const char *name)
     pu_info = TYPE_MEM_POOL_ALLOC(PU_Info, Malloc_Mem_Pool);
     PU_Info_init(pu_info);
 
+    Set_PU_Info_symtab_ptr(pu_info, NULL);
     Set_PU_Info_tree_ptr(pu_info, entry_wn);
-    if (Current_Map_Tab == NULL)
-        Current_Map_Tab = WN_MAP_TAB_Create(Malloc_Mem_Pool);
+    Current_Map_Tab = WN_MAP_TAB_Create(Malloc_Mem_Pool);
     PU_Info_maptab(pu_info) = Current_Map_Tab;
     PU_Info_proc_sym(pu_info) = ST_st_idx(func_st);
     Set_PU_Info_pu_dst(pu_info, func_dst);
@@ -2348,7 +2549,314 @@ DSL_Builder_Create_Minimal_PU (const char *name)
         DSL_Builder_PU_Root = pu_info;
     DSL_Builder_PU_Last = pu_info;
 
+    Save_Local_Symtab(Current_scope, pu_info);
+    DSL_Builder_Active_PU = pu_info;
+
+    dsl_builder_pu_interface *interface_record =
+        new dsl_builder_pu_interface;
+    interface_record->pu = pu_info;
+    interface_record->has_return = FALSE;
+    DSL_builder_pu_interfaces.push_back(interface_record);
+
     return pu_info;
+}
+
+DSL_BUILDER_VALUE
+DSL_Builder_Declare_PU_Formal
+        (DSL_BUILDER_PROGRAM_UNIT pu,
+         const char *name,
+         UINT32 ordinal,
+         TY_IDX ty,
+         const DSL_BUILDER_SOURCE_POSITION *source_position)
+{
+    dsl_builder_pu_interface *interface_record =
+        DSL_Builder_Find_PU_Interface(pu);
+    if (interface_record == NULL || !DSL_Builder_Select_PU(pu) ||
+        name == NULL || name[0] == '\0' ||
+        ordinal != interface_record->formals.size() ||
+        !interface_record->results.empty() || !TY_is_tensor_extension(ty) ||
+        !DSL_Builder_Source_Position_Valid(source_position))
+        return NULL;
+
+    ST *st = New_ST();
+    ST_Init(st, Save_Str(name), CLASS_VAR, SCLASS_FORMAL, EXPORT_LOCAL, ty);
+    Set_ST_is_value_parm(st);
+    Set_ST_Srcpos(*st, DSL_Builder_Source_Position(source_position));
+    WN *value = WN_CreateLdid(OPR_LDID, MTYPE_M, MTYPE_M, 0,
+                              ST_st_idx(*st), ty);
+
+    DSL_IR_VALUE_ID image_value_id = DSL_Builder_Add_Image_Symbol_Value
+                                         (ST_st_idx(*st), ty,
+                                          DSL_IR_VALUE_SYMBOL);
+    if (image_value_id == DSL_IR_VALUE_INVALID_ID)
+        return NULL;
+
+    DSL_BUILDER_VALUE_RECORD value_record;
+    value_record.pu = pu;
+    value_record.assignment = value;
+    value_record.expression = value;
+    value_record.result_st = ST_st_idx(*st);
+    value_record.result_ty = ty;
+    value_record.image_value_id = image_value_id;
+    DSL_builder_value_registry.push_back(value_record);
+
+    dsl_builder_pu_interface_value formal;
+    formal.value = value;
+    formal.st = ST_st_idx(*st);
+    formal.ty = ty;
+    formal.ordinal = ordinal;
+    formal.role = DSL_PU_RESULT_INVALID;
+    interface_record->formals.push_back(formal);
+    if (!DSL_Builder_Rebuild_PU_Entry(interface_record))
+        return NULL;
+    return value;
+}
+
+DSL_BUILDER_VALUE
+DSL_Builder_Declare_PU_Result
+        (DSL_BUILDER_PROGRAM_UNIT pu,
+         const char *name,
+         UINT32 ordinal,
+         TY_IDX ty,
+         DSL_BUILDER_PU_RESULT_ROLE role,
+         const DSL_BUILDER_SOURCE_POSITION *source_position)
+{
+    dsl_builder_pu_interface *interface_record =
+        DSL_Builder_Find_PU_Interface(pu);
+    if (interface_record == NULL || !DSL_Builder_Select_PU(pu) ||
+        name == NULL || name[0] == '\0' ||
+        ordinal != interface_record->results.size() ||
+        !TY_is_tensor_extension(ty) ||
+        (role != DSL_PU_RESULT_TENSOR && role != DSL_PU_RESULT_STATE) ||
+        !DSL_Builder_Source_Position_Valid(source_position))
+        return NULL;
+
+    ST *st = New_ST();
+    ST_Init(st, Save_Str(name), CLASS_VAR, SCLASS_FORMAL_REF,
+            EXPORT_LOCAL, ty);
+    Set_ST_Srcpos(*st, DSL_Builder_Source_Position(source_position));
+    ST_tensor_bind_metadata(ST_st_idx(*st), "dsl.pu.result_role",
+                            role == DSL_PU_RESULT_STATE ? "state" : "tensor");
+    char ordinal_text[32];
+    snprintf(ordinal_text, sizeof(ordinal_text), "%u", ordinal);
+    ST_tensor_bind_metadata(ST_st_idx(*st), "dsl.pu.result_ordinal",
+                            ordinal_text);
+    WN *value = WN_CreateLdid(OPR_LDID, MTYPE_M, MTYPE_M, 0,
+                              ST_st_idx(*st), ty);
+
+    DSL_IR_VALUE_ID image_value_id = DSL_Builder_Add_Image_Symbol_Value
+                                         (ST_st_idx(*st), ty,
+                                          DSL_IR_VALUE_SYMBOL);
+    if (image_value_id == DSL_IR_VALUE_INVALID_ID)
+        return NULL;
+
+    DSL_BUILDER_VALUE_RECORD value_record;
+    value_record.pu = pu;
+    value_record.assignment = value;
+    value_record.expression = value;
+    value_record.result_st = ST_st_idx(*st);
+    value_record.result_ty = ty;
+    value_record.image_value_id = image_value_id;
+    DSL_builder_value_registry.push_back(value_record);
+
+    dsl_builder_pu_interface_value result;
+    result.value = value;
+    result.st = ST_st_idx(*st);
+    result.ty = ty;
+    result.ordinal = ordinal;
+    result.role = role;
+    interface_record->results.push_back(result);
+    if (!DSL_Builder_Rebuild_PU_Entry(interface_record))
+        return NULL;
+    return value;
+}
+
+BOOL
+DSL_Builder_Return_PU_Values
+        (DSL_BUILDER_PROGRAM_UNIT pu,
+         DSL_BUILDER_VALUE *values,
+         UINT32 value_count)
+{
+    dsl_builder_pu_interface *interface_record =
+        DSL_Builder_Find_PU_Interface(pu);
+    WN *body = DSL_Builder_PU_Body(pu);
+    if (interface_record == NULL || !DSL_Builder_Select_PU(pu) ||
+        body == NULL || interface_record->has_return ||
+        value_count != interface_record->results.size() ||
+        (value_count != 0 && values == NULL))
+        return FALSE;
+
+    for (UINT32 i = 0; i < value_count; ++i) {
+        DSL_BUILDER_VALUE_RECORD *value_record =
+            DSL_Builder_Find_Value_Record(values[i]);
+        if (value_record == NULL || value_record->pu != pu ||
+            value_record->result_ty != interface_record->results[i].ty)
+            return FALSE;
+    }
+    for (UINT32 i = 0; i < value_count; ++i) {
+        DSL_BUILDER_VALUE_RECORD *value_record =
+            DSL_Builder_Find_Value_Record(values[i]);
+        WN *load = WN_CreateLdid(OPR_LDID, MTYPE_M, MTYPE_M, 0,
+                                 value_record->result_st,
+                                 value_record->result_ty);
+        WN *store = WN_CreateStid
+                        (OPR_STID, MTYPE_V, MTYPE_M, 0,
+                         interface_record->results[i].st,
+                         interface_record->results[i].ty, load);
+        WN_INSERT_BlockLast(body, store);
+    }
+    WN_INSERT_BlockLast(body, WN_CreateReturn());
+    interface_record->has_return = TRUE;
+    return TRUE;
+}
+
+DSL_BUILDER_CALL
+DSL_Builder_Create_PU_Call
+        (DSL_BUILDER_PROGRAM_UNIT caller,
+         DSL_BUILDER_PROGRAM_UNIT callee,
+         DSL_BUILDER_VALUE *arguments,
+         UINT32 argument_count,
+         const char *const *result_names,
+         UINT32 result_count,
+         const DSL_BUILDER_CALLSITE_INFO *callsite)
+{
+    dsl_builder_pu_interface *callee_interface =
+        DSL_Builder_Find_PU_Interface(callee);
+    WN *body = DSL_Builder_PU_Body(caller);
+    if (caller == callee || callee_interface == NULL ||
+        !callee_interface->has_return || !DSL_Builder_Select_PU(caller) ||
+        body == NULL || argument_count != callee_interface->formals.size() ||
+        result_count != callee_interface->results.size() ||
+        (argument_count != 0 && arguments == NULL) ||
+        (result_count != 0 && result_names == NULL) || callsite == NULL ||
+        !DSL_Builder_Source_Position_Valid(&callsite->source_position))
+        return NULL;
+
+    std::vector<DSL_BUILDER_VALUE_RECORD *> argument_records;
+    for (UINT32 i = 0; i < argument_count; ++i) {
+        DSL_BUILDER_VALUE_RECORD *record =
+            DSL_Builder_Find_Value_Record(arguments[i]);
+        if (record == NULL || record->pu != caller ||
+            record->result_ty != callee_interface->formals[i].ty)
+            return NULL;
+        argument_records.push_back(record);
+    }
+    for (UINT32 i = 0; i < result_count; ++i) {
+        if (result_names[i] == NULL || result_names[i][0] == '\0')
+            return NULL;
+    }
+
+    WN *call = WN_Create(OPR_CALL, MTYPE_V, MTYPE_V,
+                         argument_count + result_count);
+    WN_st_idx(call) = PU_Info_proc_sym(callee);
+    WN_Set_Call_Default_Flags(call);
+    WN_Set_Linenum(call,
+                   DSL_Builder_Source_Position(&callsite->source_position));
+
+    for (UINT32 i = 0; i < argument_count; ++i) {
+        TY_IDX pointer_ty = Make_Pointer_Type(argument_records[i]->result_ty);
+        WN *address = WN_CreateLda
+                          (OPR_LDA, Pointer_Mtype, MTYPE_V, 0, pointer_ty,
+                           argument_records[i]->result_st);
+        WN_kid(call, i) = WN_CreateParm
+                              (Pointer_Mtype, address, pointer_ty,
+                               WN_PARM_BY_REFERENCE | WN_PARM_READ_ONLY |
+                               WN_PARM_PASSED_NOT_SAVED);
+    }
+
+    dsl_builder_call_record *call_record = new dsl_builder_call_record;
+    call_record->call = call;
+    call_record->caller = caller;
+    call_record->callee = callee;
+    for (UINT32 i = 0; i < result_count; ++i) {
+        TY_IDX result_ty = callee_interface->results[i].ty;
+        ST_IDX result_st = DSL_Builder_Create_Tensor_Result_Symbol
+                               (result_names[i], result_ty, SCLASS_AUTO,
+                                EXPORT_LOCAL);
+        if (ST_IDX_index(result_st) == 0) {
+            delete call_record;
+            return NULL;
+        }
+        Set_ST_Srcpos(St_Table[result_st],
+                      DSL_Builder_Source_Position
+                          (&callsite->source_position));
+        ST_tensor_bind_metadata(result_st, "dsl.call.canonical_class",
+                                DSL_Builder_Safe_String
+                                    (callsite->canonical_class_name));
+        ST_tensor_bind_metadata(result_st, "dsl.call.instance_path",
+                                DSL_Builder_Safe_String
+                                    (callsite->instance_path));
+        ST_tensor_bind_metadata(result_st, "dsl.call.context_identity",
+                                DSL_Builder_Safe_String
+                                    (callsite->context_identity));
+        char ordinal_text[32];
+        snprintf(ordinal_text, sizeof(ordinal_text), "%u",
+                 callsite->call_ordinal);
+        ST_tensor_bind_metadata(result_st, "dsl.call.ordinal", ordinal_text);
+
+        TY_IDX pointer_ty = Make_Pointer_Type(result_ty);
+        WN *address = WN_CreateLda(OPR_LDA, Pointer_Mtype, MTYPE_V, 0,
+                                   pointer_ty, result_st);
+        WN_kid(call, argument_count + i) = WN_CreateParm
+                                               (Pointer_Mtype, address,
+                                                pointer_ty,
+                                                WN_PARM_BY_REFERENCE |
+                                                WN_PARM_OUT |
+                                                WN_PARM_PASSED_NOT_SAVED);
+
+        WN *value = WN_CreateLdid(OPR_LDID, MTYPE_M, MTYPE_M, 0,
+                                  result_st, result_ty);
+        DSL_IR_VALUE_ID image_value_id =
+            DSL_Builder_Add_Image_Symbol_Value
+                (result_st, result_ty, DSL_IR_VALUE_SYMBOL);
+        if (image_value_id == DSL_IR_VALUE_INVALID_ID) {
+            delete call_record;
+            return NULL;
+        }
+        DSL_BUILDER_VALUE_RECORD value_record;
+        value_record.pu = caller;
+        value_record.assignment = value;
+        value_record.expression = value;
+        value_record.result_st = result_st;
+        value_record.result_ty = result_ty;
+        value_record.image_value_id = image_value_id;
+        DSL_builder_value_registry.push_back(value_record);
+        call_record->results.push_back(value);
+    }
+
+    std::string comment_text = "__WHIRL_DSL_CALL__:callee=";
+    comment_text += ST_name(St_Table[PU_Info_proc_sym(callee)]);
+    comment_text += ";class=";
+    comment_text += DSL_Builder_Safe_String(callsite->canonical_class_name);
+    comment_text += ";instance=";
+    comment_text += DSL_Builder_Safe_String(callsite->instance_path);
+    comment_text += ";context=";
+    comment_text += DSL_Builder_Safe_String(callsite->context_identity);
+    char ordinal_text[32];
+    snprintf(ordinal_text, sizeof(ordinal_text), "%u",
+             callsite->call_ordinal);
+    comment_text += ";ordinal=";
+    comment_text += ordinal_text;
+    WN *comment = WN_CreateComment(comment_text.c_str());
+    WN_Set_Linenum(comment,
+                   DSL_Builder_Source_Position(&callsite->source_position));
+    WN_INSERT_BlockLast(body, comment);
+    WN_INSERT_BlockLast(body, call);
+    DSL_builder_call_registry.push_back(call_record);
+    return call;
+}
+
+BOOL
+DSL_Builder_Get_PU_Call_Result
+        (DSL_BUILDER_CALL call,
+         UINT32 ordinal,
+         DSL_BUILDER_VALUE *value)
+{
+    dsl_builder_call_record *record = DSL_Builder_Find_Call_Record(call);
+    if (record == NULL || value == NULL || ordinal >= record->results.size())
+        return FALSE;
+    *value = record->results[ordinal];
+    return TRUE;
 }
 
 UINT32
@@ -2411,7 +2919,8 @@ DSL_Builder_Set_Value_Source_Position
     DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
     USRCPOS position;
 
-    if (record == NULL || source_position == NULL ||
+    if (record == NULL || !DSL_Builder_Select_PU(record->pu) ||
+        source_position == NULL ||
         source_position->file_id == 0 ||
         source_position->file_id > DSL_builder_source_files.size() ||
         source_position->line < 0 || source_position->column > 4095)
@@ -2427,6 +2936,83 @@ DSL_Builder_Set_Value_Source_Position
     if (ST_IDX_index(record->result_st) != 0)
         Set_ST_Srcpos(St_Table[record->result_st],
                       USRCPOS_srcpos(position));
+    return TRUE;
+}
+
+static BOOL
+DSL_Builder_Verify_PU_Interfaces (FILE *diagnostic, UINT32 *error_count)
+{
+    BOOL valid = TRUE;
+    for (UINT32 i = 0; i < DSL_builder_pu_interfaces.size(); ++i) {
+        dsl_builder_pu_interface *interface_record =
+            DSL_builder_pu_interfaces[i];
+        if (!DSL_Builder_Select_PU(interface_record->pu)) {
+            valid = FALSE;
+        } else {
+            WN *entry = PU_Info_tree_ptr(interface_record->pu);
+            UINT32 expected = interface_record->formals.size() +
+                              interface_record->results.size();
+            if (entry == NULL || WN_operator(entry) != OPR_FUNC_ENTRY ||
+                (UINT32)WN_num_formals(entry) != expected ||
+                (!interface_record->results.empty() &&
+                 !interface_record->has_return))
+                valid = FALSE;
+            for (UINT32 j = 0; valid && j < expected; ++j) {
+                dsl_builder_pu_interface_value &formal =
+                    j < interface_record->formals.size() ?
+                    interface_record->formals[j] :
+                    interface_record->results
+                        [j - interface_record->formals.size()];
+                WN *idname = WN_formal(entry, j);
+                if (idname == NULL || WN_operator(idname) != OPR_IDNAME ||
+                    WN_st_idx(idname) != formal.st)
+                    valid = FALSE;
+            }
+        }
+        if (!valid) {
+            if (diagnostic != NULL)
+                fprintf(diagnostic,
+                        "DSL builder verification error: invalid PU interface\n");
+            if (error_count != NULL)
+                ++*error_count;
+            return FALSE;
+        }
+    }
+
+    for (UINT32 i = 0; i < DSL_builder_call_registry.size(); ++i) {
+        dsl_builder_call_record *record = DSL_builder_call_registry[i];
+        dsl_builder_pu_interface *callee =
+            DSL_Builder_Find_PU_Interface(record->callee);
+        WN *call = record->call;
+        if (callee == NULL || call == NULL || WN_operator(call) != OPR_CALL ||
+            WN_st_idx(call) != PU_Info_proc_sym(record->callee) ||
+            (UINT32)WN_kid_count(call) != callee->formals.size() +
+                                          callee->results.size() ||
+            record->results.size() != callee->results.size())
+            valid = FALSE;
+        for (UINT32 j = 0; valid && j < callee->formals.size(); ++j) {
+            WN *parm = WN_kid(call, j);
+            if (parm == NULL || WN_operator(parm) != OPR_PARM ||
+                !WN_Parm_By_Reference(parm) ||
+                !WN_Parm_Read_Only(parm) || !WN_Parm_Passed_Not_Saved(parm))
+                valid = FALSE;
+        }
+        for (UINT32 j = 0; valid && j < callee->results.size(); ++j) {
+            WN *parm = WN_kid(call, callee->formals.size() + j);
+            if (parm == NULL || WN_operator(parm) != OPR_PARM ||
+                !WN_Parm_By_Reference(parm) || !WN_Parm_Out(parm) ||
+                !WN_Parm_Passed_Not_Saved(parm))
+                valid = FALSE;
+        }
+        if (!valid) {
+            if (diagnostic != NULL)
+                fprintf(diagnostic,
+                        "DSL builder verification error: invalid PU call\n");
+            if (error_count != NULL)
+                ++*error_count;
+            return FALSE;
+        }
+    }
     return TRUE;
 }
 
@@ -2457,14 +3043,42 @@ DSL_Builder_Verify_Program (DSL_BUILDER_VERIFY_RESULT *result)
         return FALSE;
     }
 
-    BOOL valid = DSL_Gatekeeper_Verify_Program
-                     (DSL_Builder_PU_Root, diagnostic, &gatekeeper_result);
+    memset(&gatekeeper_result, 0, sizeof(gatekeeper_result));
+    BOOL valid = TRUE;
+    if (!DSL_Builder_Verify_PU_Interfaces
+             (diagnostic, &gatekeeper_result.error_count))
+        valid = FALSE;
     for (PU_Info *pu = DSL_Builder_PU_Root; pu != NULL;
          pu = PU_Info_next(pu)) {
+        DSL_GATEKEEPER_RESULT pu_result;
+        memset(&pu_result, 0, sizeof(pu_result));
+        if (!DSL_Builder_Select_PU(pu)) {
+            if (diagnostic != NULL)
+                fprintf(diagnostic,
+                        "DSL builder verification error: cannot select PU\n");
+            valid = FALSE;
+            ++gatekeeper_result.error_count;
+            continue;
+        }
+        if (!DSL_Gatekeeper_Verify_PU(pu, diagnostic, &pu_result))
+            valid = FALSE;
+        gatekeeper_result.native_node_count += pu_result.native_node_count;
+        gatekeeper_result.result_symbol_count += pu_result.result_symbol_count;
+        gatekeeper_result.error_count += pu_result.error_count;
         if (!DSL_Region_Verify_PU(pu, diagnostic)) {
             valid = FALSE;
             ++gatekeeper_result.error_count;
         }
+    }
+    if (gatekeeper_result.native_node_count != DSL_IR_Image_Node_Count()) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "native tree node count %u does not match "
+                    "DSL image node count %u\n",
+                    gatekeeper_result.native_node_count,
+                    DSL_IR_Image_Node_Count());
+        valid = FALSE;
+        ++gatekeeper_result.error_count;
     }
     if (diagnostic != NULL) {
         rewind(diagnostic);
@@ -2560,7 +3174,8 @@ DSL_Builder_Declare_State_Object_With_Flags
          DSL_STATE_KIND kind,
          UINT32 flags)
 {
-    if (DSL_Builder_PU_Body(pu) == NULL || name == NULL || name[0] == '\0' ||
+    if (DSL_Builder_PU_Body(pu) == NULL || !DSL_Builder_Select_PU(pu) ||
+        name == NULL || name[0] == '\0' ||
         kind < DSL_STATE_KIND_RUNTIME_STATUS ||
         kind > DSL_STATE_KIND_OPAQUE ||
         (flags & ~DSL_STATE_OBJECT_UNIQUE_OWNERSHIP) != 0)
@@ -2699,7 +3314,10 @@ DSL_Builder_Append_PU_Value
     WN *body;
 
     body = DSL_Builder_PU_Body(pu);
-    if (body == NULL || value == NULL)
+    DSL_BUILDER_VALUE_RECORD *record = DSL_Builder_Find_Value_Record(value);
+    if (body == NULL || value == NULL ||
+        (record != NULL && record->pu != pu) ||
+        !DSL_Builder_Select_PU(pu))
         return FALSE;
     if (!DSL_Builder_Get_Value_Annotation(value, NULL))
         return FALSE;
@@ -2864,8 +3482,9 @@ DSL_Builder_Finalize_Mapped_Image
         request->flags != 0)
         return FALSE;
 
-    if (!DSL_Gatekeeper_Verify_Program
-             (DSL_Builder_PU_Root, stderr, NULL))
+    if (DSL_Builder_PU_Root == NULL ?
+        !DSL_Gatekeeper_Verify_Program(NULL, stderr, NULL) :
+        !DSL_Builder_Verify_Program(NULL))
         return FALSE;
 
     Irb_File_Name = (char *)request->path;
@@ -2877,6 +3496,10 @@ DSL_Builder_Finalize_Mapped_Image
 
     for (PU_Info *pu = DSL_Builder_PU_Root; pu != NULL;
          pu = PU_Info_next(pu)) {
+        if (!DSL_Builder_Select_PU(pu)) {
+            Close_Output_Info();
+            return FALSE;
+        }
         if (PU_Info_state(pu, WT_SYMTAB) == Subsect_InMem ||
             PU_Info_state(pu, WT_TREE) == Subsect_InMem) {
             Write_PU_Info(pu);

--- a/osprey/common/com/dsl_builder.h
+++ b/osprey/common/com/dsl_builder.h
@@ -34,6 +34,7 @@
 
 typedef WN *DSL_BUILDER_VALUE;
 typedef WN *DSL_BUILDER_OPERATOR;
+typedef WN *DSL_BUILDER_CALL;
 typedef PU_Info *DSL_BUILDER_PROGRAM_UNIT;
 typedef DSL_REGION DSL_BUILDER_REGION;
 typedef struct dsl_builder_state *DSL_BUILDER_STATE;
@@ -91,6 +92,20 @@ typedef struct {
     UINT8 statement_begin;
     UINT8 basic_block_begin;
 } DSL_BUILDER_SOURCE_POSITION;
+
+typedef enum {
+    DSL_PU_RESULT_INVALID = 0,
+    DSL_PU_RESULT_TENSOR = 1,
+    DSL_PU_RESULT_STATE = 2
+} DSL_BUILDER_PU_RESULT_ROLE;
+
+typedef struct {
+    const char *canonical_class_name;
+    const char *instance_path;
+    const char *context_identity;
+    UINT32 call_ordinal;
+    DSL_BUILDER_SOURCE_POSITION source_position;
+} DSL_BUILDER_CALLSITE_INFO;
 
 typedef struct {
     UINT32 native_node_count;
@@ -199,6 +214,38 @@ extern BOOL DSL_Builder_Begin_Program (void);
 extern void DSL_Builder_Abort_Program (void);
 extern DSL_BUILDER_PROGRAM_UNIT DSL_Builder_Create_Minimal_PU
                                 (const char *name);
+extern BOOL DSL_Builder_Select_PU (DSL_BUILDER_PROGRAM_UNIT pu);
+extern DSL_BUILDER_VALUE DSL_Builder_Declare_PU_Formal
+                                (DSL_BUILDER_PROGRAM_UNIT pu,
+                                 const char *name,
+                                 UINT32 ordinal,
+                                 TY_IDX ty,
+                                 const DSL_BUILDER_SOURCE_POSITION
+                                     *source_position);
+extern DSL_BUILDER_VALUE DSL_Builder_Declare_PU_Result
+                                (DSL_BUILDER_PROGRAM_UNIT pu,
+                                 const char *name,
+                                 UINT32 ordinal,
+                                 TY_IDX ty,
+                                 DSL_BUILDER_PU_RESULT_ROLE role,
+                                 const DSL_BUILDER_SOURCE_POSITION
+                                     *source_position);
+extern BOOL DSL_Builder_Return_PU_Values
+                                (DSL_BUILDER_PROGRAM_UNIT pu,
+                                 DSL_BUILDER_VALUE *values,
+                                 UINT32 value_count);
+extern DSL_BUILDER_CALL DSL_Builder_Create_PU_Call
+                                (DSL_BUILDER_PROGRAM_UNIT caller,
+                                 DSL_BUILDER_PROGRAM_UNIT callee,
+                                 DSL_BUILDER_VALUE *arguments,
+                                 UINT32 argument_count,
+                                 const char *const *result_names,
+                                 UINT32 result_count,
+                                 const DSL_BUILDER_CALLSITE_INFO *callsite);
+extern BOOL DSL_Builder_Get_PU_Call_Result
+                                (DSL_BUILDER_CALL call,
+                                 UINT32 ordinal,
+                                 DSL_BUILDER_VALUE *value);
 extern UINT32 DSL_Builder_Register_Source_File
                                 (DSL_BUILDER_PROGRAM_UNIT pu,
                                  const char *path);

--- a/osprey/common/com/dsl_gatekeeper.cxx
+++ b/osprey/common/com/dsl_gatekeeper.cxx
@@ -63,6 +63,27 @@ DSL_Gatekeeper_Collect_Results
         return TRUE;
 
     BOOL valid = TRUE;
+    if (WN_operator(wn) == OPR_FUNC_ENTRY) {
+        for (INT i = 0; i < WN_num_formals(wn); ++i) {
+            WN *formal = WN_formal(wn, i);
+            if (formal != NULL && WN_operator(formal) == OPR_IDNAME &&
+                !DSL_Gatekeeper_Is_Result_Symbol
+                     (context, WN_st_idx(formal)))
+                context->result_symbols.push_back(WN_st_idx(formal));
+        }
+    }
+    if (WN_operator(wn) == OPR_CALL) {
+        for (INT i = 0; i < WN_kid_count(wn); ++i) {
+            WN *parm = WN_kid(wn, i);
+            WN *address = parm == NULL || WN_operator(parm) != OPR_PARM ?
+                          NULL : WN_kid0(parm);
+            if (address != NULL && WN_Parm_Out(parm) &&
+                WN_operator(address) == OPR_LDA &&
+                !DSL_Gatekeeper_Is_Result_Symbol
+                     (context, WN_st_idx(address)))
+                context->result_symbols.push_back(WN_st_idx(address));
+        }
+    }
     if (WN_operator(wn) == OPR_STID && WN_kid0(wn) != NULL &&
         DSL_WN_Is_Native(WN_kid0(wn))) {
         ST_IDX st = WN_st_idx(wn);
@@ -273,18 +294,32 @@ DSL_Gatekeeper_Matmul_Shapes_Compatible
 static BOOL
 DSL_Gatekeeper_Find_Image_Node
         (ST_IDX result_st,
+         const char *result_name,
+         DSL_OPERATOR dsl_operator,
+         UINT16 version,
+         const char *payload,
          DSL_IR_NODE_RECORD *node,
          DSL_IR_OPCODE_DESCRIPTOR_RECORD *descriptor)
 {
     for (UINT32 i = 1; i <= DSL_IR_Image_Value_Count(); ++i) {
         DSL_IR_VALUE_RECORD value;
         if (!DSL_IR_Image_Get_Value(i, &value) || value.st != result_st ||
-            value.producer_node_id == DSL_IR_NODE_INVALID_ID)
+            value.producer_node_id == DSL_IR_NODE_INVALID_ID ||
+            result_name == NULL ||
+            value.name == STR_IDX_ZERO ||
+            strcmp(Index_To_Str(value.name), result_name) != 0)
             continue;
         if (!DSL_IR_Image_Get_Node(value.producer_node_id, node))
             return FALSE;
-        return DSL_IR_Image_Get_Opcode_Descriptor
-                   (node->opcode_descriptor_id, descriptor);
+        if (!DSL_IR_Image_Get_Opcode_Descriptor
+                 (node->opcode_descriptor_id, descriptor))
+            return FALSE;
+        if (descriptor->logical_operator != (UINT32)dsl_operator ||
+            descriptor->version != version ||
+            node->payload == STR_IDX_ZERO || payload == NULL ||
+            strcmp(Index_To_Str(node->payload), payload) != 0)
+            continue;
+        return TRUE;
     }
     return FALSE;
 }
@@ -1443,6 +1478,8 @@ DSL_Gatekeeper_Verify_Native_Node
     TY_IDX result_ty = WN_ty(assignment);
     BOOL valid = TRUE;
     BOOL image_valid;
+    const char *result_name = DSL_Gatekeeper_ST_Valid(result_st) ?
+                              ST_name(St_Table[result_st]) : NULL;
 
     ++context->result.native_node_count;
     if (!DSL_WN_Get_Logical_Opcode(expression, &logical_opcode,
@@ -1466,17 +1503,12 @@ DSL_Gatekeeper_Verify_Native_Node
                     (context, "%s result is not a complete no-alias tensor "
                      "temporary", DSL_OPERATOR_name(dsl_operator));
 
-    image_valid = DSL_Gatekeeper_Find_Image_Node
-                      (result_st, &image_node, &image_descriptor) &&
-                  image_descriptor.logical_operator == (UINT32)dsl_operator &&
-                  image_descriptor.version ==
-                      logical_opcode.effective_version;
-    if (image_valid &&
-        (!DSL_WN_Get_Opcode_Annotation(expression, &annotation) ||
-         annotation.payload == NULL ||
-         image_node.payload == STR_IDX_ZERO ||
-         strcmp(annotation.payload, Index_To_Str(image_node.payload)) != 0))
-        image_valid = FALSE;
+    image_valid = DSL_WN_Get_Opcode_Annotation(expression, &annotation) &&
+                  annotation.payload != NULL &&
+                  DSL_Gatekeeper_Find_Image_Node
+                      (result_st, result_name, dsl_operator,
+                       logical_opcode.effective_version, annotation.payload,
+                       &image_node, &image_descriptor);
     if (!image_valid)
         valid = DSL_Gatekeeper_Report
                     (context, "%s result has no matching DSL image node",
@@ -1684,7 +1716,17 @@ DSL_Gatekeeper_Verify_Tree
         DSL_Gatekeeper_Is_Result_Symbol(context, WN_st_idx(wn))) {
         BOOL direct_operand = WN_operator(wn) == OPR_LDID && parent != NULL &&
                               DSL_WN_Is_Native(parent);
-        if (!direct_operand)
+        BOOL result_copy = WN_operator(wn) == OPR_LDID && parent != NULL &&
+                           WN_operator(parent) == OPR_STID &&
+                           ST_sclass(St_Table[WN_st_idx(parent)]) ==
+                               SCLASS_FORMAL_REF;
+        BOOL call_interface = WN_operator(wn) == OPR_LDA && parent != NULL &&
+                              WN_operator(parent) == OPR_PARM &&
+                              WN_Parm_By_Reference(parent) &&
+                              WN_Parm_Passed_Not_Saved(parent) &&
+                              (WN_Parm_Read_Only(parent) ||
+                               WN_Parm_Out(parent));
+        if (!direct_operand && !result_copy && !call_interface)
             valid = DSL_Gatekeeper_Report
                         (context, "result symbol <%u,%u> escapes through %s",
                          ST_IDX_level(WN_st_idx(wn)),

--- a/osprey/common/com/dsl_ir_print.cxx
+++ b/osprey/common/com/dsl_ir_print.cxx
@@ -62,17 +62,22 @@ DSL_IR_Print_Tensor_Descriptor (FILE *file, TY_IDX ty)
 }
 
 static void
-DSL_IR_Print_Result_Symbol (FILE *file, ST_IDX st)
+DSL_IR_Print_Result_Symbol (FILE *file, ST_IDX st, STR_IDX name)
 {
     if (ST_IDX_index(st) == 0)
         return;
     fprintf (file, " st=<%u,%u,%s>", ST_IDX_level(st), ST_IDX_index(st),
-             ST_name(St_Table[st]));
-    const char *no_alias = ST_tensor_attribute
-                               (st, TY_tensor_schema_key_name
-                                        (TY_TENSOR_SCHEMA_NO_ALIAS));
-    if (no_alias != NULL)
-        fprintf (file, " no_alias=%s", no_alias);
+             DSL_IR_String(name));
+    if (ST_IDX_level(st) <= CURRENT_SYMTAB &&
+        Scope_tab[ST_IDX_level(st)].st_tab != NULL &&
+        ST_IDX_index(st) < ST_Table_Size(ST_IDX_level(st)) &&
+        strcmp(ST_name(St_Table[st]), DSL_IR_String(name)) == 0) {
+        const char *no_alias = ST_tensor_attribute
+                                   (st, TY_tensor_schema_key_name
+                                            (TY_TENSOR_SCHEMA_NO_ALIAS));
+        if (no_alias != NULL)
+            fprintf (file, " no_alias=%s", no_alias);
+    }
 }
 
 void
@@ -171,7 +176,7 @@ DSL_IR_Image_Print (FILE *file)
         if (TY_IDX_index(record.ty) != 0)
             fprintf (file, " type_name=%s", TY_name(record.ty));
         DSL_IR_Print_Tensor_Descriptor(file, record.ty);
-        DSL_IR_Print_Result_Symbol(file, record.st);
+        DSL_IR_Print_Result_Symbol(file, record.st, record.name);
         if (record.metadata != STR_IDX_ZERO)
             fprintf (file, " metadata=%s", DSL_IR_String(record.metadata));
         fprintf (file, " flags=0x%x\n", record.flags);

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -818,6 +818,7 @@ Check_Program_Unit_Value_Attach(void)
     DSL_BUILDER_VALUE_INFO operand_info;
     int failed = 0;
 
+    DSL_Builder_Begin_Program();
     DSL_Opcode_Register_Common_Substrate();
     common_id = DSL_Domain_Find("common");
     add_id = DSL_Opcode_Find(common_id, DSL_OPCODE_COMMON_ADD, 1);
@@ -984,6 +985,11 @@ Check_Production_Native_Builder(void)
     DSL_GATEKEEPER_RESULT gatekeeper_result;
     int failed = 0;
 
+    DSL_Builder_Begin_Program();
+    pu = DSL_Builder_Create_Minimal_PU("builder_value_contract");
+    if (pu == NULL)
+        return 1;
+
     memset(&type_core, 0, sizeof(type_core));
     type_core.kind = "tensor";
     type_core.dtype = "int32";
@@ -1060,15 +1066,14 @@ Check_Production_Native_Builder(void)
         failed = 1;
     }
 
-    pu = DSL_Builder_Create_Minimal_PU("builder_value_contract");
     BOOL append_kid0 = DSL_Builder_Append_PU_Value(pu, kids[0]);
     BOOL append_kid1 = DSL_Builder_Append_PU_Value(pu, kids[1]);
     BOOL append_add = DSL_Builder_Append_PU_Value(pu, add);
     BOOL append_matmul = DSL_Builder_Append_PU_Value(pu, matmul);
     UINT32 pu_value_count = DSL_Builder_Count_PU_Values(pu);
-    BOOL got_add = DSL_Builder_Get_PU_Value(pu, 4, &info);
+    BOOL got_add = DSL_Builder_Get_PU_Value(pu, 2, &info);
     if (!append_kid0 || !append_kid1 || !append_add || !append_matmul ||
-        pu_value_count != 6 || !got_add ||
+        pu_value_count != 4 || !got_add ||
         info.opcode_name_len != strlen(DSL_OPCODE_COMMON_ADD) ||
         strncmp(info.opcode_name, DSL_OPCODE_COMMON_ADD,
                 info.opcode_name_len) != 0) {
@@ -3441,6 +3446,151 @@ Check_Llama2_Decode_State_Region(void)
     return 0;
 }
 
+static int
+Check_Multiple_Program_Units(void)
+{
+    const char *artifact = getenv("OPEN64_DSL_MULTI_PU_ARTIFACT");
+    DSL_BUILDER_TENSOR_TYPE_CORE type_core;
+    DSL_BUILDER_SOURCE_POSITION position;
+    DSL_BUILDER_MAPPED_IMAGE_REQUEST request;
+    DSL_BUILDER_VERIFY_RESULT verify;
+    DSL_BUILDER_PROGRAM_UNIT first_pu;
+    DSL_BUILDER_PROGRAM_UNIT second_pu;
+    DSL_BUILDER_VALUE first_formal;
+    DSL_BUILDER_VALUE first_result;
+    DSL_BUILDER_VALUE normalized;
+    DSL_BUILDER_VALUE second_formal;
+    DSL_BUILDER_VALUE second_result;
+    DSL_BUILDER_VALUE call_result;
+    DSL_BUILDER_CALL call;
+    DSL_BUILDER_CALLSITE_INFO callsite;
+    DSL_BUILDER_OPERATOR_ATTRIBUTE add_attr;
+    DSL_BUILDER_VALUE add_kids[2];
+    const char *call_result_names[1] = { "normalized_hidden" };
+    TY_IDX tensor_ty;
+    ST_IDX first_st;
+    ST_IDX second_st;
+    char diagnostic[1024];
+
+    if (artifact == NULL || artifact[0] == '\0') {
+        fprintf(stderr, "multiple-PU artifact path is required\n");
+        return 1;
+    }
+
+    memset(&type_core, 0, sizeof(type_core));
+    type_core.kind = "tensor";
+    type_core.dtype = "float32";
+    type_core.rank = 2;
+    type_core.logical_shape = "[2,2]";
+
+    DSL_Builder_Begin_Program();
+    DSL_Opcode_Register_Common_Substrate();
+    tensor_ty = DSL_Builder_Create_Tensor_Type_Core
+                    ("multi_pu_tensor", MTYPE_To_TY(MTYPE_F4), &type_core);
+    first_pu = DSL_Builder_Create_Minimal_PU("TinyRMSNorm");
+    UINT32 first_file = DSL_Builder_Register_Source_File
+                            (first_pu, "llama2_model.py");
+    memset(&position, 0, sizeof(position));
+    position.file_id = first_file;
+    position.line = 18;
+    position.statement_begin = 1;
+    first_formal = DSL_Builder_Declare_PU_Formal
+                       (first_pu, "hidden_states", 0, tensor_ty, &position);
+    ++position.line;
+    first_result = DSL_Builder_Declare_PU_Result
+                       (first_pu, "normalized_result", 0, tensor_ty,
+                        DSL_PU_RESULT_TENSOR, &position);
+    add_kids[0] = first_formal;
+    add_kids[1] = first_formal;
+    add_attr.name = "attr.broadcast_rule";
+    add_attr.value = "none";
+    normalized = DSL_Builder_Create_Operator
+                     (DSL_Opcode_Find(DSL_Domain_Find("common"),
+                                      DSL_OPCODE_COMMON_ADD, 1),
+                      1, add_kids, 2, &add_attr, 1);
+    first_st = DSL_Builder_Get_Value_Result_Symbol(first_formal);
+    BOOL first_position = normalized != NULL &&
+        DSL_Builder_Set_Value_Source_Position(normalized, &position);
+    BOOL first_append = normalized != NULL &&
+        DSL_Builder_Append_PU_Value(first_pu, normalized);
+    BOOL first_return = normalized != NULL &&
+        DSL_Builder_Return_PU_Values(first_pu, &normalized, 1);
+    if (first_pu == NULL || first_file == 0 || first_formal == NULL ||
+        first_result == NULL || normalized == NULL || !first_position ||
+        !first_append || !first_return) {
+        fprintf(stderr, "failed to construct first program unit\n");
+        return 1;
+    }
+
+    second_pu = DSL_Builder_Create_Minimal_PU("TinyLlama2ForCausalLM");
+    UINT32 second_file = DSL_Builder_Register_Source_File
+                             (second_pu, "llama2_model.py");
+    position.file_id = second_file;
+    position.line = 72;
+    second_formal = DSL_Builder_Declare_PU_Formal
+                        (second_pu, "model_hidden", 0, tensor_ty, &position);
+    ++position.line;
+    second_result = DSL_Builder_Declare_PU_Result
+                        (second_pu, "model_result", 0, tensor_ty,
+                         DSL_PU_RESULT_TENSOR, &position);
+    memset(&callsite, 0, sizeof(callsite));
+    callsite.canonical_class_name = "TinyRMSNorm";
+    callsite.instance_path = "model.norm";
+    callsite.context_identity = "TinyLlama2ForCausalLM.norm";
+    callsite.call_ordinal = 0;
+    callsite.source_position = position;
+    ++callsite.source_position.line;
+    call = DSL_Builder_Create_PU_Call
+               (second_pu, first_pu, &second_formal, 1,
+                call_result_names, 1, &callsite);
+    second_st = DSL_Builder_Get_Value_Result_Symbol(second_formal);
+    if (second_pu == NULL || second_pu == first_pu || second_file == 0 ||
+        second_formal == NULL || second_result == NULL || call == NULL ||
+        !DSL_Builder_Get_PU_Call_Result(call, 0, &call_result) ||
+        !DSL_Builder_Return_PU_Values(second_pu, &call_result, 1) ||
+        DSL_Builder_Append_PU_Value(second_pu, first_formal) ||
+        PU_Info_next(first_pu) != second_pu ||
+        PU_Info_maptab(first_pu) == PU_Info_maptab(second_pu)) {
+        fprintf(stderr, "failed to construct independent second program unit\n");
+        return 1;
+    }
+
+    BOOL selected_first = DSL_Builder_Select_PU(first_pu);
+    BOOL first_name_valid = selected_first && ST_IDX_index(first_st) != 0 &&
+        strcmp(ST_name(St_Table[first_st]), "hidden_states") == 0;
+    BOOL selected_second = DSL_Builder_Select_PU(second_pu);
+    BOOL second_name_valid = selected_second && ST_IDX_index(second_st) != 0 &&
+        strcmp(ST_name(St_Table[second_st]), "model_hidden") == 0;
+    BOOL found_first =
+        DSL_Builder_Create_Minimal_PU("TinyRMSNorm") == first_pu;
+    if (!selected_first || !first_name_valid || !selected_second ||
+        !second_name_valid || !found_first ||
+        !DSL_Builder_Select_PU(second_pu)) {
+        fprintf(stderr, "program-unit scope selection changed\n");
+        return 1;
+    }
+
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (!DSL_Builder_Verify_Program(&verify) ||
+        verify.native_node_count != 1 ||
+        verify.result_symbol_count != 6 ||
+        verify.error_count != 0 || diagnostic[0] != '\0') {
+        fprintf(stderr, "multiple-PU verification failed: %s\n", diagnostic);
+        return 1;
+    }
+
+    request.path = artifact;
+    request.flags = 0;
+    if (!DSL_Builder_Finalize_Mapped_Image(&request)) {
+        fprintf(stderr, "multiple-PU mapped-image finalization failed\n");
+        return 1;
+    }
+    return 0;
+}
+
 int
 main(void)
 {
@@ -3464,6 +3614,8 @@ main(void)
         return Check_Abstract_State_Effects();
     if (getenv("OPEN64_DSL_DECODE_STATE_ONLY") != NULL)
         return Check_Llama2_Decode_State_Region();
+    if (getenv("OPEN64_DSL_MULTI_PU_ONLY") != NULL)
+        return Check_Multiple_Program_Units();
 
     failed |= Check_Tensor_Type_And_Descriptor();
     failed |= Check_Symbol_Metadata();

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -963,6 +963,33 @@ Check_Mapped_Image_Finalizer(void)
 }
 
 static int
+Check_Pre_PU_Native_Value_Compatibility(void)
+{
+    DSL_BUILDER_TENSOR_TYPE_CORE type_core;
+
+    DSL_Builder_Begin_Program();
+    DSL_Opcode_Register_Common_Substrate();
+    memset(&type_core, 0, sizeof(type_core));
+    type_core.kind = "tensor";
+    type_core.dtype = "float32";
+    type_core.rank = 0;
+    type_core.logical_shape = "[]";
+    TY_IDX tensor_ty = DSL_Builder_Create_Tensor_Type_Core
+                           ("pre_pu_probe_type", MTYPE_To_TY(MTYPE_F4),
+                            &type_core);
+    DSL_BUILDER_VALUE value = DSL_Builder_Create_Tensor_Constant
+                                  ("pre_pu_probe", tensor_ty, "float32", 0,
+                                   "[]", "splat", "1.0");
+    if (value == NULL ||
+        !DSL_Builder_Attach_Value_Lineage(value, "pre_pu_probe")) {
+        fprintf(stderr, "pre-PU native value compatibility changed\n");
+        return 1;
+    }
+    DSL_Builder_Begin_Program();
+    return 0;
+}
+
+static int
 Check_Production_Native_Builder(void)
 {
     DSL_BUILDER_TENSOR_TYPE_CORE type_core;
@@ -3622,6 +3649,7 @@ main(void)
     failed |= Check_Operator_Creation();
     failed |= Check_Mapped_Image_Finalizer();
     failed |= Check_Program_Unit_Value_Attach();
+    failed |= Check_Pre_PU_Native_Value_Compatibility();
     failed |= Check_Production_Native_Builder();
     failed |= Check_Llama2_Common_Substrate();
     failed |= Check_Llama2_Transformer_Expressions();

--- a/osprey/common/com/tests/dsl_multi_pu_artifact_test.sh
+++ b/osprey/common/com/tests/dsl_multi_pu_artifact_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Preserve and inspect a mapped WHIRL image containing two independent PUs.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+contract_test="${OPEN64_DSL_CONTRACT_TEST:-$repo_root/build/osprey/targdir/ir_tools/dsl_builder_contract_test}"
+ir_b2a="${OPEN64_IR_B2A:-$repo_root/build/osprey/targdir/ir_tools/ir_b2a}"
+artifact_dir="${OPEN64_DSL_MULTI_PU_DIR:-$repo_root/artifacts/torch2whirl/multi-pu}"
+image="$artifact_dir/llama2_multi_pu.B"
+trace="$artifact_dir/llama2_multi_pu.T"
+
+mkdir -p "$artifact_dir"
+rm -f "$image" "$trace"
+
+OPEN64_DSL_MULTI_PU_ONLY=1 \
+OPEN64_DSL_MULTI_PU_ARTIFACT="$image" \
+  "$contract_test"
+"$ir_b2a" -st -src "$image" > "$trace"
+
+if [[ "$(grep -Fc 'FUNC_ENTRY' "$trace")" -ne 2 ]]; then
+  echo "expected exactly two FUNC_ENTRY nodes in $trace" >&2
+  exit 1
+fi
+for evidence in \
+  "TinyRMSNorm" \
+  "TinyLlama2ForCausalLM" \
+  "hidden_states" \
+  "normalized_result" \
+  "model_hidden" \
+  "model_result" \
+  "normalized_hidden" \
+  "Sclass: FORMAL" \
+  "Sclass: FORMAL_REF" \
+  "by_reference  read_only passed_not_saved" \
+  "by_reference  out passed_not_saved" \
+  "__WHIRL_DSL_CALL__:callee=TinyRMSNorm" \
+  "metadata=owner_pu=TinyRMSNorm" \
+  "metadata=owner_pu=TinyLlama2ForCausalLM" \
+  "location: file llama2_model.py, line 18" \
+  "location: file llama2_model.py, line 72"; do
+  if ! grep -Fq "$evidence" "$trace"; then
+    echo "missing multiple-PU evidence '$evidence' in $trace" >&2
+    exit 1
+  fi
+done
+
+echo "multiple-PU mapped-image fixture passed"
+echo "review trace: $trace"


### PR DESCRIPTION
## Summary

- add opaque native builder APIs for PU selection, typed formals, ordered result slots, returns, and inter-PU calls
- represent calls with standard WHIRL FUNC_ENTRY, CALL, PARM, STID, and RETURN nodes while preserving class, instance, context, ordinal, and source evidence
- preserve local symbol/map ownership across PUs and reject cross-PU value reuse
- model decode tuples as ordered typed result slots instead of an untyped tuple or generic multiple-result operator
- retain stable owner-PU evidence in the existing DSL value metadata field without changing ELF sections or mapped-image record sizes
- preserve historical pre-PU builder capability probes
- document the callable contract and add a retained two-PU mapped-image test

## Compatibility

No WHIRL opcode value, ELF section, mapped-image record, or record-size change is introduced. Existing single-PU behavior remains supported.

## Validation

- full dsl_builder_contract_test
- dsl_multi_pu_artifact_test.sh with mapped-image reopen and ir_b2a -st -src
- Linux DSL native syntax test
- physical operator compatibility matrix for x8664, mips, mips-sl, key-generic, loongson, and baseline
- torch2whirl exhaustive native-extension suite: 136 tests passed
- explicit single-PU and multiple-PU Llama artifact validation
- git diff --check and no-tab scan

## Review Evidence

The multiple-PU trace proves two real FUNC_ENTRY nodes, typed input/result formals, a standard VCALL, read-only and out PARMs, source positions, owner-PU metadata, and the retained logical call comment.