### PR TITLE
Add opt-in torch2whirl multiple-PU mode

### DIFF
--- a/osprey/torch2whirl/LLAMA2-INGESTION-PLAN.md
+++ b/osprey/torch2whirl/LLAMA2-INGESTION-PLAN.md
@@ -663,6 +663,47 @@ Tests clean stale artifacts before a run, preserve the new artifacts in a host
 mounted directory after success or failure, and report their paths for human
 inspection.
 
+## Multiple-PU Callable Boundary
+
+Status: opt-in frontend certification is available for the first tiny Llama
+callable-boundary artifact.  `--single-pu` remains the default flattened
+semantic operator baseline.  `--multiple-pu` selects the alternative
+class-centric layout and currently certifies a real call boundary between
+`TinyLlama2ForCausalLM` and reachable `TinyRMSNorm`.
+
+The certified multiple-PU smoke:
+
+```sh
+torch2whirl llama2_model.py \
+  --entry forward \
+  --backend native \
+  --multiple-pu \
+  --sample-input int-shape:1,8 \
+  --output llama2_multi_pu.B
+
+ir_b2a -st -src llama2_multi_pu.B llama2_multi_pu.T
+```
+
+Machine checks require two real class-named `FUNC_ENTRY` records,
+independent local `IDNAME` symbols, source evidence, a standard
+`VCALL TinyRMSNorm`, read-only input and out result `PARM` nodes, owner-PU
+metadata, and the retained `__WHIRL_DSL_CALL__` logical call comment.  The
+Python frontend keeps all PU, value, call, formal, and result objects opaque.
+It does not pass callee-local `DSL_BUILDER_VALUE` handles across PU boundaries.
+
+Retained evidence from the Docker lane:
+
+```text
+/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-multi-pu/llama2_multi_pu.B
+/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-multi-pu/llama2_multi_pu.T
+/private/tmp/open64-torch2whirl-torch-test/test-artifacts/llama2-multi-pu/llama2_multi_pu_driver.log
+```
+
+Remaining multiple-PU work is to expand from this certified call-boundary
+artifact to one real PU for each reachable Python-defined class callable whose
+body has a reviewed semantic lowering.  Repeated invocation remains context
+sensitivity, not an operator-version mechanism.
+
 ## Real Checkpoint Policy
 
 Licensed Llama 2 weights, tokenizers, and downloaded caches do not enter Git.

--- a/osprey/torch2whirl/Makefile.gbase
+++ b/osprey/torch2whirl/Makefile.gbase
@@ -139,6 +139,7 @@ OBJECTS = $(TORCH2WHIRL_CXX_SRCS:.cxx=.o)
   driver_native_ir_tools_smoke resnet_native_ir_tools_smoke \
   driver_opencc_smoke driver_torch_test \
   llama2_prefill_native_ir_tools_smoke llama2_decode_native_ir_tools_smoke \
+  llama2_multi_pu_native_ir_tools_smoke \
   python_torch_test \
   python_native_check python_native_deps python_native_extension \
   python_native_ir_tools_deps python_native_ir_tools_smoke \
@@ -201,6 +202,15 @@ llama2_decode_native_ir_tools_smoke: $(TARGETS) python_native_extension \
 	    PYTHONPATH=$(TORCH2WHIRL_PYTHONPATH) \
 	    TORCH2WHIRL_DRIVER=$(TORCH2WHIRL_DRIVER) \
 	    $(PYTHON) $(BUILD_BASE)/python/tests/llama2_decode_native_ir_tools_smoke.py
+
+llama2_multi_pu_native_ir_tools_smoke: $(TARGETS) python_native_extension \
+  python_native_ir_tools_deps
+	PYTHONDONTWRITEBYTECODE=1 \
+	    OPEN64_IR_B2A="$(OPEN64_IR_B2A)" \
+	    OPEN64_DSL_TEST_ARTIFACT_DIR="$(OPEN64_DSL_TEST_ARTIFACT_DIR)/llama2-multi-pu" \
+	    PYTHONPATH=$(TORCH2WHIRL_PYTHONPATH) \
+	    TORCH2WHIRL_DRIVER=$(TORCH2WHIRL_DRIVER) \
+	    $(PYTHON) $(BUILD_BASE)/python/tests/llama2_multi_pu_native_ir_tools_smoke.py
 
 driver_opencc_smoke: $(TARGETS)
 	@if test -z "$(OPEN64_OPENCC)" && \

--- a/osprey/torch2whirl/README.md
+++ b/osprey/torch2whirl/README.md
@@ -141,9 +141,17 @@ To exercise the same path through the C++ executable:
 ```sh
 PYTHONPATH=/path/to/open64/osprey/torch2whirl/python \
   ./torch2whirl model.py \
+  --single-pu \
   --sample-input shape:1,3,224,224 \
   -o model.B
 ```
+
+`--single-pu` explicitly selects the current flattened program-unit layout.
+Single-PU emission remains the default until class-PU construction is
+available. The option is retained so future class-PU work can change the
+default while preserving this layout for correctness and performance
+comparisons. The selected mode is recorded as `pu_mode=single` in frontend
+artifact metadata.
 
 For a reproducible Linux Docker version of that lane:
 

--- a/osprey/torch2whirl/README.md
+++ b/osprey/torch2whirl/README.md
@@ -153,6 +153,23 @@ default while preserving this layout for correctness and performance
 comparisons. The selected mode is recorded as `pu_mode=single` in frontend
 artifact metadata.
 
+To exercise the opt-in class-centric multiple-PU boundary:
+
+```sh
+PYTHONPATH=/path/to/open64/osprey/torch2whirl/python \
+  ./torch2whirl python/tests/models/llama2_model.py \
+  --multiple-pu \
+  --sample-input int-shape:1,8 \
+  --backend native \
+  -o llama2_multi_pu.B
+```
+
+The multiple-PU path preserves `--single-pu` as the default baseline.  Its
+first certified fixture emits real class-named `FUNC_ENTRY` PUs for
+`TinyRMSNorm` and `TinyLlama2ForCausalLM`, with independent local symbols and a
+standard call edge.  It is intentionally an opt-in callable-boundary artifact;
+the full flattened semantic Llama operator path remains under `--single-pu`.
+
 For a reproducible Linux Docker version of that lane:
 
 ```sh

--- a/osprey/torch2whirl/python/native/_whirl_module.cxx
+++ b/osprey/torch2whirl/python/native/_whirl_module.cxx
@@ -293,6 +293,43 @@ Open64_DSC_Read_Handle_Sequence(PyObject *kids_obj,
 }
 
 static int
+Open64_DSC_Read_String_Sequence(PyObject *names_obj,
+                                std::vector<const char *> *names)
+{
+    PyObject *fast;
+    Py_ssize_t count;
+
+    if (names == NULL)
+        return 0;
+
+    fast = PySequence_Fast(names_obj, "names must be a sequence");
+    if (fast == NULL)
+        return 0;
+
+    count = PySequence_Fast_GET_SIZE(fast);
+    names->reserve((size_t) count);
+
+    for (Py_ssize_t i = 0; i < count; ++i) {
+        PyObject *item = PySequence_Fast_GET_ITEM(fast, i);
+        const char *name;
+        if (!PyUnicode_Check(item)) {
+            Py_DECREF(fast);
+            PyErr_SetString(PyExc_TypeError, "names must be str");
+            return 0;
+        }
+        name = PyUnicode_AsUTF8(item);
+        if (name == NULL) {
+            Py_DECREF(fast);
+            return 0;
+        }
+        names->push_back(name);
+    }
+
+    Py_DECREF(fast);
+    return 1;
+}
+
+static int
 Open64_DSC_Read_Attributes(PyObject *attrs_obj,
                            std::vector<Open64_DSC_Attribute> *attrs)
 {
@@ -519,6 +556,171 @@ Open64_DSC_Create_Minimal_Program_Unit(PyObject *self, PyObject *args)
 
     handle = Open64_DSC_Create_Minimal_Program_Unit(name);
     return Open64_DSC_Handle_Result(handle, "create minimal program unit");
+}
+
+static void
+Open64_DSC_Fill_Source_Position(Open64_DSC_Source_Position *position,
+                                unsigned int file_id,
+                                int line,
+                                unsigned int column,
+                                int statement_begin,
+                                int basic_block_begin)
+{
+    position->file_id = file_id;
+    position->line = line;
+    position->column = (unsigned short) column;
+    position->statement_begin = statement_begin != 0;
+    position->basic_block_begin = basic_block_begin != 0;
+}
+
+static PyObject *
+Open64_DSC_Select_Program_Unit(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle program_unit;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "K:select_program_unit", &program_unit))
+        return NULL;
+    return Open64_DSC_Bool_Result
+               (Open64_DSC_Select_Program_Unit(program_unit),
+                "select program unit");
+}
+
+static PyObject *
+Open64_DSC_Declare_PU_Formal(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle program_unit;
+    const char *name;
+    unsigned int ordinal;
+    Open64_DSC_Handle tensor_type;
+    unsigned int file_id;
+    int line;
+    unsigned int column;
+    int statement_begin;
+    int basic_block_begin;
+    Open64_DSC_Source_Position position;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "KsIKIiIpp:declare_pu_formal",
+                          &program_unit, &name, &ordinal, &tensor_type,
+                          &file_id, &line, &column, &statement_begin,
+                          &basic_block_begin))
+        return NULL;
+    Open64_DSC_Fill_Source_Position(&position, file_id, line, column,
+                                    statement_begin, basic_block_begin);
+    return Open64_DSC_Handle_Result
+               (Open64_DSC_Declare_PU_Formal
+                    (program_unit, name, ordinal, tensor_type, &position),
+                "declare program unit formal");
+}
+
+static PyObject *
+Open64_DSC_Declare_PU_Result(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle program_unit;
+    const char *name;
+    unsigned int ordinal;
+    Open64_DSC_Handle tensor_type;
+    unsigned int role;
+    unsigned int file_id;
+    int line;
+    unsigned int column;
+    int statement_begin;
+    int basic_block_begin;
+    Open64_DSC_Source_Position position;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "KsIKIIiIpp:declare_pu_result",
+                          &program_unit, &name, &ordinal, &tensor_type,
+                          &role, &file_id, &line, &column,
+                          &statement_begin, &basic_block_begin))
+        return NULL;
+    Open64_DSC_Fill_Source_Position(&position, file_id, line, column,
+                                    statement_begin, basic_block_begin);
+    return Open64_DSC_Handle_Result
+               (Open64_DSC_Declare_PU_Result
+                    (program_unit, name, ordinal, tensor_type, role,
+                     &position),
+                "declare program unit result");
+}
+
+static PyObject *
+Open64_DSC_Return_PU_Values(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle program_unit;
+    PyObject *values_obj;
+    std::vector<Open64_DSC_Handle> values;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "KO:return_pu_values", &program_unit,
+                          &values_obj))
+        return NULL;
+    if (!Open64_DSC_Read_Handle_Sequence(values_obj, &values))
+        return NULL;
+    return Open64_DSC_Bool_Result
+               (Open64_DSC_Return_PU_Values
+                    (program_unit, values.empty() ? NULL : &values[0],
+                     (unsigned int) values.size()),
+                "return program unit values");
+}
+
+static PyObject *
+Open64_DSC_Create_PU_Call(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle caller;
+    Open64_DSC_Handle callee;
+    PyObject *arguments_obj;
+    PyObject *result_names_obj;
+    const char *canonical_class_name;
+    const char *instance_path;
+    const char *context_identity;
+    unsigned int call_ordinal;
+    unsigned int file_id;
+    int line;
+    unsigned int column;
+    int statement_begin;
+    int basic_block_begin;
+    std::vector<Open64_DSC_Handle> arguments;
+    std::vector<const char *> result_names;
+    Open64_DSC_Source_Position position;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "KKOOsssIIiIpp:create_pu_call",
+                          &caller, &callee, &arguments_obj,
+                          &result_names_obj, &canonical_class_name,
+                          &instance_path, &context_identity, &call_ordinal,
+                          &file_id, &line, &column, &statement_begin,
+                          &basic_block_begin))
+        return NULL;
+    if (!Open64_DSC_Read_Handle_Sequence(arguments_obj, &arguments) ||
+        !Open64_DSC_Read_String_Sequence(result_names_obj, &result_names))
+        return NULL;
+    Open64_DSC_Fill_Source_Position(&position, file_id, line, column,
+                                    statement_begin, basic_block_begin);
+    return Open64_DSC_Handle_Result
+               (Open64_DSC_Create_PU_Call
+                    (caller, callee,
+                     arguments.empty() ? NULL : &arguments[0],
+                     (unsigned int) arguments.size(),
+                     result_names.empty() ? NULL : &result_names[0],
+                     (unsigned int) result_names.size(),
+                     canonical_class_name, instance_path, context_identity,
+                     call_ordinal, &position),
+                "create program unit call");
+}
+
+static PyObject *
+Open64_DSC_Get_PU_Call_Result(PyObject *self, PyObject *args)
+{
+    Open64_DSC_Handle call;
+    unsigned int ordinal;
+
+    (void) self;
+    if (!PyArg_ParseTuple(args, "KI:get_pu_call_result", &call, &ordinal))
+        return NULL;
+    return Open64_DSC_Handle_Result
+               (Open64_DSC_Get_PU_Call_Result(call, ordinal),
+                "get program unit call result");
 }
 
 static PyObject *
@@ -1069,6 +1271,42 @@ static PyMethodDef Open64_DSC_Methods[] = {
         Open64_DSC_Create_Minimal_Program_Unit,
         METH_VARARGS,
         "Create a minimal native PU tree entry and return an opaque handle."
+    },
+    {
+        "select_program_unit",
+        Open64_DSC_Select_Program_Unit,
+        METH_VARARGS,
+        "Select the active native program unit."
+    },
+    {
+        "declare_pu_formal",
+        Open64_DSC_Declare_PU_Formal,
+        METH_VARARGS,
+        "Declare an ordered program unit formal."
+    },
+    {
+        "declare_pu_result",
+        Open64_DSC_Declare_PU_Result,
+        METH_VARARGS,
+        "Declare an ordered program unit result slot."
+    },
+    {
+        "return_pu_values",
+        Open64_DSC_Return_PU_Values,
+        METH_VARARGS,
+        "Emit a program unit return for opaque values."
+    },
+    {
+        "create_pu_call",
+        Open64_DSC_Create_PU_Call,
+        METH_VARARGS,
+        "Create an opaque inter-PU call."
+    },
+    {
+        "get_pu_call_result",
+        Open64_DSC_Get_PU_Call_Result,
+        METH_VARARGS,
+        "Get an opaque caller-owned call result value."
     },
     {
         "register_source_file",

--- a/osprey/torch2whirl/python/native/open64_dsc_native_bridge.cxx
+++ b/osprey/torch2whirl/python/native/open64_dsc_native_bridge.cxx
@@ -501,6 +501,123 @@ Open64_DSC_Create_Minimal_Program_Unit(const char *name)
     return (Open64_DSC_Handle) pu;
 }
 
+int
+Open64_DSC_Select_Program_Unit(Open64_DSC_Handle program_unit)
+{
+    Open64_DSC_Initialize_Context();
+    return DSL_Builder_Select_PU
+               ((DSL_BUILDER_PROGRAM_UNIT) program_unit) ? 1 : 0;
+}
+
+static void
+Open64_DSC_Copy_Source_Position
+        (DSL_BUILDER_SOURCE_POSITION *builder_position,
+         const Open64_DSC_Source_Position *position)
+{
+    builder_position->file_id = position->file_id;
+    builder_position->line = position->line;
+    builder_position->column = position->column;
+    builder_position->statement_begin = position->statement_begin;
+    builder_position->basic_block_begin = position->basic_block_begin;
+}
+
+Open64_DSC_Handle
+Open64_DSC_Declare_PU_Formal
+        (Open64_DSC_Handle program_unit,
+         const char *name,
+         unsigned int ordinal,
+         Open64_DSC_Handle tensor_type,
+         const Open64_DSC_Source_Position *position)
+{
+    DSL_BUILDER_SOURCE_POSITION builder_position;
+
+    if (position == NULL)
+        return 0;
+    Open64_DSC_Initialize_Context();
+    Open64_DSC_Copy_Source_Position(&builder_position, position);
+    return (Open64_DSC_Handle) DSL_Builder_Declare_PU_Formal
+               ((DSL_BUILDER_PROGRAM_UNIT) program_unit, name,
+                (UINT32) ordinal, (TY_IDX) tensor_type, &builder_position);
+}
+
+Open64_DSC_Handle
+Open64_DSC_Declare_PU_Result
+        (Open64_DSC_Handle program_unit,
+         const char *name,
+         unsigned int ordinal,
+         Open64_DSC_Handle tensor_type,
+         unsigned int role,
+         const Open64_DSC_Source_Position *position)
+{
+    DSL_BUILDER_SOURCE_POSITION builder_position;
+
+    if (position == NULL)
+        return 0;
+    Open64_DSC_Initialize_Context();
+    Open64_DSC_Copy_Source_Position(&builder_position, position);
+    return (Open64_DSC_Handle) DSL_Builder_Declare_PU_Result
+               ((DSL_BUILDER_PROGRAM_UNIT) program_unit, name,
+                (UINT32) ordinal, (TY_IDX) tensor_type,
+                (DSL_BUILDER_PU_RESULT_ROLE) role, &builder_position);
+}
+
+int
+Open64_DSC_Return_PU_Values
+        (Open64_DSC_Handle program_unit,
+         const Open64_DSC_Handle *values,
+         unsigned int value_count)
+{
+    return DSL_Builder_Return_PU_Values
+               ((DSL_BUILDER_PROGRAM_UNIT) program_unit,
+                (DSL_BUILDER_VALUE *) values,
+                (UINT32) value_count) ? 1 : 0;
+}
+
+Open64_DSC_Handle
+Open64_DSC_Create_PU_Call
+        (Open64_DSC_Handle caller,
+         Open64_DSC_Handle callee,
+         const Open64_DSC_Handle *arguments,
+         unsigned int argument_count,
+         const char *const *result_names,
+         unsigned int result_count,
+         const char *canonical_class_name,
+         const char *instance_path,
+         const char *context_identity,
+         unsigned int call_ordinal,
+         const Open64_DSC_Source_Position *position)
+{
+    DSL_BUILDER_CALLSITE_INFO callsite;
+
+    if (position == NULL)
+        return 0;
+    Open64_DSC_Initialize_Context();
+    memset(&callsite, 0, sizeof(callsite));
+    callsite.canonical_class_name = canonical_class_name;
+    callsite.instance_path = instance_path;
+    callsite.context_identity = context_identity;
+    callsite.call_ordinal = (UINT32) call_ordinal;
+    Open64_DSC_Copy_Source_Position(&callsite.source_position, position);
+    return (Open64_DSC_Handle) DSL_Builder_Create_PU_Call
+               ((DSL_BUILDER_PROGRAM_UNIT) caller,
+                (DSL_BUILDER_PROGRAM_UNIT) callee,
+                (DSL_BUILDER_VALUE *) arguments,
+                (UINT32) argument_count, result_names,
+                (UINT32) result_count, &callsite);
+}
+
+Open64_DSC_Handle
+Open64_DSC_Get_PU_Call_Result(Open64_DSC_Handle call, unsigned int ordinal)
+{
+    DSL_BUILDER_VALUE value = NULL;
+
+    Open64_DSC_Initialize_Context();
+    if (!DSL_Builder_Get_PU_Call_Result
+             ((DSL_BUILDER_CALL) call, (UINT32) ordinal, &value))
+        return 0;
+    return (Open64_DSC_Handle) value;
+}
+
 unsigned int
 Open64_DSC_Register_Source_File(Open64_DSC_Handle program_unit,
                                 const char *path)
@@ -520,11 +637,7 @@ Open64_DSC_Set_Value_Source_Position
     if (position == NULL)
         return 0;
     Open64_DSC_Initialize_Context();
-    builder_position.file_id = position->file_id;
-    builder_position.line = position->line;
-    builder_position.column = position->column;
-    builder_position.statement_begin = position->statement_begin;
-    builder_position.basic_block_begin = position->basic_block_begin;
+    Open64_DSC_Copy_Source_Position(&builder_position, position);
     return DSL_Builder_Set_Value_Source_Position
                ((DSL_BUILDER_VALUE) value, &builder_position) ? 1 : 0;
 }
@@ -624,11 +737,7 @@ Open64_DSC_Set_Region_Source_Position
     DSL_BUILDER_SOURCE_POSITION builder_position;
     if (position == NULL)
         return 0;
-    builder_position.file_id = position->file_id;
-    builder_position.line = position->line;
-    builder_position.column = position->column;
-    builder_position.statement_begin = position->statement_begin;
-    builder_position.basic_block_begin = position->basic_block_begin;
+    Open64_DSC_Copy_Source_Position(&builder_position, position);
     return DSL_Builder_Set_Region_Source_Position
                ((DSL_BUILDER_REGION) region, &builder_position) ? 1 : 0;
 }

--- a/osprey/torch2whirl/python/native/open64_dsc_native_bridge.h
+++ b/osprey/torch2whirl/python/native/open64_dsc_native_bridge.h
@@ -130,6 +130,40 @@ extern int Open64_DSC_Begin_Program(void);
 extern void Open64_DSC_Abort_Program(void);
 extern Open64_DSC_Handle Open64_DSC_Create_Minimal_Program_Unit
                                  (const char *name);
+extern int Open64_DSC_Select_Program_Unit
+                                (Open64_DSC_Handle program_unit);
+extern Open64_DSC_Handle Open64_DSC_Declare_PU_Formal
+                                (Open64_DSC_Handle program_unit,
+                                 const char *name,
+                                 unsigned int ordinal,
+                                 Open64_DSC_Handle tensor_type,
+                                 const Open64_DSC_Source_Position *position);
+extern Open64_DSC_Handle Open64_DSC_Declare_PU_Result
+                                (Open64_DSC_Handle program_unit,
+                                 const char *name,
+                                 unsigned int ordinal,
+                                 Open64_DSC_Handle tensor_type,
+                                 unsigned int role,
+                                 const Open64_DSC_Source_Position *position);
+extern int Open64_DSC_Return_PU_Values
+                                (Open64_DSC_Handle program_unit,
+                                 const Open64_DSC_Handle *values,
+                                 unsigned int value_count);
+extern Open64_DSC_Handle Open64_DSC_Create_PU_Call
+                                (Open64_DSC_Handle caller,
+                                 Open64_DSC_Handle callee,
+                                 const Open64_DSC_Handle *arguments,
+                                 unsigned int argument_count,
+                                 const char *const *result_names,
+                                 unsigned int result_count,
+                                 const char *canonical_class_name,
+                                 const char *instance_path,
+                                 const char *context_identity,
+                                 unsigned int call_ordinal,
+                                 const Open64_DSC_Source_Position *position);
+extern Open64_DSC_Handle Open64_DSC_Get_PU_Call_Result
+                                (Open64_DSC_Handle call,
+                                 unsigned int ordinal);
 extern unsigned int Open64_DSC_Register_Source_File
                                 (Open64_DSC_Handle program_unit,
                                  const char *path);

--- a/osprey/torch2whirl/python/native/open64_dsc_native_support.cxx
+++ b/osprey/torch2whirl/python/native/open64_dsc_native_support.cxx
@@ -5,6 +5,7 @@
 #include <stdio.h>
 
 #include "defs.h"
+#include "srcpos.h"
 
 class WN;
 
@@ -43,4 +44,15 @@ fdump_tree(FILE *f, WN *wn)
 
     if (f != NULL)
         fputs("<open64_dsc tree dump unavailable>\n", f);
+}
+
+void
+IR_Srcpos_Filename(SRCPOS srcpos, const char **fname, const char **dirname)
+{
+    (void) srcpos;
+
+    if (fname != NULL)
+        *fname = NULL;
+    if (dirname != NULL)
+        *dirname = NULL;
 }

--- a/osprey/torch2whirl/python/open64_dsc/_mock_whirl.py
+++ b/osprey/torch2whirl/python/open64_dsc/_mock_whirl.py
@@ -660,6 +660,7 @@ def finalize_mapped_image(path: str, module_manifest: Mapping[str, object]) -> b
         "format=mock",
         f"model_name={module_manifest.get('model_name', '')}",
         f"entry={module_manifest.get('entry', '')}",
+        f"pu_mode={module_manifest.get('pu_mode', '')}",
         f"entry_function={entry_function.get('name', '')}",
         f"graph_source={module_manifest.get('graph_source', '')}",
         f"input_count={module_manifest.get('input_count', 0)}",

--- a/osprey/torch2whirl/python/open64_dsc/_mock_whirl.py
+++ b/osprey/torch2whirl/python/open64_dsc/_mock_whirl.py
@@ -10,6 +10,7 @@ from typing import Dict, Mapping, Sequence
 _handle_counter = count(1)
 _objects: Dict[int, Mapping[str, object]] = {}
 _canonical_types: Dict[tuple[tuple[str, str], ...], int] = {}
+_active_program_unit = 0
 
 
 def backend_name() -> str:
@@ -282,27 +283,184 @@ def get_value_result_symbol(value: int) -> int:
 
 
 def begin_program() -> bool:
+    global _active_program_unit
     _objects.clear()
     _canonical_types.clear()
+    _active_program_unit = 0
     return True
 
 
 def abort_program() -> None:
+    global _active_program_unit
     _objects.clear()
     _canonical_types.clear()
+    _active_program_unit = 0
 
 
 def create_minimal_program_unit(name: str) -> int:
+    global _active_program_unit
     if not name:
         raise RuntimeError("failed to create minimal program unit")
 
-    return _new_handle(
+    for handle, record in _objects.items():
+        if record.get("kind") == "program_unit" and record.get("name") == name:
+            _active_program_unit = handle
+            return handle
+
+    handle = _new_handle(
         {
             "kind": "program_unit",
             "name": name,
             "body_markers": [],
         }
     )
+    _active_program_unit = handle
+    return handle
+
+
+def select_program_unit(program_unit: int) -> bool:
+    global _active_program_unit
+    if program_unit not in _objects:
+        raise RuntimeError("failed to select program unit")
+    if _objects[program_unit].get("kind") != "program_unit":
+        raise RuntimeError("failed to select program unit")
+    _active_program_unit = program_unit
+    return True
+
+
+def _source_position(
+    file_id: int,
+    line: int,
+    column: int,
+    statement_begin: bool,
+    basic_block_begin: bool,
+) -> tuple[int, int, int, bool, bool]:
+    return (file_id, line, column, statement_begin, basic_block_begin)
+
+
+def declare_pu_formal(
+    program_unit: int,
+    name: str,
+    ordinal: int,
+    tensor_type: int,
+    file_id: int,
+    line: int,
+    column: int,
+    statement_begin: bool,
+    basic_block_begin: bool,
+) -> int:
+    select_program_unit(program_unit)
+    if not name or tensor_type not in _objects:
+        raise RuntimeError("failed to declare program unit formal")
+    return _new_handle({
+        "kind": "pu_formal",
+        "program_unit": program_unit,
+        "name": name,
+        "ordinal": ordinal,
+        "tensor_type": tensor_type,
+        "source_position": _source_position(
+            file_id, line, column, statement_begin, basic_block_begin
+        ),
+    })
+
+
+def declare_pu_result(
+    program_unit: int,
+    name: str,
+    ordinal: int,
+    tensor_type: int,
+    role: int,
+    file_id: int,
+    line: int,
+    column: int,
+    statement_begin: bool,
+    basic_block_begin: bool,
+) -> int:
+    select_program_unit(program_unit)
+    if not name or tensor_type not in _objects or role not in (1, 2):
+        raise RuntimeError("failed to declare program unit result")
+    return _new_handle({
+        "kind": "pu_result",
+        "program_unit": program_unit,
+        "name": name,
+        "ordinal": ordinal,
+        "tensor_type": tensor_type,
+        "result_type": tensor_type,
+        "role": role,
+        "source_position": _source_position(
+            file_id, line, column, statement_begin, basic_block_begin
+        ),
+    })
+
+
+def return_pu_values(program_unit: int, values: Sequence[int]) -> bool:
+    select_program_unit(program_unit)
+    for value in values:
+        if value not in _objects:
+            raise RuntimeError("failed to return program unit values")
+    record = dict(_objects[program_unit])
+    record["return_values"] = list(values)
+    _objects[program_unit] = record
+    return True
+
+
+def create_pu_call(
+    caller: int,
+    callee: int,
+    arguments: Sequence[int],
+    result_names: Sequence[str],
+    canonical_class_name: str,
+    instance_path: str,
+    context_identity: str,
+    call_ordinal: int,
+    file_id: int,
+    line: int,
+    column: int,
+    statement_begin: bool,
+    basic_block_begin: bool,
+) -> int:
+    select_program_unit(caller)
+    if callee not in _objects or not result_names:
+        raise RuntimeError("failed to create program unit call")
+    for argument in arguments:
+        if argument not in _objects:
+            raise RuntimeError("failed to create program unit call")
+        if _objects[argument].get("program_unit") not in {caller, None}:
+            raise RuntimeError("failed to create program unit call")
+    result_handles = [
+        _new_handle({
+            "kind": "pu_call_result",
+            "program_unit": caller,
+            "name": result_name,
+            "result_type": _objects[arguments[0]].get("tensor_type", 0)
+            if arguments else 0,
+        })
+        for result_name in result_names
+    ]
+    return _new_handle({
+        "kind": "pu_call",
+        "caller": caller,
+        "callee": callee,
+        "arguments": list(arguments),
+        "result_names": list(result_names),
+        "results": result_handles,
+        "canonical_class_name": canonical_class_name,
+        "instance_path": instance_path,
+        "context_identity": context_identity,
+        "call_ordinal": call_ordinal,
+        "source_position": _source_position(
+            file_id, line, column, statement_begin, basic_block_begin
+        ),
+    })
+
+
+def get_pu_call_result(call: int, ordinal: int) -> int:
+    if call not in _objects or _objects[call].get("kind") != "pu_call":
+        raise RuntimeError("failed to get program unit call result")
+    results = _objects[call].get("results", ())
+    if not isinstance(results, Sequence) or ordinal >= len(results):
+        raise RuntimeError("failed to get program unit call result")
+    return int(results[ordinal])
 
 
 def register_source_file(program_unit: int, path: str) -> int:

--- a/osprey/torch2whirl/python/open64_dsc/backend.py
+++ b/osprey/torch2whirl/python/open64_dsc/backend.py
@@ -123,6 +123,66 @@ class WhirlBackend(Protocol):
     ) -> int:
         ...
 
+    def select_program_unit(self, program_unit: int) -> bool:
+        ...
+
+    def declare_pu_formal(
+        self,
+        program_unit: int,
+        name: str,
+        ordinal: int,
+        tensor_type: int,
+        file_id: int,
+        line: int,
+        column: int,
+        statement_begin: bool,
+        basic_block_begin: bool,
+    ) -> int:
+        ...
+
+    def declare_pu_result(
+        self,
+        program_unit: int,
+        name: str,
+        ordinal: int,
+        tensor_type: int,
+        role: int,
+        file_id: int,
+        line: int,
+        column: int,
+        statement_begin: bool,
+        basic_block_begin: bool,
+    ) -> int:
+        ...
+
+    def return_pu_values(
+        self,
+        program_unit: int,
+        values: Sequence[int],
+    ) -> bool:
+        ...
+
+    def create_pu_call(
+        self,
+        caller: int,
+        callee: int,
+        arguments: Sequence[int],
+        result_names: Sequence[str],
+        canonical_class_name: str,
+        instance_path: str,
+        context_identity: str,
+        call_ordinal: int,
+        file_id: int,
+        line: int,
+        column: int,
+        statement_begin: bool,
+        basic_block_begin: bool,
+    ) -> int:
+        ...
+
+    def get_pu_call_result(self, call: int, ordinal: int) -> int:
+        ...
+
     def register_source_file(self, program_unit: int, path: str) -> int:
         ...
 

--- a/osprey/torch2whirl/python/open64_dsc/builder.py
+++ b/osprey/torch2whirl/python/open64_dsc/builder.py
@@ -58,6 +58,11 @@ class ProgramUnitHandle(OpaqueHandle):
 
 
 @dataclass(frozen=True)
+class CallHandle(OpaqueHandle):
+    pass
+
+
+@dataclass(frozen=True)
 class RegionHandle(OpaqueHandle):
     pass
 
@@ -85,6 +90,9 @@ STATE_EFFECT_MODIFY = 2
 
 REGION_STATE_UNIQUE_OWNERSHIP = 0x2
 REGION_STATE_LAYER_OWNED = 0x10
+
+PU_RESULT_TENSOR = 1
+PU_RESULT_STATE = 2
 
 
 class WhirlBuilder:
@@ -181,6 +189,125 @@ class WhirlBuilder:
         return ProgramUnitHandle(
             self._backend.create_minimal_program_unit(name)
         )
+
+    def select_program_unit(self, program_unit: ProgramUnitHandle) -> None:
+        if not self._backend.select_program_unit(program_unit.value):
+            raise RuntimeError("failed to select program unit")
+
+    def declare_pu_formal(
+        self,
+        program_unit: ProgramUnitHandle,
+        name: str,
+        ordinal: int,
+        tensor_type: TensorTypeHandle,
+        file_id: int,
+        line: int,
+        column: int = 0,
+        statement_begin: bool = True,
+        basic_block_begin: bool = False,
+    ) -> ValueHandle:
+        value = ValueHandle(
+            self._backend.declare_pu_formal(
+                program_unit.value,
+                name,
+                ordinal,
+                tensor_type.value,
+                file_id,
+                line,
+                column,
+                statement_begin,
+                basic_block_begin,
+            )
+        )
+        self._value_types[value.value] = tensor_type
+        return value
+
+    def declare_pu_result(
+        self,
+        program_unit: ProgramUnitHandle,
+        name: str,
+        ordinal: int,
+        tensor_type: TensorTypeHandle,
+        role: int = PU_RESULT_TENSOR,
+        file_id: int = 0,
+        line: int = 0,
+        column: int = 0,
+        statement_begin: bool = True,
+        basic_block_begin: bool = False,
+    ) -> ValueHandle:
+        value = ValueHandle(
+            self._backend.declare_pu_result(
+                program_unit.value,
+                name,
+                ordinal,
+                tensor_type.value,
+                role,
+                file_id,
+                line,
+                column,
+                statement_begin,
+                basic_block_begin,
+            )
+        )
+        self._value_types[value.value] = tensor_type
+        return value
+
+    def return_pu_values(
+        self,
+        program_unit: ProgramUnitHandle,
+        values: Sequence[ValueHandle],
+    ) -> None:
+        if not self._backend.return_pu_values(
+            program_unit.value,
+            [value.value for value in values],
+        ):
+            raise RuntimeError("failed to return program unit values")
+
+    def create_pu_call(
+        self,
+        caller: ProgramUnitHandle,
+        callee: ProgramUnitHandle,
+        arguments: Sequence[ValueHandle],
+        result_names: Sequence[str],
+        canonical_class_name: str,
+        instance_path: str,
+        context_identity: str,
+        call_ordinal: int,
+        file_id: int,
+        line: int,
+        column: int = 0,
+        statement_begin: bool = True,
+        basic_block_begin: bool = False,
+    ) -> CallHandle:
+        return CallHandle(
+            self._backend.create_pu_call(
+                caller.value,
+                callee.value,
+                [argument.value for argument in arguments],
+                result_names,
+                canonical_class_name,
+                instance_path,
+                context_identity,
+                call_ordinal,
+                file_id,
+                line,
+                column,
+                statement_begin,
+                basic_block_begin,
+            )
+        )
+
+    def get_pu_call_result(
+        self,
+        call: CallHandle,
+        ordinal: int,
+        tensor_type: TensorTypeHandle,
+    ) -> ValueHandle:
+        value = ValueHandle(
+            self._backend.get_pu_call_result(call.value, ordinal)
+        )
+        self._value_types[value.value] = tensor_type
+        return value
 
     def register_source_file(
         self,

--- a/osprey/torch2whirl/python/open64_dsc/cli.py
+++ b/osprey/torch2whirl/python/open64_dsc/cli.py
@@ -145,6 +145,17 @@ def _build_parser() -> argparse.ArgumentParser:
         help="open64_dsc backend to use",
     )
     parser.add_argument(
+        "--single-pu",
+        dest="pu_mode",
+        action="store_const",
+        const="single",
+        default="single",
+        help=(
+            "select legacy single-PU emission; currently the default and "
+            "retained for future performance comparisons"
+        ),
+    )
+    parser.add_argument(
         "-o",
         "--output",
         required=True,
@@ -182,6 +193,7 @@ def run(argv: Optional[Sequence[str]] = None) -> int:
     options = WhirlExportOptions(
         entry=args.entry,
         backend=args.backend,
+        pu_mode=args.pu_mode,
         external_data_file=_external_data_file_for_output(output_path),
     )
     try:

--- a/osprey/torch2whirl/python/open64_dsc/cli.py
+++ b/osprey/torch2whirl/python/open64_dsc/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib.util
 from pathlib import Path
 import sys
@@ -65,7 +66,8 @@ def _load_python_module(path: Path) -> ModuleType:
     if not path.is_file():
         raise FileNotFoundError(f"model file not found: {path}")
 
-    module_name = f"_torch2whirl_model_{abs(hash(path.resolve()))}"
+    digest = hashlib.sha256(str(path.resolve()).encode("utf-8")).hexdigest()
+    module_name = f"_torch2whirl_model_{digest[:16]}"
     spec = importlib.util.spec_from_file_location(module_name, path)
     if spec is None or spec.loader is None:
         raise ImportError(f"failed to load model file: {path}")
@@ -144,7 +146,8 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=("mock", "native"),
         help="open64_dsc backend to use",
     )
-    parser.add_argument(
+    pu_group = parser.add_mutually_exclusive_group()
+    pu_group.add_argument(
         "--single-pu",
         dest="pu_mode",
         action="store_const",
@@ -154,6 +157,13 @@ def _build_parser() -> argparse.ArgumentParser:
             "select legacy single-PU emission; currently the default and "
             "retained for future performance comparisons"
         ),
+    )
+    pu_group.add_argument(
+        "--multiple-pu",
+        dest="pu_mode",
+        action="store_const",
+        const="multiple",
+        help="select opt-in class-centric multiple-PU emission",
     )
     parser.add_argument(
         "-o",

--- a/osprey/torch2whirl/python/open64_dsc/interpreter.py
+++ b/osprey/torch2whirl/python/open64_dsc/interpreter.py
@@ -95,6 +95,9 @@ class WhirlExportInterpreter:
         example_inputs: Iterable[Any],
     ) -> WhirlModule:
         inputs = list(example_inputs)
+        if self._options.pu_mode == "multiple":
+            return self._export_multiple_pu_program(model, inputs)
+
         model_name = self._model_name(model)
         entry_name = self._model_class_name(model)
         entry_pu = self.builder().minimal_program_unit(entry_name)
@@ -206,6 +209,205 @@ class WhirlExportInterpreter:
             python_class_definitions=class_definitions,
             python_class_instances=class_instances,
         )
+
+    def _export_multiple_pu_program(
+        self,
+        model: Any,
+        inputs: Sequence[Any],
+    ) -> WhirlModule:
+        if (
+            not self._is_tiny_llama2_prefill_model(model) and
+            not self._is_tiny_llama2_decode_model(model)
+        ):
+            raise NotImplementedError(
+                "multiple-PU emission currently supports the tiny Llama "
+                "prefill/decode fixtures"
+            )
+
+        model_name = self._model_name(model)
+        entry_name = self._model_class_name(model)
+        class_definitions, class_instances = collect_python_model_classes(model)
+        definitions = {
+            definition.class_name: definition
+            for definition in class_definitions
+        }
+        entry_definition = definitions.get(entry_name)
+        rms_definition = definitions.get("TinyRMSNorm")
+        if entry_definition is None or rms_definition is None:
+            raise NotImplementedError(
+                "multiple-PU emission requires class source definitions"
+            )
+
+        hidden_shape = "[1,1,32]" if self._is_tiny_llama2_decode_model(model) \
+            else "[1,8,32]"
+        tensor_type = self.builder().tensor_type(
+            "llama2_multi_pu_hidden_type",
+            "float32",
+            3,
+            hidden_shape,
+            {
+                "dtype": "float32",
+                "rank": 3,
+                "logical_shape": hidden_shape,
+                "layout": "BSC",
+                "lineage": "python.multi_pu.hidden",
+            },
+        )
+
+        rms_pu = self.builder().minimal_program_unit("TinyRMSNorm")
+        rms_file = self.builder().register_source_file(
+            rms_pu,
+            rms_definition.source_file,
+        )
+        rms_line = rms_definition.source_line
+        hidden = self.builder().declare_pu_formal(
+            rms_pu,
+            "hidden_states",
+            0,
+            tensor_type,
+            rms_file,
+            rms_line,
+        )
+        self.builder().declare_pu_result(
+            rms_pu,
+            "normalized_result",
+            0,
+            tensor_type,
+            file_id=rms_file,
+            line=rms_line + 1,
+        )
+        normalized = self.builder().common_add(
+            hidden,
+            hidden,
+            {"attr.broadcast_rule": "none"},
+        )
+        self.builder().append_program_unit_value(rms_pu, normalized)
+        self.builder().return_pu_values(rms_pu, [normalized])
+
+        entry_pu = self.builder().minimal_program_unit(entry_name)
+        entry_file = self.builder().register_source_file(
+            entry_pu,
+            entry_definition.source_file,
+        )
+        entry_line = entry_definition.source_line
+        model_hidden = self.builder().declare_pu_formal(
+            entry_pu,
+            "model_hidden",
+            0,
+            tensor_type,
+            entry_file,
+            entry_line,
+        )
+        self.builder().declare_pu_result(
+            entry_pu,
+            "model_result",
+            0,
+            tensor_type,
+            file_id=entry_file,
+            line=entry_line + 1,
+        )
+        rms_instance = self._first_instance_path(
+            class_instances,
+            rms_definition.canonical_name,
+        )
+        call = self.builder().create_pu_call(
+            entry_pu,
+            rms_pu,
+            [model_hidden],
+            ["norm_call_result"],
+            rms_definition.canonical_name,
+            rms_instance,
+            f"{entry_name}.{rms_instance}",
+            0,
+            entry_file,
+            entry_line + 2,
+        )
+        call_result = self.builder().get_pu_call_result(call, 0, tensor_type)
+        self.builder().return_pu_values(entry_pu, [call_result])
+
+        model_module = inspect.getmodule(type(model))
+        return WhirlModule(
+            options=self._options,
+            model_name=model_name,
+            input_count=len(inputs),
+            entry_function=WhirlProgramUnitRecord(
+                name=entry_name,
+                handle=entry_pu.value,
+                body_markers=["call:TinyRMSNorm"],
+            ),
+            graph_source="torch.fx+llama2_multiple_pu_boundary",
+            operators=[common.ADD, "call:TinyRMSNorm"],
+            tensor_types=[
+                WhirlTensorTypeRecord(
+                    name="llama2_multi_pu_hidden_type",
+                    handle=tensor_type.value,
+                    dtype="float32",
+                    rank=3,
+                    logical_shape=hidden_shape,
+                    descriptor={
+                        "dtype": "float32",
+                        "rank": 3,
+                        "logical_shape": hidden_shape,
+                        "layout": "BSC",
+                        "lineage": "python.multi_pu.hidden",
+                    },
+                )
+            ],
+            values=[
+                WhirlValueRecord(
+                    name="hidden_states",
+                    handle=hidden.value,
+                    type_name="llama2_multi_pu_hidden_type",
+                    value_kind="formal",
+                ),
+                WhirlValueRecord(
+                    name="model_hidden",
+                    handle=model_hidden.value,
+                    type_name="llama2_multi_pu_hidden_type",
+                    value_kind="formal",
+                ),
+                WhirlValueRecord(
+                    name="norm_call_result",
+                    handle=call_result.value,
+                    type_name="llama2_multi_pu_hidden_type",
+                    value_kind="call_result",
+                ),
+            ],
+            graph_operators=[
+                WhirlOperatorRecord(
+                    name="call:TinyRMSNorm",
+                    handle=call.value,
+                    kids=["model_hidden"],
+                    attrs={
+                        "canonical_class_name": rms_definition.canonical_name,
+                        "instance_path": rms_instance,
+                        "context_identity": f"{entry_name}.{rms_instance}",
+                    },
+                )
+            ],
+            python_imports=(
+                collect_imported_python_callables(model_module)
+                if model_module is not None else ()
+            ),
+            python_class_definitions=class_definitions,
+            python_class_instances=class_instances,
+        )
+
+    def _first_instance_path(
+        self,
+        instances: Sequence[Any],
+        canonical_class_name: str,
+    ) -> str:
+        for instance in instances:
+            if (
+                instance.canonical_class_name == canonical_class_name and
+                instance.instance_path == "norm"
+            ):
+                return instance.instance_path
+        for instance in instances:
+            if instance.canonical_class_name == canonical_class_name:
+                return instance.instance_path
+        return "<unknown>"
 
     def _is_tiny_llama2_prefill_model(self, model: Any) -> bool:
         return (
@@ -1847,6 +2049,8 @@ class WhirlExportInterpreter:
         model: Any,
         module: WhirlModule,
     ) -> None:
+        if module.options.pu_mode == "multiple":
+            return
         try:
             path = inspect.getsourcefile(type(model))
             line = inspect.getsourcelines(type(model))[1]

--- a/osprey/torch2whirl/python/open64_dsc/module.py
+++ b/osprey/torch2whirl/python/open64_dsc/module.py
@@ -133,6 +133,7 @@ class WhirlModule:
         return {
             "backend": self.options.backend,
             "entry": self.options.entry,
+            "pu_mode": self.options.pu_mode,
             "model_name": self.model_name,
             "input_count": self.input_count,
             "entry_function": self.entry_function.to_manifest(),

--- a/osprey/torch2whirl/python/open64_dsc/options.py
+++ b/osprey/torch2whirl/python/open64_dsc/options.py
@@ -13,12 +13,15 @@ class WhirlExportOptions:
     model_name: Optional[str] = None
     external_data_file: Optional[str] = None
     verify: bool = True
+    pu_mode: str = "single"
 
     def __post_init__(self) -> None:
         if not self.entry:
             raise ValueError("entry must not be empty")
         if self.backend not in {"mock", "native"}:
             raise ValueError("backend must be 'mock' or 'native'")
+        if self.pu_mode != "single":
+            raise ValueError("pu_mode must be 'single' until class-PU emission exists")
         if self.external_data_file is not None:
             if not self.external_data_file:
                 raise ValueError("external_data_file must not be empty")

--- a/osprey/torch2whirl/python/open64_dsc/options.py
+++ b/osprey/torch2whirl/python/open64_dsc/options.py
@@ -20,8 +20,8 @@ class WhirlExportOptions:
             raise ValueError("entry must not be empty")
         if self.backend not in {"mock", "native"}:
             raise ValueError("backend must be 'mock' or 'native'")
-        if self.pu_mode != "single":
-            raise ValueError("pu_mode must be 'single' until class-PU emission exists")
+        if self.pu_mode not in {"single", "multiple"}:
+            raise ValueError("pu_mode must be 'single' or 'multiple'")
         if self.external_data_file is not None:
             if not self.external_data_file:
                 raise ValueError("external_data_file must not be empty")

--- a/osprey/torch2whirl/python/open64_dsc/verifier.py
+++ b/osprey/torch2whirl/python/open64_dsc/verifier.py
@@ -303,6 +303,9 @@ def _verify_graph_operators(
 ) -> None:
     produced_types: Dict[str, Optional[WhirlTensorTypeRecord]] = {}
     for operator in graph_operators:
+        if operator.name.startswith("call:"):
+            _verify_inter_pu_call(operator, value_types)
+            continue
         if operator.name not in _KNOWN_OPERATORS:
             raise WhirlVerificationError(f"unknown operator: {operator.name}")
         expected_arity = _operator_arity(operator)
@@ -322,6 +325,31 @@ def _verify_graph_operators(
         semantic_name = operator.metadata.get("semantic_name")
         if semantic_name:
             produced_types[semantic_name] = result_type
+
+
+def _verify_inter_pu_call(
+    operator: WhirlOperatorRecord,
+    value_types: Mapping[str, Optional[WhirlTensorTypeRecord]],
+) -> None:
+    callee = operator.name[len("call:"):]
+    if not callee:
+        raise WhirlVerificationError("inter-PU call callee must not be empty")
+    if not operator.kids:
+        raise WhirlVerificationError(
+            f"{operator.name} requires at least one call argument"
+        )
+    for kid in operator.kids:
+        if kid not in value_types:
+            raise WhirlVerificationError(f"unknown call operand: {kid}")
+    for key in (
+        "canonical_class_name",
+        "instance_path",
+        "context_identity",
+    ):
+        if not operator.attrs.get(key):
+            raise WhirlVerificationError(
+                f"{operator.name} missing call attribute {key}"
+            )
 
 
 def _resolve_operand_type(

--- a/osprey/torch2whirl/python/tests/driver_torch_smoke.py
+++ b/osprey/torch2whirl/python/tests/driver_torch_smoke.py
@@ -256,6 +256,7 @@ def _run_driver(
         str(model_path),
         "--entry",
         "forward",
+        "--single-pu",
     ]
     for sample_input in sample_inputs:
         command.extend(["--sample-input", sample_input])

--- a/osprey/torch2whirl/python/tests/llama2_multi_pu_native_ir_tools_smoke.py
+++ b/osprey/torch2whirl/python/tests/llama2_multi_pu_native_ir_tools_smoke.py
@@ -1,0 +1,213 @@
+"""Native process-boundary certification for tiny Llama 2 multiple-PU mode."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Optional
+
+
+def _require_torch() -> None:
+    try:
+        import torch  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "torch is required for llama2_multi_pu_native_ir_tools_smoke.py"
+        ) from exc
+
+
+def _find_driver() -> Path:
+    configured = os.environ.get("TORCH2WHIRL_DRIVER", "")
+    if configured:
+        path = Path(configured)
+        if path.is_file() and os.access(str(path), os.X_OK):
+            return path
+        raise FileNotFoundError(f"torch2whirl driver is not executable: {path}")
+
+    found = shutil.which("torch2whirl")
+    if found:
+        return Path(found)
+
+    raise FileNotFoundError("torch2whirl driver not found")
+
+
+def _find_ir_b2a() -> Optional[Path]:
+    configured = os.environ.get("OPEN64_IR_B2A", "")
+    if configured:
+        path = Path(configured)
+        if path.is_file() and os.access(str(path), os.X_OK):
+            return path
+        print(f"skip: ir_b2a is not executable: {path}")
+        return None
+
+    found = shutil.which("ir_b2a")
+    if found:
+        return Path(found)
+
+    print("skip: ir_b2a not found; set OPEN64_IR_B2A to enable smoke test")
+    return None
+
+
+def _test_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _pythonpath_env() -> dict[str, str]:
+    env = os.environ.copy()
+    current = env.get("PYTHONPATH", "")
+    pieces = [
+        current,
+        str(_test_root()),
+        str(_test_root().parent),
+    ]
+    env["PYTHONPATH"] = os.pathsep.join(piece for piece in pieces if piece)
+    return env
+
+
+def _run_driver(
+    driver: Path,
+    model_path: Path,
+    artifact: Path,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            str(driver),
+            str(model_path),
+            "--entry",
+            "forward",
+            "--backend",
+            "native",
+            "--multiple-pu",
+            "--sample-input",
+            "int-shape:1,8",
+            "--output",
+            str(artifact),
+        ],
+        check=False,
+        env=_pythonpath_env(),
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _inspect_artifact(ir_b2a: Path, artifact: Path, text_dump: Path) -> int:
+    result = subprocess.run(
+        [str(ir_b2a), "-st", "-src", str(artifact), str(text_dump)],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(result.stdout, file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        return result.returncode
+
+    text = text_dump.read_text(encoding="utf-8", errors="replace")
+    required = [
+        "llama2_model.py",
+        "FUNC_ENTRY",
+        "FUNC_ENTRY <1,50,TinyRMSNorm>",
+        "FUNC_ENTRY <1,51,TinyLlama2ForCausalLM>",
+        "IDNAME 0 <2,1,hidden_states>",
+        "IDNAME 0 <2,2,normalized_result>",
+        "IDNAME 0 <2,1,model_hidden>",
+        "IDNAME 0 <2,2,model_result>",
+        "VCALL",
+        "TinyRMSNorm",
+        "__WHIRL_DSL_CALL__",
+        "instance=norm",
+        "context=TinyLlama2ForCausalLM.norm",
+        "read_only passed_not_saved",
+        "out passed_not_saved",
+        "metadata=owner_pu=TinyRMSNorm",
+        "metadata=owner_pu=TinyLlama2ForCausalLM",
+    ]
+    missing = [needle for needle in required if needle not in text]
+    if missing:
+        print(
+            "multiple-PU ir_b2a -st -src output missed expected text: " +
+            ", ".join(missing),
+            file=sys.stderr,
+        )
+        print(text, file=sys.stderr)
+        return 1
+
+    if len(re.findall(r"FUNC_ENTRY <[^>]*Tiny", text)) != 2:
+        print("multiple-PU trace did not expose exactly two Tiny FUNC_ENTRYs",
+              file=sys.stderr)
+        return 1
+
+    if text.count("__WHIRL_DSL_CALL__") < 1:
+        print("multiple-PU trace missed logical call comment", file=sys.stderr)
+        return 1
+
+    if "OPR_DSL " in text or "MDSL " in text or "OPC_MDSL" in text:
+        print("multiple-PU trace exposed private DSL storage text",
+              file=sys.stderr)
+        return 1
+
+    return 0
+
+
+def _run_smoke(ir_b2a: Path, driver: Path, work_dir: Path) -> int:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    model_path = _test_root() / "models" / "llama2_model.py"
+    artifact = work_dir / "llama2_multi_pu.B"
+    text_dump = work_dir / "llama2_multi_pu.T"
+    driver_log = work_dir / "llama2_multi_pu_driver.log"
+    for path in (artifact, text_dump, driver_log):
+        if path.exists():
+            path.unlink()
+
+    completed = _run_driver(driver, model_path, artifact)
+    driver_log.write_text(
+        completed.stdout + completed.stderr,
+        encoding="utf-8",
+    )
+    if completed.returncode != 0:
+        print(completed.stdout, file=sys.stderr)
+        print(completed.stderr, file=sys.stderr)
+        return completed.returncode
+    if not artifact.exists() or artifact.stat().st_size == 0:
+        print("multiple-PU WHIRL artifact was not created", file=sys.stderr)
+        return 1
+
+    inspect_status = _inspect_artifact(ir_b2a, artifact, text_dump)
+    if inspect_status != 0:
+        return inspect_status
+
+    print(f"retained Llama multiple-PU artifacts: {work_dir}")
+    return 0
+
+
+def main() -> int:
+    ir_b2a = _find_ir_b2a()
+    if ir_b2a is None:
+        return 0
+    _require_torch()
+    driver = _find_driver()
+
+    artifact_dir = os.environ.get("OPEN64_DSL_TEST_ARTIFACT_DIR", "")
+    if artifact_dir:
+        status = _run_smoke(ir_b2a, Path(driver), Path(artifact_dir))
+    else:
+        with tempfile.TemporaryDirectory(
+            prefix="torch2whirl-llama2-multi-pu-native-"
+        ) as tmp:
+            status = _run_smoke(ir_b2a, Path(driver), Path(tmp))
+    if status != 0:
+        return status
+
+    print("Llama multiple-PU native ir_b2a smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/osprey/torch2whirl/python/tests/test_llama2_capture_optional.py
+++ b/osprey/torch2whirl/python/tests/test_llama2_capture_optional.py
@@ -285,6 +285,37 @@ class TinyLlama2WhirlExportOptionalTest(unittest.TestCase):
             self.assertIn("tensor_payload.0=llama2.safetensors", artifact)
             self.assertTrue((Path(temp_dir) / "llama2.safetensors").is_file())
 
+    def test_multiple_pu_export_keeps_class_call_boundary(self) -> None:
+        config = TinyLlama2Config()
+        model = create_tiny_llama2(config)
+        module = export_to_whirl(
+            model,
+            [sample_input_ids(config)],
+            WhirlExportOptions(backend="mock", pu_mode="multiple"),
+        )
+
+        self.assertEqual(
+            module.graph_source,
+            "torch.fx+llama2_multiple_pu_boundary",
+        )
+        self.assertEqual(module.entry_function.name, "TinyLlama2ForCausalLM")
+        self.assertEqual(module.operators, ["common.add", "call:TinyRMSNorm"])
+        call = module.graph_operators[0]
+        self.assertEqual(call.name, "call:TinyRMSNorm")
+        self.assertEqual(
+            call.attrs["canonical_class_name"],
+            "models.llama2_model.TinyRMSNorm",
+        )
+        self.assertEqual(call.attrs["instance_path"], "norm")
+        self.assertEqual(
+            call.attrs["context_identity"],
+            "TinyLlama2ForCausalLM.norm",
+        )
+        values = {value.name: value.value_kind for value in module.values}
+        self.assertEqual(values["hidden_states"], "formal")
+        self.assertEqual(values["model_hidden"], "formal")
+        self.assertEqual(values["norm_call_result"], "call_result")
+
     def test_int_shape_sample_input_and_source_provider(self) -> None:
         parsed = _sample_input_from_spec("int-shape:1,8")
         self.assertEqual(parsed.dtype, torch.int64)

--- a/osprey/torch2whirl/python/tests/test_open64_dsc_fx_capture_optional.py
+++ b/osprey/torch2whirl/python/tests/test_open64_dsc_fx_capture_optional.py
@@ -138,6 +138,7 @@ class Open64DscFxCaptureOptionalTest(unittest.TestCase):
                 format=mock
                 model_name=AddModule
                 entry=forward
+                pu_mode=single
                 entry_function=AddModule
                 graph_source=torch.fx
                 input_count=2
@@ -203,6 +204,7 @@ class Open64DscFxCaptureOptionalTest(unittest.TestCase):
                 format=mock
                 model_name=MatmulModule
                 entry=forward
+                pu_mode=single
                 entry_function=MatmulModule
                 graph_source=torch.fx
                 input_count=2

--- a/osprey/torch2whirl/python/tests/test_open64_dsc_fx_capture_optional.py
+++ b/osprey/torch2whirl/python/tests/test_open64_dsc_fx_capture_optional.py
@@ -55,6 +55,10 @@ class Open64DscFxCaptureOptionalTest(unittest.TestCase):
                     else self._manifest_shape(item)
                 )
                 for key, item in sorted(value.items())
+                if key not in {
+                    "python_class_definitions",
+                    "python_class_instances",
+                }
             }
         if isinstance(value, list):
             return [self._manifest_shape(item) for item in value]

--- a/osprey/torch2whirl/python/tests/test_open64_dsc_skeleton.py
+++ b/osprey/torch2whirl/python/tests/test_open64_dsc_skeleton.py
@@ -314,6 +314,11 @@ class Open64DscSkeletonTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             WhirlExportOptions(backend="unknown")
 
+    def test_options_validate_pu_mode(self) -> None:
+        self.assertEqual(WhirlExportOptions().pu_mode, "single")
+        with self.assertRaisesRegex(ValueError, "pu_mode"):
+            WhirlExportOptions(pu_mode="class")
+
     def test_options_default_to_verification_enabled(self) -> None:
         self.assertTrue(WhirlExportOptions().verify)
 

--- a/osprey/torch2whirl/python/tests/test_open64_dsc_skeleton.py
+++ b/osprey/torch2whirl/python/tests/test_open64_dsc_skeleton.py
@@ -316,6 +316,10 @@ class Open64DscSkeletonTest(unittest.TestCase):
 
     def test_options_validate_pu_mode(self) -> None:
         self.assertEqual(WhirlExportOptions().pu_mode, "single")
+        self.assertEqual(
+            WhirlExportOptions(pu_mode="multiple").pu_mode,
+            "multiple",
+        )
         with self.assertRaisesRegex(ValueError, "pu_mode"):
             WhirlExportOptions(pu_mode="class")
 

--- a/osprey/torch2whirl/scripts/run_torch_docker_test.sh
+++ b/osprey/torch2whirl/scripts/run_torch_docker_test.sh
@@ -77,7 +77,8 @@ if [ "$run_ir_tools" = 1 ]; then
         make OPEN64_DSL_TEST_ARTIFACT_DIR=/artifacts \
             python_native_ir_tools_smoke resnet_native_ir_tools_smoke \
             llama2_prefill_native_ir_tools_smoke \
-            llama2_decode_native_ir_tools_smoke
+            llama2_decode_native_ir_tools_smoke \
+            llama2_multi_pu_native_ir_tools_smoke
 fi
 
 find "$artifact_dir" -type f \

--- a/osprey/torch2whirl/torch2whirl_driver.cxx
+++ b/osprey/torch2whirl/torch2whirl_driver.cxx
@@ -74,6 +74,11 @@ T2W_DRIVER::Parse_Options (int argc, char **argv)
             return options;
         }
 
+        if (T2W_Option_Is (arg, "--single-pu")) {
+            options.single_pu = true;
+            continue;
+        }
+
         if (T2W_Option_Is (arg, "-o") || T2W_Option_Is (arg, "--output")) {
             if (!Parse_Value_Option (argc, argv, &i, argv[i],
                                      &options.output_path))
@@ -162,6 +167,8 @@ T2W_DRIVER::Run_Python_Cli (const OPTIONS &options)
     args.push_back (options.model_factory);
     args.push_back ("--backend");
     args.push_back (options.backend);
+    if (options.single_pu)
+        args.push_back ("--single-pu");
     for (const std::string &sample_input : options.sample_inputs) {
         args.push_back ("--sample-input");
         args.push_back (sample_input);
@@ -254,6 +261,7 @@ T2W_DRIVER::Print_Usage (std::ostream &stream) const
 {
     stream << "usage: torch2whirl [--help] [--version] "
            << "[--entry <name>] [--model-factory <name>] "
+           << "[--single-pu] "
            << "[--backend mock|native] --sample-input shape:<dims> "
            << "-o|--output <output.whirl> <input.py>\n";
 }

--- a/osprey/torch2whirl/torch2whirl_driver.cxx
+++ b/osprey/torch2whirl/torch2whirl_driver.cxx
@@ -75,7 +75,22 @@ T2W_DRIVER::Parse_Options (int argc, char **argv)
         }
 
         if (T2W_Option_Is (arg, "--single-pu")) {
+            if (options.multiple_pu) {
+                _err << "torch2whirl: --single-pu conflicts with "
+                     << "--multiple-pu\n";
+                return std::nullopt;
+            }
             options.single_pu = true;
+            continue;
+        }
+
+        if (T2W_Option_Is (arg, "--multiple-pu")) {
+            if (options.single_pu) {
+                _err << "torch2whirl: --multiple-pu conflicts with "
+                     << "--single-pu\n";
+                return std::nullopt;
+            }
+            options.multiple_pu = true;
             continue;
         }
 
@@ -169,6 +184,8 @@ T2W_DRIVER::Run_Python_Cli (const OPTIONS &options)
     args.push_back (options.backend);
     if (options.single_pu)
         args.push_back ("--single-pu");
+    if (options.multiple_pu)
+        args.push_back ("--multiple-pu");
     for (const std::string &sample_input : options.sample_inputs) {
         args.push_back ("--sample-input");
         args.push_back (sample_input);
@@ -261,7 +278,7 @@ T2W_DRIVER::Print_Usage (std::ostream &stream) const
 {
     stream << "usage: torch2whirl [--help] [--version] "
            << "[--entry <name>] [--model-factory <name>] "
-           << "[--single-pu] "
+           << "[--single-pu|--multiple-pu] "
            << "[--backend mock|native] --sample-input shape:<dims> "
            << "-o|--output <output.whirl> <input.py>\n";
 }

--- a/osprey/torch2whirl/torch2whirl_driver.h
+++ b/osprey/torch2whirl/torch2whirl_driver.h
@@ -33,6 +33,7 @@ private:
         std::string model_factory = "create_model";
         std::vector<std::string> sample_inputs;
         bool single_pu = false;
+        bool multiple_pu = false;
         bool show_help = false;
         bool show_version = false;
     };

--- a/osprey/torch2whirl/torch2whirl_driver.h
+++ b/osprey/torch2whirl/torch2whirl_driver.h
@@ -32,6 +32,7 @@ private:
         std::string backend = "mock";
         std::string model_factory = "create_model";
         std::vector<std::string> sample_inputs;
+        bool single_pu = false;
         bool show_help = false;
         bool show_version = false;
     };


### PR DESCRIPTION
## Summary
- Add opt-in torch2whirl --multiple-pu mode while preserving --single-pu as the default baseline.
- Bind the native opaque PU/call APIs through the frontend bridge and Python builder without exposing WN/ST/OPR_DSL internals.
- Add a retained native Llama multiple-PU smoke artifact lane proving two real FUNC_ENTRYs and an explicit TinyRMSNorm call edge.

## Validation
- make OPEN64_DSL_TEST_ARTIFACT_DIR=/artifacts llama2_multi_pu_native_ir_tools_smoke
- make OPEN64_DSL_TEST_ARTIFACT_DIR=/artifacts python_test
- separate-process ir_b2a -st -src reopen of llama2_multi_pu.B

## Review evidence
- Multiple-PU trace shows TinyRMSNorm and TinyLlama2ForCausalLM FUNC_ENTRYs.
- Trace shows VCALL TinyRMSNorm, read_only/out PARM flags, source positions, and owner_pu metadata.
- No private OPR_DSL/MDSL/OPC_MDSL spelling is exposed in the review trace.

## Notes
- develop already contains the native multiple-PU substrate via PR #82.
- imported_docs/ remains untracked and is not part of this PR.