### PR TITLE
Persist DSL PU identity and callsite metadata

### DIFF
--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1009,6 +1009,102 @@ rejects wrong formal/result counts, noncontiguous ordinals, cross-PU value
 reuse, missing returns, and call parameters whose read-only/out flags disagree
 with the published interface.
 
+#### First-class PU identity and callsite metadata
+
+The standard WHIRL call structure remains the semantic authority.  An
+`OPR_CALL` names its callee `ST`, its `PARM` kids carry ordered typed inputs and
+caller-owned result slots, and its statement `SRCPOS` identifies the source
+callsite.  Do not introduce a DSL call operator, tuple operator, or alternate
+call edge to represent Python class invocation.
+
+Python class and invocation context must become first-class *managed compiler
+metadata*, not first-class expression semantics.  In this usage,
+"first-class" means that common/com owns typed, pointer-free records and
+accessors associated directly with the native PU or `OPR_CALL`.  These records
+must survive mapped-image write/reopen, cloning, and inlining without requiring
+clients to parse comments or search result symbols.  They remain
+`CompilerMetadataIR`: they do not affect tensor type equivalence, DSL operator
+versioning, common-substrate promotion, or the target call ABI.
+
+The architectural ownership is:
+
+| Information | Authoritative representation |
+| --- | --- |
+| Callee and call edge | Native `OPR_CALL` plus callee `ST` |
+| Callable signature | PU type, ordered formals, and ordered result slots |
+| Canonical Python definition identity | PU-level source-identity metadata |
+| Python instance path | Callsite metadata attached to the `OPR_CALL` |
+| Context identity | Callsite metadata attached to the `OPR_CALL` |
+| Original source call ordinal | Callsite metadata attached to the `OPR_CALL` |
+| Source file, line, and column | Existing statement `SRCPOS` and DST |
+| Tensor result semantics | Result `TY_IDX` and `TensorDescriptorIR` |
+| `__WHIRL_DSL_CALL__` text | Compatibility and human-review projection |
+
+The fixed-row models are published in `common/com/dsl_ir_image.h`:
+
+```text
+DSL_PU_SOURCE_IDENTITY_RECORD
+  owner_pu_st
+  canonical_definition_name
+  defining_module
+  defining_file
+  defining_line
+  flags
+
+DSL_CALLSITE_METADATA_RECORD
+  owner_pu_st
+  wn_offset
+  callee_pu_st
+  instance_path
+  context_identity
+  source_call_ordinal
+  flags
+```
+
+These pointer-free rows occupy 48 bytes each and use `ST_IDX` and `STR_IDX`
+handles.  They live in the optional `.WHIRL.dsl_calls` section under
+`DSL_CALL_IMAGE_VERSION` 1; the existing `.WHIRL.dsl` version-1 layout is not
+changed.  The call identity is the validated WN image offset within its owner
+PU tree, following the common region mapping design.  Runtime WN pointers are
+held only in the in-memory association registry and never enter the file.
+Absence of `.WHIRL.dsl_calls` means legacy compatibility input, not a malformed
+image.
+
+The current result-symbol keys `dsl.call.canonical_class`,
+`dsl.call.instance_path`, `dsl.call.context_identity`, and `dsl.call.ordinal`
+remain compatibility mirrors only.  They cannot remain authoritative because
+a zero-result call has no result symbol, a multiple-result call duplicates the
+same callsite facts, and symbol replacement or inlining can detach them from
+the call.  The adjacent `__WHIRL_DSL_CALL__` comment also remains a required
+high-level `ir_b2a -st -src` projection until an explicit retirement decision;
+compiler analysis must not parse it as the primary representation.
+
+Compatibility staging is mandatory:
+
+1. **Complete.** Add PU-identity and callsite-metadata accessors plus an in-memory common/com
+   registry without changing the current mapped-image layout.
+2. **Complete.** Make compatibility accessors read the managed registry first, then accept
+   current result-symbol metadata and `__WHIRL_DSL_CALL__` input while old
+   artifacts remain supported.
+3. **Complete.** Specify pointer-free fixed rows, WN association, record ordering, cloning
+   policy, verifier rules, image-version transition, and old-image fallback
+   before changing the binary DSL image.
+4. **Complete.** Add optional-section mapped-image reader coverage.  Existing images with no PU
+   identity or callsite rows must continue to reopen and retain their current
+   semantics.
+5. **Complete.** Make the gatekeeper validate native callee/signature facts independently,
+   then validate any managed source identity and callsite rows against their
+   owning PU and `OPR_CALL`.
+6. **Complete.** Make `ir_b2a -st -src` print stable logical PU identity and callsite tables
+   while retaining the existing comment projection for human review.
+7. Define IPA and inliner behavior: cloned calls copy source provenance and
+   receive a distinct compiler call identity; inlining preserves original
+   provenance on the inlined scope while removing no metadata still referenced
+   by diagnostics or profile data.
+8. Stop duplicating call facts onto result symbols only after compatibility
+   readers, migration tests, gatekeeper checks, printing, and IPA/inliner tests
+   are complete.
+
 #### Structured regions
 
 1. Add opaque `DSL_BUILDER_REGION` and region-classifier handles.
@@ -1488,6 +1584,30 @@ full-sequence causal prompt evaluation with no KV cache.
    `lowered/decode_state.t`.  The test checks the logical v2 operators, mapped
    state rows, ordered MODIFY effects, versioned runtime calls, and absence of
    executable DSL nodes after lowering.
+
+30. [ ] Promote PU identity and callsite context to managed compiler metadata.
+
+   Stages 1 through 6 complete: common/com owns runtime and fixed-row PU
+   source-identity and callsite records; typed accessors read managed rows
+   before legacy result-symbol metadata; `.WHIRL.dsl_calls` version 1 reopens
+   through the standard mapped-image path; gatekeeper validates native WN/ST
+   associations; and `ir_b2a -st -src` prints both logical tables while
+   retaining the compatibility comment.  A pre-section `.B` artifact reopens
+   with zero managed rows and unchanged native call/comment evidence.
+
+   Preserve native `FUNC_ENTRY`, `OPR_CALL`, formals, result slots, `PARM`
+   flags, callee `ST`, and `SRCPOS` as the semantic call contract.  Do not add a
+   DSL call operator or classify Python class context as tensor state or opcode
+   attributes.
+
+   Stage this work through the accessor-first compatibility sequence in
+   "First-class PU identity and callsite metadata": add the runtime registry
+   and accessors; retain current comment and result-symbol input; publish and
+   review fixed pointer-free rows plus a dual-version mapped-image plan; add
+   gatekeeper and `ir_b2a -st -src` support; define clone/inlining behavior;
+   and retire result-symbol duplication only after old-image and transformation
+   coverage passes.  Any mapped-image record or version change is a separate
+   reviewed implementation stage, not an implication of this planning item.
 
 ### Deferred work TODO
 

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -73,14 +73,30 @@ struct dsl_builder_pu_interface {
     BOOL has_return;
 };
 
+struct dsl_builder_pu_source_identity {
+    DSL_BUILDER_PROGRAM_UNIT pu;
+    std::string canonical_definition_name;
+    std::string defining_module;
+    std::string defining_file;
+    UINT32 defining_line;
+    UINT32 flags;
+};
+
 struct dsl_builder_call_record {
     DSL_BUILDER_CALL call;
     DSL_BUILDER_PROGRAM_UNIT caller;
     DSL_BUILDER_PROGRAM_UNIT callee;
+    std::string canonical_class_name;
+    std::string instance_path;
+    std::string context_identity;
+    UINT32 call_ordinal;
+    DSL_BUILDER_SOURCE_POSITION source_position;
     std::vector<DSL_BUILDER_VALUE> results;
 };
 
 static std::vector<dsl_builder_pu_interface *> DSL_builder_pu_interfaces;
+static std::vector<dsl_builder_pu_source_identity *>
+    DSL_builder_pu_source_identities;
 static std::vector<dsl_builder_call_record *> DSL_builder_call_registry;
 
 static void
@@ -90,6 +106,8 @@ DSL_Builder_Reset_Program (void)
         delete DSL_builder_state_registry[i];
     for (UINT32 i = 0; i < DSL_builder_pu_interfaces.size(); ++i)
         delete DSL_builder_pu_interfaces[i];
+    for (UINT32 i = 0; i < DSL_builder_pu_source_identities.size(); ++i)
+        delete DSL_builder_pu_source_identities[i];
     for (UINT32 i = 0; i < DSL_builder_call_registry.size(); ++i)
         delete DSL_builder_call_registry[i];
     DSL_Builder_PU_Root = NULL;
@@ -102,6 +120,7 @@ DSL_Builder_Reset_Program (void)
     DSL_builder_value_registry.clear();
     DSL_builder_state_registry.clear();
     DSL_builder_pu_interfaces.clear();
+    DSL_builder_pu_source_identities.clear();
     DSL_builder_call_registry.clear();
     DSL_IR_Image_Reset();
     DSL_Region_Reset();
@@ -123,6 +142,16 @@ DSL_Builder_Find_Call_Record (DSL_BUILDER_CALL call)
     for (UINT32 i = 0; i < DSL_builder_call_registry.size(); ++i) {
         if (DSL_builder_call_registry[i]->call == call)
             return DSL_builder_call_registry[i];
+    }
+    return NULL;
+}
+
+static dsl_builder_pu_source_identity *
+DSL_Builder_Find_PU_Source_Identity (DSL_BUILDER_PROGRAM_UNIT pu)
+{
+    for (UINT32 i = 0; i < DSL_builder_pu_source_identities.size(); ++i) {
+        if (DSL_builder_pu_source_identities[i]->pu == pu)
+            return DSL_builder_pu_source_identities[i];
     }
     return NULL;
 }
@@ -344,6 +373,78 @@ static const char *
 DSL_Builder_Safe_String (const char *value)
 {
     return value == NULL ? "" : value;
+}
+
+BOOL
+DSL_Builder_Set_PU_Source_Identity
+        (DSL_BUILDER_PROGRAM_UNIT pu,
+         const DSL_BUILDER_PU_SOURCE_IDENTITY *identity)
+{
+    if (!DSL_Builder_PU_Is_Registered(pu) || identity == NULL ||
+        identity->canonical_definition_name == NULL ||
+        identity->canonical_definition_name[0] == '\0' ||
+        identity->defining_file == NULL || identity->defining_file[0] == '\0' ||
+        identity->defining_line == 0 ||
+        DSL_Builder_Find_PU_Source_Identity(pu) != NULL)
+        return FALSE;
+
+    DSL_PU_SOURCE_IDENTITY_RECORD image_record;
+    memset(&image_record, 0, sizeof(image_record));
+    image_record.owner_pu_st = PU_Info_proc_sym(pu);
+    image_record.canonical_definition_name =
+        Save_Str(identity->canonical_definition_name);
+    image_record.defining_module =
+        Save_Str(DSL_Builder_Safe_String(identity->defining_module));
+    image_record.defining_file = Save_Str(identity->defining_file);
+    image_record.defining_line = identity->defining_line;
+    image_record.flags = identity->flags;
+    if (DSL_Call_Image_Add_PU_Identity(&image_record) ==
+        DSL_PU_SOURCE_IDENTITY_INVALID_ID)
+        return FALSE;
+
+    dsl_builder_pu_source_identity *record =
+        new dsl_builder_pu_source_identity;
+    record->pu = pu;
+    record->canonical_definition_name = identity->canonical_definition_name;
+    record->defining_module = DSL_Builder_Safe_String
+                                  (identity->defining_module);
+    record->defining_file = identity->defining_file;
+    record->defining_line = identity->defining_line;
+    record->flags = identity->flags;
+    DSL_builder_pu_source_identities.push_back(record);
+    return TRUE;
+}
+
+BOOL
+DSL_Builder_Get_PU_Source_Identity
+        (DSL_BUILDER_PROGRAM_UNIT pu,
+         DSL_BUILDER_PU_SOURCE_IDENTITY *identity)
+{
+    if (pu == NULL || identity == NULL)
+        return FALSE;
+    DSL_PU_SOURCE_IDENTITY_RECORD image_record;
+    if (DSL_Call_Image_Find_PU_Identity
+            (PU_Info_proc_sym(pu), &image_record)) {
+        identity->canonical_definition_name =
+            Index_To_Str(image_record.canonical_definition_name);
+        identity->defining_module = Index_To_Str(image_record.defining_module);
+        identity->defining_file = Index_To_Str(image_record.defining_file);
+        identity->defining_line = image_record.defining_line;
+        identity->flags = image_record.flags;
+        return TRUE;
+    }
+    dsl_builder_pu_source_identity *record =
+        DSL_Builder_Find_PU_Source_Identity(pu);
+    if (record == NULL)
+        return FALSE;
+
+    identity->canonical_definition_name =
+        record->canonical_definition_name.c_str();
+    identity->defining_module = record->defining_module.c_str();
+    identity->defining_file = record->defining_file.c_str();
+    identity->defining_line = record->defining_line;
+    identity->flags = record->flags;
+    return TRUE;
 }
 
 static BOOL
@@ -2778,6 +2879,14 @@ DSL_Builder_Create_PU_Call
     call_record->call = call;
     call_record->caller = caller;
     call_record->callee = callee;
+    call_record->canonical_class_name = DSL_Builder_Safe_String
+                                            (callsite->canonical_class_name);
+    call_record->instance_path = DSL_Builder_Safe_String
+                                     (callsite->instance_path);
+    call_record->context_identity = DSL_Builder_Safe_String
+                                        (callsite->context_identity);
+    call_record->call_ordinal = callsite->call_ordinal;
+    call_record->source_position = callsite->source_position;
     for (UINT32 i = 0; i < result_count; ++i) {
         TY_IDX result_ty = callee_interface->results[i].ty;
         ST_IDX result_st = DSL_Builder_Create_Tensor_Result_Symbol
@@ -2834,6 +2943,24 @@ DSL_Builder_Create_PU_Call
         call_record->results.push_back(value);
     }
 
+    DSL_CALLSITE_METADATA_RECORD image_callsite;
+    memset(&image_callsite, 0, sizeof(image_callsite));
+    image_callsite.owner_pu_st = PU_Info_proc_sym(caller);
+    image_callsite.callee_pu_st = PU_Info_proc_sym(callee);
+    image_callsite.canonical_class_name = Save_Str
+        (DSL_Builder_Safe_String(callsite->canonical_class_name));
+    image_callsite.instance_path = Save_Str
+        (DSL_Builder_Safe_String(callsite->instance_path));
+    image_callsite.context_identity = Save_Str
+        (DSL_Builder_Safe_String(callsite->context_identity));
+    image_callsite.source_call_ordinal = callsite->call_ordinal;
+    if (DSL_Call_Image_Add_Callsite
+            (PU_Info_proc_sym(caller), call, &image_callsite) ==
+        DSL_CALLSITE_METADATA_INVALID_ID) {
+        delete call_record;
+        return NULL;
+    }
+
     std::string comment_text = "__WHIRL_DSL_CALL__:callee=";
     comment_text += ST_name(St_Table[PU_Info_proc_sym(callee)]);
     comment_text += ";class=";
@@ -2867,6 +2994,88 @@ DSL_Builder_Get_PU_Call_Result
         return FALSE;
     *value = record->results[ordinal];
     return TRUE;
+}
+
+BOOL
+DSL_Builder_Get_PU_Callsite_Info
+        (DSL_BUILDER_CALL call,
+         DSL_BUILDER_CALLSITE_INFO *callsite)
+{
+    if (call == NULL || callsite == NULL || WN_operator(call) != OPR_CALL)
+        return FALSE;
+
+    dsl_builder_call_record *record = DSL_Builder_Find_Call_Record(call);
+    DSL_CALLSITE_METADATA_RECORD image_record;
+    if (DSL_Call_Image_Find_Callsite(call, &image_record)) {
+        callsite->canonical_class_name =
+            Index_To_Str(image_record.canonical_class_name);
+        callsite->instance_path = Index_To_Str(image_record.instance_path);
+        callsite->context_identity = Index_To_Str(image_record.context_identity);
+        callsite->call_ordinal = image_record.source_call_ordinal;
+        SRCPOS source_position = WN_Get_Linenum(call);
+        callsite->source_position.file_id = SRCPOS_filenum(source_position);
+        callsite->source_position.line = SRCPOS_linenum(source_position);
+        callsite->source_position.column = SRCPOS_column(source_position);
+        callsite->source_position.statement_begin =
+            SRCPOS_stmt_begin(source_position);
+        callsite->source_position.basic_block_begin =
+            SRCPOS_bb_begin(source_position);
+        return TRUE;
+    }
+    if (record != NULL) {
+        callsite->canonical_class_name =
+            record->canonical_class_name.c_str();
+        callsite->instance_path = record->instance_path.c_str();
+        callsite->context_identity = record->context_identity.c_str();
+        callsite->call_ordinal = record->call_ordinal;
+        callsite->source_position = record->source_position;
+        return TRUE;
+    }
+
+    for (UINT32 i = 0; i < WN_kid_count(call); ++i) {
+        WN *parm = WN_kid(call, i);
+        if (parm == NULL || WN_operator(parm) != OPR_PARM ||
+            !WN_Parm_Out(parm))
+            continue;
+        WN *address = WN_kid0(parm);
+        if (address == NULL || WN_operator(address) != OPR_LDA)
+            continue;
+        ST_IDX result_st = WN_st_idx(address);
+        if (ST_IDX_index(result_st) == 0)
+            continue;
+        const char *canonical_class =
+            ST_tensor_metadata(result_st, "dsl.call.canonical_class");
+        const char *instance_path =
+            ST_tensor_metadata(result_st, "dsl.call.instance_path");
+        const char *context_identity =
+            ST_tensor_metadata(result_st, "dsl.call.context_identity");
+        const char *ordinal =
+            ST_tensor_metadata(result_st, "dsl.call.ordinal");
+        if (canonical_class == NULL || instance_path == NULL ||
+            context_identity == NULL || ordinal == NULL || ordinal[0] == '\0')
+            continue;
+
+        char *ordinal_end = NULL;
+        unsigned long parsed_ordinal = strtoul(ordinal, &ordinal_end, 10);
+        if (ordinal_end == NULL || ordinal_end[0] != '\0' ||
+            parsed_ordinal > (unsigned long)~(UINT32)0)
+            continue;
+
+        callsite->canonical_class_name = canonical_class;
+        callsite->instance_path = instance_path;
+        callsite->context_identity = context_identity;
+        callsite->call_ordinal = (UINT32)parsed_ordinal;
+        SRCPOS source_position = WN_Get_Linenum(call);
+        callsite->source_position.file_id = SRCPOS_filenum(source_position);
+        callsite->source_position.line = SRCPOS_linenum(source_position);
+        callsite->source_position.column = SRCPOS_column(source_position);
+        callsite->source_position.statement_begin =
+            SRCPOS_stmt_begin(source_position);
+        callsite->source_position.basic_block_begin =
+            SRCPOS_bb_begin(source_position);
+        return TRUE;
+    }
+    return FALSE;
 }
 
 UINT32

--- a/osprey/common/com/dsl_builder.h
+++ b/osprey/common/com/dsl_builder.h
@@ -100,6 +100,16 @@ typedef enum {
 } DSL_BUILDER_PU_RESULT_ROLE;
 
 typedef struct {
+    const char *canonical_definition_name;
+    const char *defining_module;
+    const char *defining_file;
+    UINT32 defining_line;
+    UINT32 flags;
+} DSL_BUILDER_PU_SOURCE_IDENTITY;
+
+/* String pointers returned by Get APIs remain valid until program reset. */
+
+typedef struct {
     const char *canonical_class_name;
     const char *instance_path;
     const char *context_identity;
@@ -215,6 +225,13 @@ extern void DSL_Builder_Abort_Program (void);
 extern DSL_BUILDER_PROGRAM_UNIT DSL_Builder_Create_Minimal_PU
                                 (const char *name);
 extern BOOL DSL_Builder_Select_PU (DSL_BUILDER_PROGRAM_UNIT pu);
+extern BOOL DSL_Builder_Set_PU_Source_Identity
+                                (DSL_BUILDER_PROGRAM_UNIT pu,
+                                 const DSL_BUILDER_PU_SOURCE_IDENTITY
+                                     *identity);
+extern BOOL DSL_Builder_Get_PU_Source_Identity
+                                (DSL_BUILDER_PROGRAM_UNIT pu,
+                                 DSL_BUILDER_PU_SOURCE_IDENTITY *identity);
 extern DSL_BUILDER_VALUE DSL_Builder_Declare_PU_Formal
                                 (DSL_BUILDER_PROGRAM_UNIT pu,
                                  const char *name,
@@ -246,6 +263,9 @@ extern BOOL DSL_Builder_Get_PU_Call_Result
                                 (DSL_BUILDER_CALL call,
                                  UINT32 ordinal,
                                  DSL_BUILDER_VALUE *value);
+extern BOOL DSL_Builder_Get_PU_Callsite_Info
+                                (DSL_BUILDER_CALL call,
+                                 DSL_BUILDER_CALLSITE_INFO *callsite);
 extern UINT32 DSL_Builder_Register_Source_File
                                 (DSL_BUILDER_PROGRAM_UNIT pu,
                                  const char *path);

--- a/osprey/common/com/dsl_gatekeeper.cxx
+++ b/osprey/common/com/dsl_gatekeeper.cxx
@@ -1766,6 +1766,10 @@ DSL_Gatekeeper_Verify_PU
         valid = FALSE;
         ++context.result.error_count;
     }
+    if (!DSL_Call_Image_Validate(diagnostic)) {
+        valid = FALSE;
+        ++context.result.error_count;
+    }
     if (pu == NULL || PU_Info_state(pu, WT_TREE) != Subsect_InMem ||
         PU_Info_tree_ptr(pu) == NULL)
         valid = DSL_Gatekeeper_Report
@@ -1798,6 +1802,10 @@ DSL_Gatekeeper_Verify_Program
     if (!valid)
         ++context.result.error_count;
     if (!DSL_Effect_Image_Validate(diagnostic)) {
+        valid = FALSE;
+        ++context.result.error_count;
+    }
+    if (!DSL_Call_Image_Validate(diagnostic)) {
         valid = FALSE;
         ++context.result.error_count;
     }

--- a/osprey/common/com/dsl_ir_image.cxx
+++ b/osprey/common/com/dsl_ir_image.cxx
@@ -3,11 +3,17 @@
  */
 
 #include <string.h>
+#include <vector>
 
 #include "dsl_ir_image.h"
 #include "dsl_opcode.h"
 #include "segmented_array.h"
 #include "strtab.h"
+
+typedef struct wn_map_tab WN_MAP_TAB;
+extern WN_MAP_TAB *Current_Map_Tab;
+extern "C" INT32 IPA_WN_MAP32_Get (WN_MAP_TAB *maptab, WN_MAP wn_map,
+                                    const WN *wn);
 
 typedef SEGMENTED_ARRAY<DSL_IR_OPCODE_DESCRIPTOR_RECORD>
     DSL_IR_OPCODE_DESCRIPTOR_TABLE;
@@ -18,6 +24,10 @@ typedef SEGMENTED_ARRAY<DSL_IR_VALUE_REFERENCE_RECORD>
     DSL_IR_VALUE_REFERENCE_TABLE;
 typedef SEGMENTED_ARRAY<DSL_STATE_OBJECT_RECORD> DSL_STATE_OBJECT_TABLE;
 typedef SEGMENTED_ARRAY<DSL_STATE_EFFECT_RECORD> DSL_STATE_EFFECT_TABLE;
+typedef SEGMENTED_ARRAY<DSL_PU_SOURCE_IDENTITY_RECORD>
+    DSL_PU_SOURCE_IDENTITY_TABLE;
+typedef SEGMENTED_ARRAY<DSL_CALLSITE_METADATA_RECORD>
+    DSL_CALLSITE_METADATA_TABLE;
 
 static DSL_IR_OPCODE_DESCRIPTOR_TABLE DSL_ir_opcode_descriptor_table;
 static DSL_IR_NODE_TABLE DSL_ir_node_table;
@@ -26,6 +36,19 @@ static DSL_IR_VALUE_TABLE DSL_ir_value_table;
 static DSL_IR_VALUE_REFERENCE_TABLE DSL_ir_value_reference_table;
 static DSL_STATE_OBJECT_TABLE DSL_state_object_table;
 static DSL_STATE_EFFECT_TABLE DSL_state_effect_table;
+static DSL_PU_SOURCE_IDENTITY_TABLE DSL_pu_source_identity_table;
+static DSL_CALLSITE_METADATA_TABLE DSL_callsite_metadata_table;
+
+typedef struct {
+    ST_IDX owner_pu_st;
+    WN *call;
+    DSL_CALLSITE_METADATA_ID id;
+} DSL_CALLSITE_RUNTIME_ASSOCIATION;
+
+static std::vector<DSL_CALLSITE_RUNTIME_ASSOCIATION>
+    DSL_callsite_runtime_associations;
+
+static BOOL DSL_IR_Image_String_Id_Valid (STR_IDX id, BOOL required);
 
 typedef struct {
     const DSL_IR_IMAGE_HEADER *header;
@@ -56,6 +79,14 @@ typedef char DSL_State_Object_Size_Check
     [sizeof(DSL_STATE_OBJECT_RECORD) == DSL_STATE_OBJECT_RECORD_SIZE ? 1 : -1];
 typedef char DSL_State_Effect_Size_Check
     [sizeof(DSL_STATE_EFFECT_RECORD) == DSL_STATE_EFFECT_RECORD_SIZE ? 1 : -1];
+typedef char DSL_Call_Image_Header_Size_Check
+    [sizeof(DSL_CALL_IMAGE_HEADER) == DSL_CALL_IMAGE_HEADER_SIZE ? 1 : -1];
+typedef char DSL_PU_Source_Identity_Size_Check
+    [sizeof(DSL_PU_SOURCE_IDENTITY_RECORD) ==
+        DSL_PU_SOURCE_IDENTITY_RECORD_SIZE ? 1 : -1];
+typedef char DSL_Callsite_Metadata_Size_Check
+    [sizeof(DSL_CALLSITE_METADATA_RECORD) ==
+        DSL_CALLSITE_METADATA_RECORD_SIZE ? 1 : -1];
 
 template <typename RECORD>
 static void
@@ -87,6 +118,285 @@ DSL_IR_Image_Reset (void)
     DSL_ir_value_reference_table.Delete_down_to(0);
     DSL_state_object_table.Delete_down_to(0);
     DSL_state_effect_table.Delete_down_to(0);
+    DSL_Call_Image_Reset();
+}
+
+static BOOL
+DSL_Call_Image_Report (FILE *diagnostic, const char *message, UINT32 id)
+{
+    if (diagnostic != NULL)
+        fprintf(diagnostic, "DSL call image error: %s id=%u\n", message, id);
+    return FALSE;
+}
+
+void
+DSL_Call_Image_Get_Header (DSL_CALL_IMAGE_HEADER *header)
+{
+    if (header == NULL)
+        return;
+    memset(header, 0, sizeof(*header));
+    header->magic = DSL_CALL_IMAGE_MAGIC;
+    header->version = DSL_CALL_IMAGE_VERSION;
+    header->pu_identity_count = DSL_pu_source_identity_table.Size();
+    header->callsite_count = DSL_callsite_metadata_table.Size();
+}
+
+void
+DSL_Call_Image_Reset (void)
+{
+    DSL_pu_source_identity_table.Delete_down_to(0);
+    DSL_callsite_metadata_table.Delete_down_to(0);
+    DSL_callsite_runtime_associations.clear();
+}
+
+BOOL
+DSL_Call_Image_Has_Records (void)
+{
+    return DSL_pu_source_identity_table.Size() != 0 ||
+           DSL_callsite_metadata_table.Size() != 0;
+}
+
+static BOOL
+DSL_Call_Image_Call_Has_Association (UINT32 id)
+{
+    for (UINT32 i = 0; i < DSL_callsite_runtime_associations.size(); ++i) {
+        if (DSL_callsite_runtime_associations[i].id == id &&
+            DSL_callsite_runtime_associations[i].call != NULL)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+static BOOL
+DSL_Call_Image_Association_Valid
+        (const DSL_CALLSITE_METADATA_RECORD &record)
+{
+    for (UINT32 i = 0; i < DSL_callsite_runtime_associations.size(); ++i) {
+        const DSL_CALLSITE_RUNTIME_ASSOCIATION &association =
+            DSL_callsite_runtime_associations[i];
+        if (association.id != record.id)
+            continue;
+        return ST_IDX_index(association.owner_pu_st) != 0 &&
+               association.call != NULL &&
+               association.owner_pu_st == record.owner_pu_st;
+    }
+    return record.wn_offset != 0;
+}
+
+BOOL
+DSL_Call_Image_Validate (FILE *diagnostic)
+{
+    for (UINT32 i = 0; i < DSL_pu_source_identity_table.Size(); ++i) {
+        const DSL_PU_SOURCE_IDENTITY_RECORD &record =
+            DSL_pu_source_identity_table[i];
+        if (record.id != i + 1 || ST_IDX_index(record.owner_pu_st) == 0 ||
+            !DSL_IR_Image_String_Id_Valid
+                 (record.canonical_definition_name, TRUE) ||
+            !DSL_IR_Image_String_Id_Valid(record.defining_module, FALSE) ||
+            !DSL_IR_Image_String_Id_Valid(record.defining_file, TRUE) ||
+            record.defining_line == 0 || record.reserved != 0)
+            return DSL_Call_Image_Report
+                       (diagnostic, "invalid PU identity", i + 1);
+        for (UINT32 j = 0; j < i; ++j) {
+            if (DSL_pu_source_identity_table[j].owner_pu_st ==
+                record.owner_pu_st)
+                return DSL_Call_Image_Report
+                           (diagnostic, "duplicate PU identity", i + 1);
+        }
+    }
+    for (UINT32 i = 0; i < DSL_callsite_metadata_table.Size(); ++i) {
+        const DSL_CALLSITE_METADATA_RECORD &record =
+            DSL_callsite_metadata_table[i];
+        if (record.id != i + 1 || ST_IDX_index(record.owner_pu_st) == 0 ||
+            ST_IDX_index(record.callee_pu_st) == 0 ||
+            !DSL_IR_Image_String_Id_Valid
+                 (record.canonical_class_name, TRUE) ||
+            !DSL_IR_Image_String_Id_Valid(record.instance_path, TRUE) ||
+            !DSL_IR_Image_String_Id_Valid(record.context_identity, TRUE) ||
+            (record.wn_offset == 0 &&
+             !DSL_Call_Image_Call_Has_Association(record.id)) ||
+            !DSL_Call_Image_Association_Valid(record))
+            return DSL_Call_Image_Report
+                       (diagnostic, "invalid callsite", i + 1);
+    }
+    return TRUE;
+}
+
+DSL_PU_SOURCE_IDENTITY_ID
+DSL_Call_Image_Add_PU_Identity
+        (const DSL_PU_SOURCE_IDENTITY_RECORD *record)
+{
+    if (record == NULL || ST_IDX_index(record->owner_pu_st) == 0 ||
+        record->canonical_definition_name == STR_IDX_ZERO ||
+        record->defining_file == STR_IDX_ZERO || record->defining_line == 0)
+        return DSL_PU_SOURCE_IDENTITY_INVALID_ID;
+    DSL_PU_SOURCE_IDENTITY_RECORD copy = *record;
+    UINT32 index = DSL_pu_source_identity_table.Insert(copy);
+    DSL_pu_source_identity_table[index].id = index + 1;
+    if (!DSL_Call_Image_Validate(NULL)) {
+        DSL_pu_source_identity_table.Delete_down_to(index);
+        return DSL_PU_SOURCE_IDENTITY_INVALID_ID;
+    }
+    return index + 1;
+}
+
+DSL_CALLSITE_METADATA_ID
+DSL_Call_Image_Add_Callsite
+        (ST_IDX owner_pu_st, WN *call,
+         const DSL_CALLSITE_METADATA_RECORD *record)
+{
+    if (ST_IDX_index(owner_pu_st) == 0 || call == NULL || record == NULL ||
+        record->owner_pu_st != owner_pu_st ||
+        ST_IDX_index(record->callee_pu_st) == 0)
+        return DSL_CALLSITE_METADATA_INVALID_ID;
+    DSL_CALLSITE_METADATA_RECORD copy = *record;
+    UINT32 index = DSL_callsite_metadata_table.Insert(copy);
+    DSL_callsite_metadata_table[index].id = index + 1;
+    DSL_CALLSITE_RUNTIME_ASSOCIATION association;
+    association.owner_pu_st = owner_pu_st;
+    association.call = call;
+    association.id = index + 1;
+    DSL_callsite_runtime_associations.push_back(association);
+    if (!DSL_Call_Image_Validate(NULL)) {
+        DSL_callsite_runtime_associations.pop_back();
+        DSL_callsite_metadata_table.Delete_down_to(index);
+        return DSL_CALLSITE_METADATA_INVALID_ID;
+    }
+    return index + 1;
+}
+
+BOOL
+DSL_Call_Image_Find_PU_Identity
+        (ST_IDX owner_pu_st, DSL_PU_SOURCE_IDENTITY_RECORD *record)
+{
+    for (UINT32 i = 0; i < DSL_pu_source_identity_table.Size(); ++i) {
+        if (DSL_pu_source_identity_table[i].owner_pu_st == owner_pu_st)
+            return DSL_IR_Table_Get
+                       (DSL_pu_source_identity_table, i + 1, record);
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_Call_Image_Find_Callsite
+        (const WN *call, DSL_CALLSITE_METADATA_RECORD *record)
+{
+    for (UINT32 i = 0; i < DSL_callsite_runtime_associations.size(); ++i) {
+        const DSL_CALLSITE_RUNTIME_ASSOCIATION &association =
+            DSL_callsite_runtime_associations[i];
+        if (association.call == call)
+            return DSL_IR_Table_Get
+                       (DSL_callsite_metadata_table, association.id, record);
+    }
+    return FALSE;
+}
+
+UINT32 DSL_Call_Image_PU_Identity_Count (void)
+{ return DSL_pu_source_identity_table.Size(); }
+
+UINT32 DSL_Call_Image_Callsite_Count (void)
+{ return DSL_callsite_metadata_table.Size(); }
+
+BOOL DSL_Call_Image_Get_PU_Identity
+        (DSL_PU_SOURCE_IDENTITY_ID id, DSL_PU_SOURCE_IDENTITY_RECORD *record)
+{ return DSL_IR_Table_Get(DSL_pu_source_identity_table, id, record); }
+
+BOOL DSL_Call_Image_Get_Callsite
+        (DSL_CALLSITE_METADATA_ID id, DSL_CALLSITE_METADATA_RECORD *record)
+{ return DSL_IR_Table_Get(DSL_callsite_metadata_table, id, record); }
+
+BOOL
+DSL_Call_Image_PU_Has_Calls (ST_IDX owner_pu_st)
+{
+    if (ST_IDX_index(owner_pu_st) == 0)
+        return FALSE;
+    for (UINT32 i = 0; i < DSL_callsite_metadata_table.Size(); ++i) {
+        if (DSL_callsite_metadata_table[i].owner_pu_st == owner_pu_st)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_Call_Image_Finalize_PU (ST_IDX owner_pu_st, WN_MAP off_map)
+{
+    if (!DSL_Call_Image_PU_Has_Calls(owner_pu_st))
+        return TRUE;
+    if (off_map == (WN_MAP)-1)
+        return FALSE;
+    for (UINT32 i = 0; i < DSL_callsite_runtime_associations.size(); ++i) {
+        DSL_CALLSITE_RUNTIME_ASSOCIATION &association =
+            DSL_callsite_runtime_associations[i];
+        if (association.owner_pu_st != owner_pu_st)
+            continue;
+        UINT32 offset = IPA_WN_MAP32_Get
+                            (Current_Map_Tab, off_map, association.call);
+        if (offset == 0)
+            return FALSE;
+        DSL_callsite_metadata_table[association.id - 1].wn_offset = offset;
+    }
+    return DSL_Call_Image_Validate(NULL);
+}
+
+BOOL
+DSL_Call_Image_Load_PU
+        (ST_IDX owner_pu_st, const void *tree_base, UINT64 tree_size)
+{
+    if (ST_IDX_index(owner_pu_st) == 0 || tree_base == NULL || tree_size == 0)
+        return FALSE;
+    for (UINT32 i = 0; i < DSL_callsite_metadata_table.Size(); ++i) {
+        const DSL_CALLSITE_METADATA_RECORD &record =
+            DSL_callsite_metadata_table[i];
+        if (record.owner_pu_st != owner_pu_st)
+            continue;
+        if (record.wn_offset == 0 || record.wn_offset >= tree_size)
+            return FALSE;
+        WN *call = (WN *)((const char *)tree_base + record.wn_offset);
+        DSL_CALLSITE_RUNTIME_ASSOCIATION association;
+        association.owner_pu_st = owner_pu_st;
+        association.call = call;
+        association.id = record.id;
+        DSL_callsite_runtime_associations.push_back(association);
+    }
+    return TRUE;
+}
+
+BOOL
+DSL_Call_Image_Load_Mapped
+        (const void *section_base, UINT64 section_size, FILE *diagnostic)
+{
+    if (section_base == NULL || section_size < DSL_CALL_IMAGE_HEADER_SIZE)
+        return DSL_Call_Image_Report(diagnostic, "section is truncated", 0);
+    const DSL_CALL_IMAGE_HEADER *header =
+        (const DSL_CALL_IMAGE_HEADER *)section_base;
+    UINT64 expected = DSL_CALL_IMAGE_HEADER_SIZE +
+        (UINT64)header->pu_identity_count *
+            DSL_PU_SOURCE_IDENTITY_RECORD_SIZE +
+        (UINT64)header->callsite_count * DSL_CALLSITE_METADATA_RECORD_SIZE;
+    if (header->magic != DSL_CALL_IMAGE_MAGIC ||
+        header->version != DSL_CALL_IMAGE_VERSION || header->flags != 0 ||
+        header->reserved != 0 || expected != section_size)
+        return DSL_Call_Image_Report(diagnostic, "invalid header", 0);
+    const char *cursor = (const char *)section_base +
+                         DSL_CALL_IMAGE_HEADER_SIZE;
+    const DSL_PU_SOURCE_IDENTITY_RECORD *identities =
+        (const DSL_PU_SOURCE_IDENTITY_RECORD *)cursor;
+    cursor += (UINT64)header->pu_identity_count *
+              DSL_PU_SOURCE_IDENTITY_RECORD_SIZE;
+    const DSL_CALLSITE_METADATA_RECORD *calls =
+        (const DSL_CALLSITE_METADATA_RECORD *)cursor;
+    DSL_Call_Image_Reset();
+    if (header->pu_identity_count != 0)
+        DSL_pu_source_identity_table.Insert
+            (identities, header->pu_identity_count);
+    if (header->callsite_count != 0)
+        DSL_callsite_metadata_table.Insert(calls, header->callsite_count);
+    if (!DSL_Call_Image_Validate(diagnostic)) {
+        DSL_pu_source_identity_table.Delete_down_to(0);
+        DSL_callsite_metadata_table.Delete_down_to(0);
+        return FALSE;
+    }
+    return TRUE;
 }
 
 void

--- a/osprey/common/com/dsl_ir_image.h
+++ b/osprey/common/com/dsl_ir_image.h
@@ -10,6 +10,9 @@
 #include "defs.h"
 #include "symtab_idx.h"
 
+class WN;
+typedef INT32 WN_MAP;
+
 /*
  * Source-level DSL fixed-row image model.
  *
@@ -37,6 +40,12 @@
 #define DSL_STATE_OBJECT_RECORD_SIZE        40
 #define DSL_STATE_EFFECT_RECORD_SIZE        24
 
+#define DSL_CALL_IMAGE_MAGIC                0x44534c43
+#define DSL_CALL_IMAGE_VERSION              1
+#define DSL_CALL_IMAGE_HEADER_SIZE          24
+#define DSL_PU_SOURCE_IDENTITY_RECORD_SIZE  48
+#define DSL_CALLSITE_METADATA_RECORD_SIZE   48
+
 #define DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID 0
 #define DSL_IR_NODE_INVALID_ID              0
 #define DSL_IR_ATTRIBUTE_INVALID_ID         0
@@ -50,9 +59,45 @@ typedef UINT32 DSL_IR_VALUE_ID;
 typedef UINT32 DSL_IR_VALUE_REFERENCE_ID;
 typedef UINT32 DSL_STATE_OBJECT_ID;
 typedef UINT32 DSL_STATE_EFFECT_ID;
+typedef UINT32 DSL_PU_SOURCE_IDENTITY_ID;
+typedef UINT32 DSL_CALLSITE_METADATA_ID;
 
 #define DSL_STATE_OBJECT_INVALID_ID 0
 #define DSL_STATE_EFFECT_INVALID_ID 0
+#define DSL_PU_SOURCE_IDENTITY_INVALID_ID 0
+#define DSL_CALLSITE_METADATA_INVALID_ID 0
+
+typedef struct {
+    UINT32 magic;
+    UINT32 version;
+    UINT32 pu_identity_count;
+    UINT32 callsite_count;
+    UINT32 flags;
+    UINT32 reserved;
+} DSL_CALL_IMAGE_HEADER;
+
+typedef struct {
+    DSL_PU_SOURCE_IDENTITY_ID id;
+    UINT32 flags;
+    ST_IDX owner_pu_st;
+    STR_IDX canonical_definition_name;
+    STR_IDX defining_module;
+    STR_IDX defining_file;
+    UINT32 defining_line;
+    UINT32 reserved;
+} DSL_PU_SOURCE_IDENTITY_RECORD;
+
+typedef struct {
+    DSL_CALLSITE_METADATA_ID id;
+    UINT32 wn_offset;
+    ST_IDX owner_pu_st;
+    ST_IDX callee_pu_st;
+    STR_IDX canonical_class_name;
+    STR_IDX instance_path;
+    STR_IDX context_identity;
+    UINT32 source_call_ordinal;
+    UINT32 flags;
+} DSL_CALLSITE_METADATA_RECORD;
 
 typedef enum {
     DSL_IR_IMAGE_RECORD_UNKNOWN = 0,
@@ -230,6 +275,38 @@ extern void DSL_IR_Image_Print (FILE *file);
 extern BOOL DSL_IR_Image_Load_Mapped (const void *section_base,
                                       UINT64 section_size,
                                       FILE *diagnostic);
+
+extern void DSL_Call_Image_Get_Header (DSL_CALL_IMAGE_HEADER *header);
+extern void DSL_Call_Image_Reset (void);
+extern BOOL DSL_Call_Image_Has_Records (void);
+extern BOOL DSL_Call_Image_Validate (FILE *diagnostic);
+extern BOOL DSL_Call_Image_Load_Mapped (const void *section_base,
+                                        UINT64 section_size,
+                                        FILE *diagnostic);
+extern DSL_PU_SOURCE_IDENTITY_ID DSL_Call_Image_Add_PU_Identity
+                                (const DSL_PU_SOURCE_IDENTITY_RECORD *record);
+extern DSL_CALLSITE_METADATA_ID DSL_Call_Image_Add_Callsite
+                                (ST_IDX owner_pu_st, WN *call,
+                                 const DSL_CALLSITE_METADATA_RECORD *record);
+extern BOOL DSL_Call_Image_Find_PU_Identity
+                                (ST_IDX owner_pu_st,
+                                 DSL_PU_SOURCE_IDENTITY_RECORD *record);
+extern BOOL DSL_Call_Image_Find_Callsite
+                                (const WN *call,
+                                 DSL_CALLSITE_METADATA_RECORD *record);
+extern UINT32 DSL_Call_Image_PU_Identity_Count (void);
+extern UINT32 DSL_Call_Image_Callsite_Count (void);
+extern BOOL DSL_Call_Image_Get_PU_Identity
+                                (DSL_PU_SOURCE_IDENTITY_ID id,
+                                 DSL_PU_SOURCE_IDENTITY_RECORD *record);
+extern BOOL DSL_Call_Image_Get_Callsite
+                                (DSL_CALLSITE_METADATA_ID id,
+                                 DSL_CALLSITE_METADATA_RECORD *record);
+extern BOOL DSL_Call_Image_PU_Has_Calls (ST_IDX owner_pu_st);
+extern BOOL DSL_Call_Image_Finalize_PU (ST_IDX owner_pu_st, WN_MAP off_map);
+extern BOOL DSL_Call_Image_Load_PU (ST_IDX owner_pu_st,
+                                    const void *tree_base,
+                                    UINT64 tree_size);
 
 extern void DSL_Effect_Image_Get_Header (DSL_EFFECT_IMAGE_HEADER *header);
 extern void DSL_Effect_Image_Reset (void);

--- a/osprey/common/com/dsl_ir_print.cxx
+++ b/osprey/common/com/dsl_ir_print.cxx
@@ -221,4 +221,38 @@ DSL_IR_Image_Print (FILE *file)
                      ((DSL_STATE_EFFECT_KIND)record.effect_kind),
                  record.flags);
     }
+
+    DSL_CALL_IMAGE_HEADER call_header;
+    DSL_Call_Image_Get_Header(&call_header);
+    fprintf(file, "DSL PU Source Identity Table: version=%u entries=%u\n",
+            call_header.version, call_header.pu_identity_count);
+    for (UINT32 i = 1; i <= call_header.pu_identity_count; ++i) {
+        DSL_PU_SOURCE_IDENTITY_RECORD record;
+        DSL_Call_Image_Get_PU_Identity(i, &record);
+        fprintf(file, "  [%u] owner_pu=<%u,%u> definition=%s module=%s "
+                "file=%s line=%u flags=0x%x\n", record.id,
+                ST_IDX_level(record.owner_pu_st),
+                ST_IDX_index(record.owner_pu_st),
+                DSL_IR_String(record.canonical_definition_name),
+                DSL_IR_String(record.defining_module),
+                DSL_IR_String(record.defining_file), record.defining_line,
+                record.flags);
+    }
+    fprintf(file, "DSL Callsite Metadata Table: version=%u entries=%u\n",
+            call_header.version, call_header.callsite_count);
+    for (UINT32 i = 1; i <= call_header.callsite_count; ++i) {
+        DSL_CALLSITE_METADATA_RECORD record;
+        DSL_Call_Image_Get_Callsite(i, &record);
+        fprintf(file, "  [%u] owner_pu=<%u,%u> callee=<%u,%u> "
+                "class=%s instance=%s context=%s source_ordinal=%u "
+                "flags=0x%x\n", record.id,
+                ST_IDX_level(record.owner_pu_st),
+                ST_IDX_index(record.owner_pu_st),
+                ST_IDX_level(record.callee_pu_st),
+                ST_IDX_index(record.callee_pu_st),
+                DSL_IR_String(record.canonical_class_name),
+                DSL_IR_String(record.instance_path),
+                DSL_IR_String(record.context_identity),
+                record.source_call_ordinal, record.flags);
+    }
 }

--- a/osprey/common/com/ir_bcom.cxx
+++ b/osprey/common/com/ir_bcom.cxx
@@ -360,7 +360,8 @@ ir_b_write_tree (WN *node, off_t base_offset, Output_File *fl, WN_MAP off_map)
 
     opcode = (OPCODE) WN_opcode (node);
 
-    if (off_map != WN_MAP_UNDEFINED && WN_operator(node) == OPR_REGION)
+    if (off_map != WN_MAP_UNDEFINED &&
+        (WN_operator(node) == OPR_REGION || WN_operator(node) == OPR_CALL))
         WN_MAP32_Set(off_map, node, node_offset - base_offset);
 
 #ifdef BACK_END

--- a/osprey/common/com/ir_bread.cxx
+++ b/osprey/common/com/ir_bread.cxx
@@ -468,6 +468,21 @@ WN_get_dsl_effect_image (void *handle)
                (section_base, shdr.size, stderr) ? 0 : -1;
 }
 
+INT
+WN_get_dsl_callsite_image (void *handle)
+{
+    OFFSET_AND_SIZE shdr = get_section
+                               (handle, SHT_MIPS_WHIRL,
+                                WT_DSL_CALLSITE_IMAGE);
+    if (shdr.offset == 0) {
+        DSL_Call_Image_Reset();
+        return 0;
+    }
+    const void *section_base = (const char *)handle + shdr.offset;
+    return DSL_Call_Image_Load_Mapped
+               (section_base, shdr.size, stderr) ? 0 : -1;
+}
+
 /*
  *  Note: get SSA info from file into memory 
  */
@@ -1618,6 +1633,9 @@ Read_Global_Info (INT32 *p_num_PUs)
     if (WN_get_dsl_effect_image(global_fhandle) == -1) {
         ErrMsg (EC_IR_Scn_Read, "DSL effect image", global_ir_file);
     }
+    if (WN_get_dsl_callsite_image(global_fhandle) == -1) {
+        ErrMsg (EC_IR_Scn_Read, "DSL callsite image", global_ir_file);
+    }
 
 #if defined(KEY) && defined(BACK_END)
     WN_get_mod_ref_table (global_fhandle);
@@ -1678,6 +1696,36 @@ Read_Local_Info (MEM_POOL *pool, PU_Info *pu)
     UINT64 tree_size = PU_Info_subsect_size(pu, WT_TREE);
     if (WN_get_tree (local_fhandle, pu) == (WN*) -1) {
 	ErrMsg ( EC_IR_Scn_Read, "tree", local_ir_file);
+    }
+
+    if (DSL_Call_Image_PU_Has_Calls(PU_Info_proc_sym(pu))) {
+        OFFSET_AND_SIZE pu_section = get_section
+            (local_fhandle, SHT_MIPS_WHIRL, WT_PU_SECTION);
+        BOOL tree_range_valid = pu_section.offset != 0 &&
+            tree_offset <= pu_section.size &&
+            tree_size <= pu_section.size - tree_offset;
+        const char *tree_base = !tree_range_valid ? NULL :
+            (char *)local_fhandle + pu_section.offset + tree_offset;
+        BOOL calls_valid = tree_base != NULL;
+        for (UINT32 i = 1;
+             calls_valid && i <= DSL_Call_Image_Callsite_Count(); ++i) {
+            DSL_CALLSITE_METADATA_RECORD record;
+            if (!DSL_Call_Image_Get_Callsite(i, &record) ||
+                record.owner_pu_st != PU_Info_proc_sym(pu))
+                continue;
+            if (record.wn_offset == 0 || record.wn_offset >= tree_size) {
+                calls_valid = FALSE;
+                break;
+            }
+            WN *call = (WN *)(tree_base + record.wn_offset);
+            calls_valid = WN_operator(call) == OPR_CALL &&
+                          WN_st_idx(call) == record.callee_pu_st;
+        }
+        if (!tree_range_valid || !calls_valid ||
+            !DSL_Call_Image_Load_PU
+                 (PU_Info_proc_sym(pu),
+                  tree_base, tree_size))
+            ErrMsg (EC_IR_Scn_Read, "DSL callsites", local_ir_file);
     }
 
     if (PU_Info_state(pu, WT_REGIONS) == Subsect_Exists) {

--- a/osprey/common/com/ir_bwrite.cxx
+++ b/osprey/common/com/ir_bwrite.cxx
@@ -883,6 +883,37 @@ WN_write_dsl_effect_image (Output_File *fl)
     cur_section->shdr.sh_addralign = sizeof(mINT64);
 }
 
+void
+WN_write_dsl_callsite_image (Output_File *fl)
+{
+    if (!DSL_Call_Image_Has_Records())
+        return;
+    FmtAssert(DSL_Call_Image_Validate(stderr),
+              ("invalid DSL callsite tables"));
+    Section *cur_section = get_section
+                               (WT_DSL_CALLSITE_IMAGE,
+                                MIPS_WHIRL_DSL_CALLSITE_IMAGE, fl);
+    fl->file_size = ir_b_align(fl->file_size, sizeof(mINT64), 0);
+    cur_section->shdr.sh_offset = fl->file_size;
+    DSL_CALL_IMAGE_HEADER header;
+    DSL_Call_Image_Get_Header(&header);
+    ir_b_save_buf(&header, sizeof(header), sizeof(mINT64), 0, fl);
+    for (UINT32 i = 1; i <= header.pu_identity_count; ++i) {
+        DSL_PU_SOURCE_IDENTITY_RECORD record;
+        FmtAssert(DSL_Call_Image_Get_PU_Identity(i, &record),
+                  ("missing DSL PU identity %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    for (UINT32 i = 1; i <= header.callsite_count; ++i) {
+        DSL_CALLSITE_METADATA_RECORD record;
+        FmtAssert(DSL_Call_Image_Get_Callsite(i, &record),
+                  ("missing DSL callsite %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    cur_section->shdr.sh_size = fl->file_size - cur_section->shdr.sh_offset;
+    cur_section->shdr.sh_addralign = sizeof(mINT64);
+}
+
 
 /*
  * Write out the debug symbol table (dst).  The DST gets its own Elf
@@ -1616,7 +1647,9 @@ Write_PU_Info (PU_Info *pu)
 
     WN_MAP off_map = WN_MAP_UNDEFINED;
     BOOL region_map = PU_Info_state(pu, WT_REGIONS) == Subsect_InMem;
-    BOOL need_off_map = region_map;
+    BOOL callsite_map =
+        DSL_Call_Image_PU_Has_Calls(PU_Info_proc_sym(pu));
+    BOOL need_off_map = region_map || callsite_map;
 
     WN_write_symtab (pu, ir_output);
 
@@ -1635,6 +1668,10 @@ Write_PU_Info (PU_Info *pu)
     }
 
     WN_write_tree (pu, off_map, ir_output);
+
+    if (callsite_map &&
+        !DSL_Call_Image_Finalize_PU(PU_Info_proc_sym(pu), off_map))
+        ErrMsg (EC_IR_Scn_Write, "DSL callsites", ir_output->file_name);
 
     if (region_map && !DSL_Region_Write_PU(pu, off_map, ir_output))
         ErrMsg (EC_IR_Scn_Write, "regions", ir_output->file_name);
@@ -1700,6 +1737,7 @@ Write_Global_Info (PU_Info *pu_tree)
 
     WN_write_dsl_ir_image(ir_output);
     WN_write_dsl_effect_image(ir_output);
+    WN_write_dsl_callsite_image(ir_output);
 
     WN_write_strtab(Index_To_Str (0), STR_Table_Size (), ir_output);
 

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -3491,6 +3491,9 @@ Check_Multiple_Program_Units(void)
     DSL_BUILDER_VALUE call_result;
     DSL_BUILDER_CALL call;
     DSL_BUILDER_CALLSITE_INFO callsite;
+    DSL_BUILDER_CALLSITE_INFO observed_callsite;
+    DSL_BUILDER_PU_SOURCE_IDENTITY source_identity;
+    DSL_BUILDER_PU_SOURCE_IDENTITY observed_identity;
     DSL_BUILDER_OPERATOR_ATTRIBUTE add_attr;
     DSL_BUILDER_VALUE add_kids[2];
     const char *call_result_names[1] = { "normalized_hidden" };
@@ -3517,6 +3520,15 @@ Check_Multiple_Program_Units(void)
     first_pu = DSL_Builder_Create_Minimal_PU("TinyRMSNorm");
     UINT32 first_file = DSL_Builder_Register_Source_File
                             (first_pu, "llama2_model.py");
+    memset(&source_identity, 0, sizeof(source_identity));
+    source_identity.canonical_definition_name = "TinyRMSNorm.forward";
+    source_identity.defining_module = "llama2_model";
+    source_identity.defining_file = "llama2_model.py";
+    source_identity.defining_line = 12;
+    if (!DSL_Builder_Set_PU_Source_Identity(first_pu, &source_identity)) {
+        fprintf(stderr, "failed to attach PU source identity\n");
+        return 1;
+    }
     memset(&position, 0, sizeof(position));
     position.file_id = first_file;
     position.line = 18;
@@ -3570,15 +3582,58 @@ Check_Multiple_Program_Units(void)
     call = DSL_Builder_Create_PU_Call
                (second_pu, first_pu, &second_formal, 1,
                 call_result_names, 1, &callsite);
+    memset(&observed_identity, 0, sizeof(observed_identity));
+    memset(&observed_callsite, 0, sizeof(observed_callsite));
     second_st = DSL_Builder_Get_Value_Result_Symbol(second_formal);
     if (second_pu == NULL || second_pu == first_pu || second_file == 0 ||
         second_formal == NULL || second_result == NULL || call == NULL ||
+        !DSL_Builder_Get_PU_Source_Identity(first_pu, &observed_identity) ||
+        strcmp(observed_identity.canonical_definition_name,
+               "TinyRMSNorm.forward") != 0 ||
+        strcmp(observed_identity.defining_module, "llama2_model") != 0 ||
+        strcmp(observed_identity.defining_file, "llama2_model.py") != 0 ||
+        observed_identity.defining_line != 12 ||
+        !DSL_Builder_Get_PU_Callsite_Info(call, &observed_callsite) ||
+        strcmp(observed_callsite.canonical_class_name, "TinyRMSNorm") != 0 ||
+        strcmp(observed_callsite.instance_path, "model.norm") != 0 ||
+        strcmp(observed_callsite.context_identity,
+               "TinyLlama2ForCausalLM.norm") != 0 ||
+        observed_callsite.call_ordinal != 0 ||
+        observed_callsite.source_position.line != 74 ||
         !DSL_Builder_Get_PU_Call_Result(call, 0, &call_result) ||
         !DSL_Builder_Return_PU_Values(second_pu, &call_result, 1) ||
         DSL_Builder_Append_PU_Value(second_pu, first_formal) ||
         PU_Info_next(first_pu) != second_pu ||
         PU_Info_maptab(first_pu) == PU_Info_maptab(second_pu)) {
         fprintf(stderr, "failed to construct independent second program unit\n");
+        return 1;
+    }
+
+    ST_IDX compatibility_result_st =
+        DSL_Builder_Get_Value_Result_Symbol(call_result);
+    WN *compatibility_call = WN_Create(OPR_CALL, MTYPE_V, MTYPE_V, 1);
+    WN_st_idx(compatibility_call) = PU_Info_proc_sym(first_pu);
+    TY_IDX compatibility_pointer_ty = Make_Pointer_Type(tensor_ty);
+    WN *compatibility_address = WN_CreateLda
+                                    (OPR_LDA, Pointer_Mtype, MTYPE_V, 0,
+                                     compatibility_pointer_ty,
+                                     compatibility_result_st);
+    WN_kid0(compatibility_call) = WN_CreateParm
+                                      (Pointer_Mtype, compatibility_address,
+                                       compatibility_pointer_ty,
+                                       WN_PARM_BY_REFERENCE | WN_PARM_OUT |
+                                       WN_PARM_PASSED_NOT_SAVED);
+    WN_Set_Linenum(compatibility_call, WN_Get_Linenum(call));
+    memset(&observed_callsite, 0, sizeof(observed_callsite));
+    if (!DSL_Builder_Get_PU_Callsite_Info(compatibility_call,
+                                          &observed_callsite) ||
+        strcmp(observed_callsite.canonical_class_name, "TinyRMSNorm") != 0 ||
+        strcmp(observed_callsite.instance_path, "model.norm") != 0 ||
+        strcmp(observed_callsite.context_identity,
+               "TinyLlama2ForCausalLM.norm") != 0 ||
+        observed_callsite.call_ordinal != 0 ||
+        observed_callsite.source_position.line != 74) {
+        fprintf(stderr, "legacy callsite metadata fallback changed\n");
         return 1;
     }
 

--- a/osprey/common/com/tests/dsl_multi_pu_artifact_test.sh
+++ b/osprey/common/com/tests/dsl_multi_pu_artifact_test.sh
@@ -37,6 +37,10 @@ for evidence in \
   "by_reference  read_only passed_not_saved" \
   "by_reference  out passed_not_saved" \
   "__WHIRL_DSL_CALL__:callee=TinyRMSNorm" \
+  "DSL PU Source Identity Table: version=1 entries=1" \
+  "definition=TinyRMSNorm.forward module=llama2_model" \
+  "DSL Callsite Metadata Table: version=1 entries=1" \
+  "class=TinyRMSNorm instance=model.norm" \
   "metadata=owner_pu=TinyRMSNorm" \
   "metadata=owner_pu=TinyLlama2ForCausalLM" \
   "location: file llama2_model.py, line 18" \

--- a/osprey/include/sys/elf_whirl.h
+++ b/osprey/include/sys/elf_whirl.h
@@ -82,6 +82,7 @@
 #define WT_DSL_IR_IMAGE 0x20
 #define WT_DSL_TENSOR_DESCRIPTOR WT_DSL_IR_IMAGE
 #define WT_DSL_EFFECT_IMAGE 0x21
+#define WT_DSL_CALLSITE_IMAGE 0x22
 
 /*
  * Special WHIRL section names.
@@ -97,6 +98,7 @@
 #define MIPS_WHIRL_DSL_IR_IMAGE ".WHIRL.dsl"
 #define MIPS_WHIRL_DSL_TENSOR_DESCRIPTOR MIPS_WHIRL_DSL_IR_IMAGE
 #define MIPS_WHIRL_DSL_EFFECT_IMAGE ".WHIRL.dsl_effects"
+#define MIPS_WHIRL_DSL_CALLSITE_IMAGE ".WHIRL.dsl_calls"
 #if defined(TARG_SL)
 #define MIPS_WHIRL_CALLGRAPH    ".WHIRL.callgraph"
 #endif


### PR DESCRIPTION
## Summary

- promote Python PU identity and callsite context to typed common/com compiler metadata
- preserve native FUNC_ENTRY, OPR_CALL, callee ST, PARM flags, result slots, and SRCPOS as the semantic call contract
- add the optional `.WHIRL.dsl_calls` version-1 mapped-image section without changing the existing `.WHIRL.dsl` layout
- associate calls through validated WN image offsets within their owning PU
- expose stable PU identity and callsite evidence through `ir_b2a -st -src`
- retain result-symbol metadata and `__WHIRL_DSL_CALL__` comments as compatibility input and human-review projection

## Compatibility

Existing WHIRL and DSL images may omit `.WHIRL.dsl_calls`. The reader treats an absent section as legacy input, clears any prior managed call records, and preserves native call/comment behavior. A retained pre-section multiple-PU artifact reopens with zero managed rows.

The physical DSL operator compatibility matrix remains unchanged across x86-64, MIPS, MIPS-SL, Loongson, key-generic, and baseline configurations.

## Validation

- rebuilt `dsl_builder_contract_test` and `ir_b2a` in Linux/amd64 Docker
- passed `dsl_multi_pu_artifact_test.sh` with retained `.B` and `ir_b2a -st -src` trace
- reopened the retained pre-section `.B` artifact with the new reader
- passed the DSL native syntax and physical operator compatibility matrix
- `git diff --check` passed
- no tab characters were introduced

## Review evidence

The new trace contains two real `FUNC_ENTRY` nodes, the native `VCALL`, the preserved `__WHIRL_DSL_CALL__` projection, one `DSL PU Source Identity Table` row, and one `DSL Callsite Metadata Table` row.

## Frontend dependency

Merge this infrastructure PR before rebasing and continuing `codex/torch2whirl-python-fe`. The frontend should consume the typed opaque builder APIs and must not inspect WN layout or `.WHIRL.dsl_calls` rows directly.