### PR TITLE
Materialize DSL operator results at PU boundaries

### DIFF
--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -980,6 +980,15 @@ The native builder publishes the following opaque interfaces:
   caller-local value handle.  A callee-local value handle never crosses the PU
   boundary.
 
+Operator results are materialized in their owning PU before they are used as
+call actuals or copied to declared result slots.  The builder recursively emits
+pending operand definitions in dependency order and emits each defining
+`STID MTYPE_M` at most once.  This permits nested Python expressions to remain
+opaque builder values while ensuring that no raw expression WN or callee-local
+value handle crosses a PU boundary.  Explicit
+`DSL_Builder_Append_PU_Value()` remains compatible and is idempotent for an
+already materialized native value.
+
 Tensor inputs are passed through standard `PARM` nodes marked
 `BY_REFERENCE|READ_ONLY|PASSED_NOT_SAVED`.  Result slots are passed through
 `BY_REFERENCE|OUT|PASSED_NOT_SAVED`; the caller owns their unique no-alias

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -46,6 +46,8 @@ typedef struct {
     ST_IDX result_st;
     TY_IDX result_ty;
     DSL_IR_VALUE_ID image_value_id;
+    BOOL materializing;
+    BOOL materialized;
 } DSL_BUILDER_VALUE_RECORD;
 
 static std::vector<DSL_BUILDER_VALUE_RECORD> DSL_builder_value_registry;
@@ -265,6 +267,44 @@ DSL_Builder_PU_Body (DSL_BUILDER_PROGRAM_UNIT pu)
         return NULL;
 
     return body;
+}
+
+static BOOL
+DSL_Builder_Materialize_PU_Value
+        (DSL_BUILDER_PROGRAM_UNIT pu,
+         DSL_BUILDER_VALUE_RECORD *record)
+{
+    WN *body = DSL_Builder_PU_Body(pu);
+
+    if (body == NULL || record == NULL || record->pu != pu)
+        return FALSE;
+    if (record->materialized)
+        return TRUE;
+    if (record->materializing || record->assignment == NULL ||
+        record->expression == NULL ||
+        !DSL_Builder_Get_Value_Annotation(record->assignment, NULL))
+        return FALSE;
+
+    record->materializing = TRUE;
+    for (UINT32 i = 0; i < WN_kid_count(record->expression); ++i) {
+        WN *kid = WN_kid(record->expression, i);
+        if (kid == NULL || WN_operator(kid) != OPR_LDID) {
+            record->materializing = FALSE;
+            return FALSE;
+        }
+        DSL_BUILDER_VALUE_RECORD *dependency =
+            DSL_Builder_Find_Value_Record_By_ST(WN_st_idx(kid));
+        if (dependency == NULL ||
+            !DSL_Builder_Materialize_PU_Value(pu, dependency)) {
+            record->materializing = FALSE;
+            return FALSE;
+        }
+    }
+
+    WN_INSERT_BlockLast(body, record->assignment);
+    record->materializing = FALSE;
+    record->materialized = TRUE;
+    return TRUE;
 }
 
 static BOOL
@@ -1775,6 +1815,8 @@ DSL_Builder_Create_Native_Value
     record.result_st = result_st;
     record.result_ty = result_ty;
     record.image_value_id = image_value_id;
+    record.materializing = FALSE;
+    record.materialized = FALSE;
     DSL_builder_value_registry.push_back(record);
     return assignment;
 }
@@ -2709,6 +2751,8 @@ DSL_Builder_Declare_PU_Formal
     value_record.result_st = ST_st_idx(*st);
     value_record.result_ty = ty;
     value_record.image_value_id = image_value_id;
+    value_record.materializing = FALSE;
+    value_record.materialized = TRUE;
     DSL_builder_value_registry.push_back(value_record);
 
     dsl_builder_pu_interface_value formal;
@@ -2768,6 +2812,8 @@ DSL_Builder_Declare_PU_Result
     value_record.result_st = ST_st_idx(*st);
     value_record.result_ty = ty;
     value_record.image_value_id = image_value_id;
+    value_record.materializing = FALSE;
+    value_record.materialized = TRUE;
     DSL_builder_value_registry.push_back(value_record);
 
     dsl_builder_pu_interface_value result;
@@ -2802,6 +2848,12 @@ DSL_Builder_Return_PU_Values
             DSL_Builder_Find_Value_Record(values[i]);
         if (value_record == NULL || value_record->pu != pu ||
             value_record->result_ty != interface_record->results[i].ty)
+            return FALSE;
+    }
+    for (UINT32 i = 0; i < value_count; ++i) {
+        DSL_BUILDER_VALUE_RECORD *value_record =
+            DSL_Builder_Find_Value_Record(values[i]);
+        if (!DSL_Builder_Materialize_PU_Value(pu, value_record))
             return FALSE;
     }
     for (UINT32 i = 0; i < value_count; ++i) {
@@ -2854,6 +2906,11 @@ DSL_Builder_Create_PU_Call
     }
     for (UINT32 i = 0; i < result_count; ++i) {
         if (result_names[i] == NULL || result_names[i][0] == '\0')
+            return NULL;
+    }
+    for (UINT32 i = 0; i < argument_count; ++i) {
+        if (!DSL_Builder_Materialize_PU_Value(caller,
+                                              argument_records[i]))
             return NULL;
     }
 
@@ -2939,6 +2996,8 @@ DSL_Builder_Create_PU_Call
         value_record.result_st = result_st;
         value_record.result_ty = result_ty;
         value_record.image_value_id = image_value_id;
+        value_record.materializing = FALSE;
+        value_record.materialized = TRUE;
         DSL_builder_value_registry.push_back(value_record);
         call_record->results.push_back(value);
     }
@@ -3540,6 +3599,9 @@ DSL_Builder_Append_PU_Value
         return FALSE;
     if (!DSL_Builder_Get_Value_Annotation(value, NULL))
         return FALSE;
+
+    if (record != NULL)
+        return DSL_Builder_Materialize_PU_Value(pu, record);
 
     WN_INSERT_BlockLast(body, value);
     return TRUE;

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -3498,6 +3498,7 @@ Check_Multiple_Program_Units(void)
     DSL_BUILDER_VALUE normalized;
     DSL_BUILDER_VALUE second_formal;
     DSL_BUILDER_VALUE second_result;
+    DSL_BUILDER_VALUE call_argument;
     DSL_BUILDER_VALUE call_result;
     DSL_BUILDER_CALL call;
     DSL_BUILDER_CALLSITE_INFO callsite;
@@ -3560,13 +3561,14 @@ Check_Multiple_Program_Units(void)
     first_st = DSL_Builder_Get_Value_Result_Symbol(first_formal);
     BOOL first_position = normalized != NULL &&
         DSL_Builder_Set_Value_Source_Position(normalized, &position);
-    BOOL first_append = normalized != NULL &&
-        DSL_Builder_Append_PU_Value(first_pu, normalized);
     BOOL first_return = normalized != NULL &&
         DSL_Builder_Return_PU_Values(first_pu, &normalized, 1);
+    BOOL first_reappend = normalized != NULL &&
+        DSL_Builder_Append_PU_Value(first_pu, normalized);
     if (first_pu == NULL || first_file == 0 || first_formal == NULL ||
         first_result == NULL || normalized == NULL || !first_position ||
-        !first_append || !first_return) {
+        !first_return || !first_reappend ||
+        DSL_Builder_Count_PU_Values(first_pu) != 1) {
         fprintf(stderr, "failed to construct first program unit\n");
         return 1;
     }
@@ -3582,6 +3584,14 @@ Check_Multiple_Program_Units(void)
     second_result = DSL_Builder_Declare_PU_Result
                         (second_pu, "model_result", 0, tensor_ty,
                          DSL_PU_RESULT_TENSOR, &position);
+    add_kids[0] = second_formal;
+    add_kids[1] = second_formal;
+    call_argument = DSL_Builder_Create_Operator
+                        (DSL_Opcode_Find(DSL_Domain_Find("common"),
+                                         DSL_OPCODE_COMMON_ADD, 1),
+                         1, add_kids, 2, &add_attr, 1);
+    BOOL second_position = call_argument != NULL &&
+        DSL_Builder_Set_Value_Source_Position(call_argument, &position);
     memset(&callsite, 0, sizeof(callsite));
     callsite.canonical_class_name = "TinyRMSNorm";
     callsite.instance_path = "model.norm";
@@ -3590,13 +3600,14 @@ Check_Multiple_Program_Units(void)
     callsite.source_position = position;
     ++callsite.source_position.line;
     call = DSL_Builder_Create_PU_Call
-               (second_pu, first_pu, &second_formal, 1,
+               (second_pu, first_pu, &call_argument, 1,
                 call_result_names, 1, &callsite);
     memset(&observed_identity, 0, sizeof(observed_identity));
     memset(&observed_callsite, 0, sizeof(observed_callsite));
     second_st = DSL_Builder_Get_Value_Result_Symbol(second_formal);
     if (second_pu == NULL || second_pu == first_pu || second_file == 0 ||
         second_formal == NULL || second_result == NULL || call == NULL ||
+        call_argument == NULL || !second_position ||
         !DSL_Builder_Get_PU_Source_Identity(first_pu, &observed_identity) ||
         strcmp(observed_identity.canonical_definition_name,
                "TinyRMSNorm.forward") != 0 ||
@@ -3612,6 +3623,7 @@ Check_Multiple_Program_Units(void)
         observed_callsite.source_position.line != 74 ||
         !DSL_Builder_Get_PU_Call_Result(call, 0, &call_result) ||
         !DSL_Builder_Return_PU_Values(second_pu, &call_result, 1) ||
+        DSL_Builder_Count_PU_Values(second_pu) != 1 ||
         DSL_Builder_Append_PU_Value(second_pu, first_formal) ||
         PU_Info_next(first_pu) != second_pu ||
         PU_Info_maptab(first_pu) == PU_Info_maptab(second_pu)) {
@@ -3667,8 +3679,8 @@ Check_Multiple_Program_Units(void)
     verify.diagnostic = diagnostic;
     verify.diagnostic_capacity = sizeof(diagnostic);
     if (!DSL_Builder_Verify_Program(&verify) ||
-        verify.native_node_count != 1 ||
-        verify.result_symbol_count != 6 ||
+        verify.native_node_count != 2 ||
+        verify.result_symbol_count != 7 ||
         verify.error_count != 0 || diagnostic[0] != '\0') {
         fprintf(stderr, "multiple-PU verification failed: %s\n", diagnostic);
         return 1;

--- a/osprey/common/com/tests/dsl_multi_pu_artifact_test.sh
+++ b/osprey/common/com/tests/dsl_multi_pu_artifact_test.sh
@@ -32,6 +32,7 @@ for evidence in \
   "model_hidden" \
   "model_result" \
   "normalized_hidden" \
+  "U8LDA 0 <2,3,dsl_result_2>" \
   "Sclass: FORMAL" \
   "Sclass: FORMAL_REF" \
   "by_reference  read_only passed_not_saved" \
@@ -50,6 +51,22 @@ for evidence in \
     exit 1
   fi
 done
+
+callee_definition_line="$(grep -nF 'MSTID 0 <2,3,dsl_result_1>' "$trace" |
+  head -1 | cut -d: -f1)"
+callee_result_line="$(grep -nF 'MSTID 0 <2,2,normalized_result>' "$trace" |
+  head -1 | cut -d: -f1)"
+caller_definition_line="$(grep -nF 'MSTID 0 <2,3,dsl_result_2>' "$trace" |
+  head -1 | cut -d: -f1)"
+call_line="$(grep -nF 'VCALL 126 <1,50,TinyRMSNorm>' "$trace" |
+  head -1 | cut -d: -f1)"
+if [[ -z "$callee_definition_line" || -z "$callee_result_line" ||
+      -z "$caller_definition_line" || -z "$call_line" ||
+      "$callee_definition_line" -ge "$callee_result_line" ||
+      "$caller_definition_line" -ge "$call_line" ]]; then
+  echo "operator result materialization order changed in $trace" >&2
+  exit 1
+fi
 
 echo "multiple-PU mapped-image fixture passed"
 echo "review trace: $trace"


### PR DESCRIPTION
## Summary

Completes the native multiple-PU operator-result materialization required by the coordinated torch2whirl frontend work.

- recursively materializes pending caller-local operator definitions before inter-PU calls
- materializes callee-local operator definitions before copying values to declared PU result slots
- emits each defining `STID MTYPE_M` at most once and keeps explicit append idempotent
- preserves opaque `DSL_BUILDER_VALUE` handles and the existing call/formal/return APIs
- preserves caller-owned, uniquely owned `no_alias=true` result temporaries
- adds no WHIRL opcode, WN layout, ELF section, or mapped-image record change

## Frontend handoff

After this PR lands, rebase `codex/torch2whirl-python-fe` onto `develop`. Nested expressions such as projection -> rotary, norm -> attention, and decoder-layer -> top-level calls can pass ordinary opaque operator values directly to `DSL_Builder_Create_PU_Call` or `DSL_Builder_Return_PU_Values`. The frontend no longer needs to inline child semantics merely to force temporary creation.

Import/declaration identity is intentionally outside this PR.

## Validation

- Linux `dsl_native_syntax_test.sh` passed, including the physical-operator compatibility matrix.
- The multiple-PU producer generated and reopened a mapped binary WHIRL image.
- `ir_b2a -st -src` showed two real `FUNC_ENTRY` nodes and explicit call evidence.
- Regression checks prove the callee operator definition precedes its result-slot copy and the caller operator definition precedes the `CALL`.
- `git diff --check` and no-tab checks passed.

Retained local review trace: `/private/tmp/open64-dsl-pu-results-artifacts/multi-pu/llama2_multi_pu.T`