### PR TITLE
Stage DSL canonicalization under WHIRL simplifier control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,36 @@ only when the current task needs detail.
    demonstrated and documented.
 13. Follow the coding guidelines below for every touched file.
 
+## Open64 Design Continuity
+
+1. When new DSL infrastructure overlaps an established Open64 service, first
+   study and reuse that service's intended extension points, controls, data
+   structures, and tests. Preparation and postprocessing for DSL semantics are
+   acceptable; an independent parallel implementation requires a documented
+   incompatibility and explicit design review.
+2. DSL expression simplification must use the traditional Open64
+   `wn_simp_code.h` rule engine whenever the traditional rule has equivalent
+   semantics. Follow the established physical-WN protocol: prepare a
+   stack-local WN view for the simplifier, discard that temporary input after
+   the call, and retain only simplifier results allocated in the normal WN
+   memory-pool space. Tensor descriptor, effect, ownership, and logical-opcode
+   checks belong in preparation; DSL result symbols, metadata, lineage, and
+   mapped-image relationships belong in postprocessing.
+3. Do not duplicate traditional constant folding, identity, reassociation,
+   cancellation, or factorization rules in a separate DSL rule engine. Add a
+   DSL-only rule only when no traditional rule has equivalent semantics, and
+   document and test that distinction.
+4. Revisit this continuity principle during design reviews for new DSL
+   services. The concrete reuse mechanism may differ by subsystem, but the
+   review must identify the existing Open64 design being preserved or explain
+   why it cannot be reused.
+5. When WOPT admits unlowered DSL expressions, decode the physical `OPR_DSL`
+   boundary representation into a first-class logical CODEREP identity.
+   CODEREP hashing, equality, printing, effects, and simplification must include
+   the DSL operator, version, canonical attributes, and TensorDescriptorIR
+   identity. Continue using WOPT's existing `CODEREP` instantiation of
+   `wn_simp_code.h`; do not add a parallel WOPT simplifier.
+
 ## Coding Guidelines
 
 1. Do not introduce tab characters in any file touched in this Open64 project.
@@ -247,6 +277,13 @@ add one condition at a time:
 5. If `-O*` works but `-O* -ipa` fails, suspect IPA.
 6. After identifying a component, reduce by file, then procedure, then specific
    optimization. Use binary search where possible.
+7. Treat `-OPT:wn_simplify` and its abbreviation `-OPT:wn_simp` as the master
+   WHIRL construction-time simplifier control. When triaging a simplifier
+   regression, preserve separate `.B` files with simplification enabled and
+   disabled, produce matching `ir_b2a -st -src` traces, and compare the
+   resulting WHIRL. New DSL construction-time simplification must honor
+   `Enable_WN_Simp`; a DSL-specific control may further restrict a stage but
+   must not override the master switch.
 
 ## Reference Docs
 

--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -1099,8 +1099,8 @@ capability per pull request. Do not use M7 as a miscellaneous cleanup batch.
 
 | Milestone | Status | Merge dependency | Review artifact |
 | --- | --- | --- | --- |
-| M0 | Ready for review | None | Contract/API test report |
-| M1 | Blocked by M0 | M0 merged | Simplifier bridge traces |
+| M0 | PR #89 open | None | Contract/API test report |
+| M1 | Canonicalization/control preparation | M0 merged | Simplifier bridge traces |
 | M2 | Blocked by M1 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Blocked by M2 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |
@@ -1127,11 +1127,22 @@ bounded results, policies, and structured rejection reasons. The target hook
 deliberately rejects evaluation in M0; no tensor TCON is created and no
 builder behavior changes.
 
-Canonical ordering, `common.mul.v1`, builder integration, and the
-master-control hierarchy remain M1 work. In particular, any builder-local
-control must be subordinate to `Enable_WN_Simp`, and M1 must follow the
-prepare, traditional Open64 engine, and postprocess protocol before claiming
-construction-time simplification.
+The first M1 preparation is implemented:
+
+- `common.add.v1` and appended `common.mul.v1` have runtime-only algebraic
+  contracts;
+- paired factor/distribute relations record all four operand positions;
+- integer tensor operands with equivalent semantic descriptors are placed in a
+  deterministic order, with a lone constant normalized to `kid1`;
+- canonical keys include logical operator/version, sorted opcode attributes,
+  semantic TensorDescriptorIR fields, and recursively ordered operands;
+- compiler metadata, source context, and lineage do not participate;
+- the builder-local control can further restrict work but cannot override a
+  disabled `Enable_WN_Simp` master control.
+
+This preparation does not complete M1. Stack-local physical WN preparation,
+the traditional `wn_simp_code.h` engine call, DSL postprocessing, structured
+traces, and the mock tensor evaluator remain required.
 
 ## Staged Action List
 

--- a/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
+++ b/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
@@ -545,8 +545,8 @@ The clean pull-request rule is:
 
 | Milestone | Status | Merge dependency | Review artifact |
 | --- | --- | --- | --- |
-| M0 | Ready for review | None | Contract/API test report |
-| M1 | Blocked by M0 | M0 merged | Simplifier bridge traces |
+| M0 | PR #89 open | None | Contract/API test report |
+| M1 | Canonicalization/control preparation | M0 merged | Simplifier bridge traces |
 | M2 | Blocked by M1 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Blocked by M2 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -6,6 +6,7 @@
 #include "common_com_pch.h"
 #endif /* USE_PCH */
 #pragma hdrstop
+#include <algorithm>
 #include <ctype.h>
 #include <float.h>
 #include <stdio.h>
@@ -19,6 +20,7 @@
 
 #include "dsl_builder.h"
 #include "dsl_gatekeeper.h"
+#include "config.h"
 #include "dwarf_DST.h"
 #include "dwarf_DST_mem.h"
 #include "dwarf_DST_producer.h"
@@ -46,11 +48,14 @@ typedef struct {
     ST_IDX result_st;
     TY_IDX result_ty;
     DSL_IR_VALUE_ID image_value_id;
+    UINT32 value_kind;
+    std::string canonical_key;
     BOOL materializing;
     BOOL materialized;
 } DSL_BUILDER_VALUE_RECORD;
 
 static std::vector<DSL_BUILDER_VALUE_RECORD> DSL_builder_value_registry;
+static BOOL DSL_builder_canonicalization_enabled = FALSE;
 
 struct dsl_builder_state {
     DSL_BUILDER_PROGRAM_UNIT pu;
@@ -415,6 +420,179 @@ DSL_Builder_Safe_String (const char *value)
     return value == NULL ? "" : value;
 }
 
+static void
+DSL_Builder_Append_Canonical_Field
+        (std::string *key,
+         const char *name,
+         const char *value)
+{
+    char length[32];
+    const char *safe_value = DSL_Builder_Safe_String(value);
+
+    snprintf(length, sizeof(length), "%u",
+             (unsigned int)strlen(safe_value));
+    *key += name;
+    *key += ":";
+    *key += length;
+    *key += ":";
+    *key += safe_value;
+    *key += ";";
+}
+
+static std::string
+DSL_Builder_Tensor_Canonical_Key (TY_IDX ty)
+{
+    static const TY_TENSOR_SCHEMA_KEY semantic_key[] = {
+        TY_TENSOR_SCHEMA_KIND,
+        TY_TENSOR_SCHEMA_DTYPE,
+        TY_TENSOR_SCHEMA_RANK,
+        TY_TENSOR_SCHEMA_SHAPE,
+        TY_TENSOR_SCHEMA_TRAITS,
+        TY_TENSOR_SCHEMA_LAYOUT,
+        TY_TENSOR_SCHEMA_SHARDING,
+        TY_TENSOR_SCHEMA_PLACEMENT,
+        TY_TENSOR_SCHEMA_MEMORY,
+        TY_TENSOR_SCHEMA_QUANTIZATION,
+        TY_TENSOR_SCHEMA_RUNTIME_STATE
+    };
+    std::string key;
+    char element_type[32];
+
+    if (!TY_is_tensor_extension(ty))
+        return key;
+
+    snprintf(element_type, sizeof(element_type), "%u",
+             (unsigned int)TY_mtype(TY_tensor_element_ty(ty)));
+    DSL_Builder_Append_Canonical_Field
+        (&key, "element_type", element_type);
+    for (UINT32 i = 0;
+         i < sizeof(semantic_key) / sizeof(semantic_key[0]); ++i) {
+        const char *name = TY_tensor_schema_key_name(semantic_key[i]);
+        const char *value = TY_tensor_attribute(ty, semantic_key[i]);
+        DSL_Builder_Append_Canonical_Field(&key, name, value);
+    }
+
+    return key;
+}
+
+static std::string
+DSL_Builder_Attribute_Canonical_Key
+        (const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count)
+{
+    std::vector<std::string> fields;
+    std::string key;
+
+    for (UINT32 i = 0; attrs != NULL && i < attr_count; ++i) {
+        std::string field;
+        DSL_Builder_Append_Canonical_Field
+            (&field, DSL_Builder_Safe_String(attrs[i].name),
+             attrs[i].value);
+        fields.push_back(field);
+    }
+    std::sort(fields.begin(), fields.end());
+    for (UINT32 i = 0; i < fields.size(); ++i)
+        key += fields[i];
+    return key;
+}
+
+static std::string
+DSL_Builder_Value_Canonical_Key
+        (DSL_OPERATOR dsl_operator,
+         UINT16 version,
+         TY_IDX result_ty,
+         DSL_BUILDER_VALUE_RECORD **operand_records,
+         UINT32 operand_count,
+         const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count,
+         const char *result_name)
+{
+    std::string key;
+    char version_text[32];
+
+    DSL_Builder_Append_Canonical_Field
+        (&key, "operator", DSL_OPERATOR_name(dsl_operator));
+    snprintf(version_text, sizeof(version_text), "%u",
+             (unsigned int)version);
+    DSL_Builder_Append_Canonical_Field(&key, "version", version_text);
+    key += DSL_Builder_Tensor_Canonical_Key(result_ty);
+    key += DSL_Builder_Attribute_Canonical_Key(attrs, attr_count);
+    for (UINT32 i = 0; i < operand_count; ++i)
+        DSL_Builder_Append_Canonical_Field
+            (&key, "operand", operand_records[i]->canonical_key.c_str());
+    if (operand_count == 0)
+        DSL_Builder_Append_Canonical_Field(&key, "name", result_name);
+    return key;
+}
+
+static BOOL
+DSL_Builder_Is_Integer_Tensor (TY_IDX ty)
+{
+    return TY_is_tensor_extension(ty) &&
+           MTYPE_is_integral(TY_mtype(TY_tensor_element_ty(ty)));
+}
+
+static BOOL
+DSL_Builder_Canonicalize_Kids
+        (DSL_OPERATOR dsl_operator,
+         UINT16 version,
+         DSL_BUILDER_VALUE *kids,
+         UINT32 kid_count)
+{
+    DSL_BUILDER_VALUE_RECORD *kid0;
+    DSL_BUILDER_VALUE_RECORD *kid1;
+    BOOL kid0_constant;
+    BOOL kid1_constant;
+    BOOL equivalent_descriptors;
+    BOOL swap;
+    std::string kid0_descriptor_key;
+    std::string kid1_descriptor_key;
+
+    if (!DSL_Builder_Canonicalization_Enabled() || kids == NULL ||
+        kid_count != 2)
+        return FALSE;
+
+    kid0 = DSL_Builder_Find_Value_Record(kids[0]);
+    kid1 = DSL_Builder_Find_Value_Record(kids[1]);
+    if (kid0 == NULL || kid1 == NULL ||
+        !DSL_Builder_Is_Integer_Tensor(kid0->result_ty) ||
+        !DSL_Builder_Is_Integer_Tensor(kid1->result_ty))
+        return FALSE;
+
+    kid0_descriptor_key =
+        DSL_Builder_Tensor_Canonical_Key(kid0->result_ty);
+    kid1_descriptor_key =
+        DSL_Builder_Tensor_Canonical_Key(kid1->result_ty);
+    equivalent_descriptors =
+        !kid0_descriptor_key.empty() &&
+        kid0_descriptor_key == kid1_descriptor_key;
+    kid0_constant = kid0->value_kind == DSL_IR_VALUE_CONSTANT;
+    kid1_constant = kid1->value_kind == DSL_IR_VALUE_CONSTANT;
+    swap = DSL_Algebraic_Should_Swap_Binary_Operands
+               (dsl_operator, version, TRUE, equivalent_descriptors,
+                kid0_constant, kid1_constant,
+                kid0->canonical_key.c_str(), kid1->canonical_key.c_str());
+
+    if (swap) {
+        DSL_BUILDER_VALUE temporary = kids[0];
+        kids[0] = kids[1];
+        kids[1] = temporary;
+    }
+    return swap;
+}
+
+void
+DSL_Builder_Set_Canonicalization_Enabled (BOOL enabled)
+{
+    DSL_builder_canonicalization_enabled = enabled;
+}
+
+BOOL
+DSL_Builder_Canonicalization_Enabled (void)
+{
+    return Enable_WN_Simp && DSL_builder_canonicalization_enabled;
+}
+
 BOOL
 DSL_Builder_Set_PU_Source_Identity
         (DSL_BUILDER_PROGRAM_UNIT pu,
@@ -494,6 +672,7 @@ DSL_Builder_Uses_Xpragma_Carrier (const DSL_OPCODE_INFO *info)
         return FALSE;
 
     return strcmp (info->name, DSL_OPCODE_COMMON_ADD) == 0 ||
+           strcmp (info->name, DSL_OPCODE_COMMON_MUL) == 0 ||
            strcmp (info->name, DSL_OPCODE_COMMON_MATMUL) == 0 ||
            strcmp (info->name, DSL_OPCODE_COMMON_TENSOR_CONST) == 0;
 }
@@ -1806,6 +1985,10 @@ DSL_Builder_Create_Native_Value
         delete [] operand_records;
         return NULL;
     }
+    std::string canonical_key = DSL_Builder_Value_Canonical_Key
+                                    (dsl_operator, version, result_ty,
+                                     operand_records, kid_count, attrs,
+                                     attr_count, result_name);
     delete [] operand_records;
 
     DSL_BUILDER_VALUE_RECORD record;
@@ -1815,6 +1998,8 @@ DSL_Builder_Create_Native_Value
     record.result_st = result_st;
     record.result_ty = result_ty;
     record.image_value_id = image_value_id;
+    record.value_kind = value_kind;
+    record.canonical_key = canonical_key;
     record.materializing = FALSE;
     record.materialized = FALSE;
     DSL_builder_value_registry.push_back(record);
@@ -2253,6 +2438,8 @@ DSL_Builder_Create_Operator
     DSL_OPCODE_INFO info;
     DSL_OPERATOR dsl_operator;
     DSL_OPERATOR_INFO logical_info;
+    DSL_BUILDER_VALUE canonical_kids[2];
+    DSL_BUILDER_VALUE *effective_kids = kids;
     char *payload;
     WN *wn;
 
@@ -2265,13 +2452,21 @@ DSL_Builder_Create_Operator
               (dsl_operator, version, &logical_info) ||
          (DSL_Builder_Requires_Exact_Attribute_Schema
               (dsl_operator, version) &&
-          !DSL_Builder_Attributes_Match_Schema
+         !DSL_Builder_Attributes_Match_Schema
                (&logical_info, attrs, attr_count))))
         return NULL;
 
-    payload = DSL_Builder_Format_Operator_Payload (kids, kid_count, attrs,
-                                                   attr_count);
-    if ((dsl_operator == OPR_DSLADD || dsl_operator == OPR_DSLMATMUL ||
+    if (dsl_operator != OPR_DSLUNKNOWN && kid_count == 2 && kids != NULL) {
+        canonical_kids[0] = kids[0];
+        canonical_kids[1] = kids[1];
+        DSL_Builder_Canonicalize_Kids
+            (dsl_operator, version, canonical_kids, kid_count);
+        effective_kids = canonical_kids;
+    }
+    payload = DSL_Builder_Format_Operator_Payload
+                  (effective_kids, kid_count, attrs, attr_count);
+    if ((dsl_operator == OPR_DSLADD || dsl_operator == OPR_DSLMUL ||
+         dsl_operator == OPR_DSLMATMUL ||
          dsl_operator == OPR_DSLLINEAR ||
          dsl_operator == OPR_DSLRELU || dsl_operator == OPR_DSLFLATTEN ||
          dsl_operator == OPR_DSLRESIDUALADD ||
@@ -2294,7 +2489,7 @@ DSL_Builder_Create_Operator
             return NULL;
         }
         DSL_BUILDER_VALUE_RECORD *first =
-            DSL_Builder_Find_Value_Record(kids[0]);
+            DSL_Builder_Find_Value_Record(effective_kids[0]);
         char result_name[64];
         char result_type_name[80];
 
@@ -2426,21 +2621,21 @@ DSL_Builder_Create_Operator
                 }
             }
             wn = DSL_Builder_Create_Native_Value
-                     (dsl_operator, version, payload, kids, kid_count, attrs,
-                      attr_count, result_name, result_ty,
+                     (dsl_operator, version, payload, effective_kids,
+                      kid_count, attrs, attr_count, result_name, result_ty,
                       DSL_IR_VALUE_OPERATOR_RESULT);
             delete [] payload;
             return wn;
         }
     }
 
-    WN **compatibility_kids = kids;
+    WN **compatibility_kids = effective_kids;
     if (kid_count != 0) {
         compatibility_kids = new WN *[kid_count];
         for (UINT32 i = 0; i < kid_count; ++i) {
             DSL_BUILDER_VALUE_RECORD *kid_record =
-                DSL_Builder_Find_Value_Record(kids[i]);
-            compatibility_kids[i] = kid_record == NULL ? kids[i] :
+                DSL_Builder_Find_Value_Record(effective_kids[i]);
+            compatibility_kids[i] = kid_record == NULL ? effective_kids[i] :
                 DSL_WN_Create_Opcode_Comment_Projection
                     (kid_record->expression);
             if (compatibility_kids[i] == NULL) {
@@ -2466,7 +2661,7 @@ DSL_Builder_Create_Operator
         wn = DSL_WN_Create_Opcode_With_Operands
                  (info.name, version, payload, compatibility_kids, kid_count);
     }
-    if (compatibility_kids != kids)
+    if (compatibility_kids != effective_kids)
         delete [] compatibility_kids;
     delete [] payload;
     return wn;
@@ -2486,6 +2681,8 @@ DSL_Builder_Create_Operator_With_Result
     DSL_OPCODE_INFO info;
     DSL_OPERATOR dsl_operator;
     DSL_OPERATOR_INFO logical_info;
+    DSL_BUILDER_VALUE canonical_kids[2];
+    DSL_BUILDER_VALUE *effective_kids = kids;
     char *payload;
     DSL_BUILDER_OPERATOR result;
 
@@ -2512,11 +2709,18 @@ DSL_Builder_Create_Operator_With_Result
               (&logical_info, attrs, attr_count)))
         return NULL;
 
+    if (kid_count == 2 && kids != NULL) {
+        canonical_kids[0] = kids[0];
+        canonical_kids[1] = kids[1];
+        DSL_Builder_Canonicalize_Kids
+            (dsl_operator, version, canonical_kids, kid_count);
+        effective_kids = canonical_kids;
+    }
     payload = DSL_Builder_Format_Operator_Payload
-                  (kids, kid_count, attrs, attr_count);
+                  (effective_kids, kid_count, attrs, attr_count);
     result = DSL_Builder_Create_Native_Value
-                 (dsl_operator, version, payload, kids, kid_count, attrs,
-                  attr_count, result_name, result_ty,
+                 (dsl_operator, version, payload, effective_kids, kid_count,
+                  attrs, attr_count, result_name, result_ty,
                   DSL_IR_VALUE_OPERATOR_RESULT);
     delete [] payload;
     return result;
@@ -2751,6 +2955,10 @@ DSL_Builder_Declare_PU_Formal
     value_record.result_st = ST_st_idx(*st);
     value_record.result_ty = ty;
     value_record.image_value_id = image_value_id;
+    value_record.value_kind = DSL_IR_VALUE_SYMBOL;
+    value_record.canonical_key = DSL_Builder_Value_Canonical_Key
+                                     (OPR_DSLUNKNOWN, 0, ty, NULL, 0,
+                                      NULL, 0, name);
     value_record.materializing = FALSE;
     value_record.materialized = TRUE;
     DSL_builder_value_registry.push_back(value_record);
@@ -2812,6 +3020,10 @@ DSL_Builder_Declare_PU_Result
     value_record.result_st = ST_st_idx(*st);
     value_record.result_ty = ty;
     value_record.image_value_id = image_value_id;
+    value_record.value_kind = DSL_IR_VALUE_SYMBOL;
+    value_record.canonical_key = DSL_Builder_Value_Canonical_Key
+                                     (OPR_DSLUNKNOWN, 0, ty, NULL, 0,
+                                      NULL, 0, name);
     value_record.materializing = FALSE;
     value_record.materialized = TRUE;
     DSL_builder_value_registry.push_back(value_record);
@@ -2996,6 +3208,11 @@ DSL_Builder_Create_PU_Call
         value_record.result_st = result_st;
         value_record.result_ty = result_ty;
         value_record.image_value_id = image_value_id;
+        value_record.value_kind = DSL_IR_VALUE_SYMBOL;
+        value_record.canonical_key = DSL_Builder_Value_Canonical_Key
+                                         (OPR_DSLUNKNOWN, 0, result_ty,
+                                          NULL, 0, NULL, 0,
+                                          ST_name(St_Table[result_st]));
         value_record.materializing = FALSE;
         value_record.materialized = TRUE;
         DSL_builder_value_registry.push_back(value_record);

--- a/osprey/common/com/dsl_builder.h
+++ b/osprey/common/com/dsl_builder.h
@@ -143,6 +143,12 @@ typedef struct {
 
 typedef DSL_BUILDER_MARKER_INFO DSL_BUILDER_VALUE_INFO;
 
+/*
+ * This builder control may further restrict construction-time
+ * canonicalization. It must never enable work disabled by Enable_WN_Simp.
+ */
+extern void DSL_Builder_Set_Canonicalization_Enabled (BOOL enabled);
+extern BOOL DSL_Builder_Canonicalization_Enabled (void);
 extern TY_IDX DSL_Builder_Create_Tensor_Type_Core
                                 (const char *name,
                                  TY_IDX element_ty,

--- a/osprey/common/com/dsl_opcode.cxx
+++ b/osprey/common/com/dsl_opcode.cxx
@@ -136,7 +136,8 @@ static const char *DSL_operator_name[] = {
     "OPR_DSLROTARYEMBEDDING",
     "OPR_DSLATTENTION",
     "OPR_DSLSWIGLU",
-    "OPR_DSLSCATTER"
+    "OPR_DSLSCATTER",
+    "OPR_DSLMUL"
 };
 
 static const char *DSL_cprom_diagnostic_code[] = {
@@ -449,7 +450,11 @@ static const DSL_COMMON_OPCODE_SEED DSL_common_opcode_seed[] = {
     { "common.tensor_const", DSL_OPCODE_CATEGORY_EXECUTABLE,
         DSL_OPCODE_LEVEL_1_TENSOR, 0,
         DSL_SHAPE_RULE_OPAQUE, DSL_EFFECT_MODEL_PURE,
-        DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_TENSOR_CONST" }
+        DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_TENSOR_CONST" },
+    { "common.mul", DSL_OPCODE_CATEGORY_EXECUTABLE,
+        DSL_OPCODE_LEVEL_2_NUMERIC, 2,
+        DSL_SHAPE_RULE_BROADCAST, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_MARKER_ONLY, "DOPC_COMMON_MUL" }
 };
 
 static const DSL_LOGICAL_OPERATOR_SEED DSL_logical_operator_seed[] = {
@@ -596,7 +601,12 @@ static const DSL_LOGICAL_OPERATOR_SEED DSL_logical_operator_seed[] = {
         DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_4_RUNTIME, 3,
         DSL_SHAPE_RULE_VIEW, DSL_EFFECT_MODEL_RUNTIME_EFFECT,
         DSL_LOWERING_MODEL_RUNTIME_CALL, "DOPC_COMMON_SCATTER_V1",
-        "attr.axis" }
+        "attr.axis" },
+    { OPR_DSLMUL, "common.mul", 1,
+        DSL_OPCODE_CATEGORY_EXECUTABLE, DSL_OPCODE_LEVEL_2_NUMERIC, 2,
+        DSL_SHAPE_RULE_BROADCAST, DSL_EFFECT_MODEL_PURE,
+        DSL_LOWERING_MODEL_MARKER_ONLY, "DOPC_COMMON_MUL",
+        "attr.broadcast_rule" }
 };
 
 static const DSL_LOGICAL_OPERATOR_SEED *
@@ -728,6 +738,135 @@ DSL_OPERATOR_name (DSL_OPERATOR dsl_operator)
            (UINT32)dsl_operator < DSL_ARRAY_COUNT(DSL_operator_name) ?
            DSL_operator_name[dsl_operator] :
            DSL_operator_name[OPR_DSLUNKNOWN];
+}
+
+static const DSL_ALGEBRAIC_INFO DSL_algebraic_info[] = {
+    { OPR_DSLADD, 1, OPR_DSLADD, DSL_ALGEBRAIC_IDENTITY_ZERO,
+        DSL_ALGEBRAIC_SAFETY_INTEGER,
+        DSL_ALGEBRAIC_SAFETY_INTEGER_OR_FP_REASSOCIATE,
+        DSL_ALGEBRAIC_ALLOW_COMMUTATION |
+        DSL_ALGEBRAIC_ALLOW_REASSOCIATION },
+    { OPR_DSLMUL, 1, OPR_DSLMUL, DSL_ALGEBRAIC_IDENTITY_ONE,
+        DSL_ALGEBRAIC_SAFETY_INTEGER,
+        DSL_ALGEBRAIC_SAFETY_INTEGER_OR_FP_REASSOCIATE,
+        DSL_ALGEBRAIC_ALLOW_COMMUTATION |
+        DSL_ALGEBRAIC_ALLOW_REASSOCIATION }
+};
+
+static const DSL_ALGEBRAIC_RELATION_INFO DSL_algebraic_relation[] = {
+    { OPR_DSLADD, 1, OPR_DSLMUL, 1, DSL_ALGEBRAIC_RELATION_FACTOR,
+        DSL_ALGEBRAIC_SAFETY_INTEGER_OR_FP_REASSOCIATE,
+        DSL_ALGEBRAIC_OPERAND_ALL },
+    { OPR_DSLMUL, 1, OPR_DSLADD, 1,
+        DSL_ALGEBRAIC_RELATION_DISTRIBUTE,
+        DSL_ALGEBRAIC_SAFETY_INTEGER_OR_FP_REASSOCIATE,
+        DSL_ALGEBRAIC_OPERAND_ALL }
+};
+
+BOOL
+DSL_Operator_Get_Algebraic_Info
+        (DSL_OPERATOR dsl_operator,
+         UINT16 version,
+         DSL_ALGEBRAIC_INFO *info)
+{
+    for (UINT32 i = 0; i < DSL_ARRAY_COUNT(DSL_algebraic_info); ++i) {
+        if (DSL_algebraic_info[i].dsl_operator != dsl_operator ||
+            DSL_algebraic_info[i].version != version)
+            continue;
+        if (info != NULL)
+            *info = DSL_algebraic_info[i];
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+BOOL
+DSL_Operator_Get_Swap_Equivalent
+        (DSL_OPERATOR dsl_operator,
+         UINT16 version,
+         DSL_OPERATOR *swap_equivalent)
+{
+    DSL_ALGEBRAIC_INFO info;
+
+    if (!DSL_Operator_Get_Algebraic_Info
+             (dsl_operator, version, &info) ||
+        (info.flags & DSL_ALGEBRAIC_ALLOW_COMMUTATION) == 0 ||
+        info.swap_equivalent == OPR_DSLUNKNOWN)
+        return FALSE;
+    if (swap_equivalent != NULL)
+        *swap_equivalent = info.swap_equivalent;
+    return TRUE;
+}
+
+BOOL
+DSL_Algebraic_Should_Swap_Binary_Operands
+        (DSL_OPERATOR dsl_operator,
+         UINT16 version,
+         BOOL integer_operands,
+         BOOL equivalent_descriptors,
+         BOOL kid0_is_constant,
+         BOOL kid1_is_constant,
+         const char *kid0_key,
+         const char *kid1_key)
+{
+    DSL_ALGEBRAIC_INFO info;
+
+    if (!integer_operands || !equivalent_descriptors ||
+        kid0_key == NULL || kid1_key == NULL ||
+        !DSL_Operator_Get_Algebraic_Info
+             (dsl_operator, version, &info) ||
+        (info.flags & DSL_ALGEBRAIC_ALLOW_COMMUTATION) == 0 ||
+        info.commutation_safety != DSL_ALGEBRAIC_SAFETY_INTEGER)
+        return FALSE;
+
+    if (kid0_is_constant != kid1_is_constant)
+        return kid0_is_constant;
+    return strcmp(kid0_key, kid1_key) > 0;
+}
+
+UINT32
+DSL_Algebraic_Relation_Count (void)
+{
+    return DSL_ARRAY_COUNT(DSL_algebraic_relation);
+}
+
+BOOL
+DSL_Algebraic_Relation_At
+        (UINT32 ordinal,
+         DSL_ALGEBRAIC_RELATION_INFO *info)
+{
+    if (ordinal >= DSL_ARRAY_COUNT(DSL_algebraic_relation))
+        return FALSE;
+    if (info != NULL)
+        *info = DSL_algebraic_relation[ordinal];
+    return TRUE;
+}
+
+BOOL
+DSL_Algebraic_Relation_Get
+        (DSL_OPERATOR outer_operator,
+         UINT16 outer_version,
+         DSL_OPERATOR inner_operator,
+         UINT16 inner_version,
+         DSL_ALGEBRAIC_RELATION relation,
+         DSL_ALGEBRAIC_RELATION_INFO *info)
+{
+    for (UINT32 i = 0; i < DSL_ARRAY_COUNT(DSL_algebraic_relation); ++i) {
+        const DSL_ALGEBRAIC_RELATION_INFO &candidate =
+            DSL_algebraic_relation[i];
+        if (candidate.outer_operator != outer_operator ||
+            candidate.outer_version != outer_version ||
+            candidate.inner_operator != inner_operator ||
+            candidate.inner_version != inner_version ||
+            candidate.relation != relation)
+            continue;
+        if (info != NULL)
+            *info = candidate;
+        return TRUE;
+    }
+
+    return FALSE;
 }
 
 static const DSL_DOMAIN_WRAPPER_SEED DSL_domain_wrapper_seed[] = {

--- a/osprey/common/com/dsl_opcode.h
+++ b/osprey/common/com/dsl_opcode.h
@@ -41,8 +41,63 @@ typedef enum {
     OPR_DSLROTARYEMBEDDING = 18,
     OPR_DSLATTENTION = 19,
     OPR_DSLSWIGLU = 20,
-    OPR_DSLSCATTER = 21
+    OPR_DSLSCATTER = 21,
+    OPR_DSLMUL = 22
 } DSL_OPERATOR;
+
+typedef enum {
+    DSL_ALGEBRAIC_IDENTITY_NONE = 0,
+    DSL_ALGEBRAIC_IDENTITY_ZERO = 1,
+    DSL_ALGEBRAIC_IDENTITY_ONE = 2
+} DSL_ALGEBRAIC_IDENTITY;
+
+typedef enum {
+    DSL_ALGEBRAIC_SAFETY_NEVER = 0,
+    DSL_ALGEBRAIC_SAFETY_EXACT = 1,
+    DSL_ALGEBRAIC_SAFETY_INTEGER = 2,
+    DSL_ALGEBRAIC_SAFETY_INTEGER_OR_FP_REASSOCIATE = 3,
+    DSL_ALGEBRAIC_SAFETY_RELAXED_MATH = 4
+} DSL_ALGEBRAIC_SAFETY;
+
+typedef enum {
+    DSL_ALGEBRAIC_RELATION_FACTOR = 0,
+    DSL_ALGEBRAIC_RELATION_DISTRIBUTE = 1
+} DSL_ALGEBRAIC_RELATION;
+
+enum {
+    DSL_ALGEBRAIC_ALLOW_COMMUTATION = 1U << 0,
+    DSL_ALGEBRAIC_ALLOW_REASSOCIATION = 1U << 1
+};
+
+enum {
+    DSL_ALGEBRAIC_OPERAND_11 = 1U << 0,
+    DSL_ALGEBRAIC_OPERAND_12 = 1U << 1,
+    DSL_ALGEBRAIC_OPERAND_21 = 1U << 2,
+    DSL_ALGEBRAIC_OPERAND_22 = 1U << 3,
+    DSL_ALGEBRAIC_OPERAND_ALL =
+        DSL_ALGEBRAIC_OPERAND_11 | DSL_ALGEBRAIC_OPERAND_12 |
+        DSL_ALGEBRAIC_OPERAND_21 | DSL_ALGEBRAIC_OPERAND_22
+};
+
+typedef struct {
+    DSL_OPERATOR dsl_operator;
+    UINT16 version;
+    DSL_OPERATOR swap_equivalent;
+    DSL_ALGEBRAIC_IDENTITY identity;
+    DSL_ALGEBRAIC_SAFETY commutation_safety;
+    DSL_ALGEBRAIC_SAFETY reassociation_safety;
+    UINT32 flags;
+} DSL_ALGEBRAIC_INFO;
+
+typedef struct {
+    DSL_OPERATOR outer_operator;
+    UINT16 outer_version;
+    DSL_OPERATOR inner_operator;
+    UINT16 inner_version;
+    DSL_ALGEBRAIC_RELATION relation;
+    DSL_ALGEBRAIC_SAFETY safety;
+    UINT32 operand_mask;
+} DSL_ALGEBRAIC_RELATION_INFO;
 
 typedef enum {
     DSL_OPCODE_CATEGORY_EXECUTABLE = 0,
@@ -190,6 +245,34 @@ extern DSL_OPERATOR DSL_Operator_Find (const char *stable_name,
 extern DSL_OPERATOR DSL_Operator_Find_Current (const char *stable_name,
                                                UINT32 stable_name_len);
 extern const char *DSL_OPERATOR_name (DSL_OPERATOR dsl_operator);
+extern BOOL DSL_Operator_Get_Algebraic_Info
+                                (DSL_OPERATOR dsl_operator,
+                                 UINT16 version,
+                                 DSL_ALGEBRAIC_INFO *info);
+extern BOOL DSL_Operator_Get_Swap_Equivalent
+                                (DSL_OPERATOR dsl_operator,
+                                 UINT16 version,
+                                 DSL_OPERATOR *swap_equivalent);
+extern BOOL DSL_Algebraic_Should_Swap_Binary_Operands
+                                (DSL_OPERATOR dsl_operator,
+                                 UINT16 version,
+                                 BOOL integer_operands,
+                                 BOOL equivalent_descriptors,
+                                 BOOL kid0_is_constant,
+                                 BOOL kid1_is_constant,
+                                 const char *kid0_key,
+                                 const char *kid1_key);
+extern UINT32 DSL_Algebraic_Relation_Count (void);
+extern BOOL DSL_Algebraic_Relation_At
+                                (UINT32 ordinal,
+                                 DSL_ALGEBRAIC_RELATION_INFO *info);
+extern BOOL DSL_Algebraic_Relation_Get
+                                (DSL_OPERATOR outer_operator,
+                                 UINT16 outer_version,
+                                 DSL_OPERATOR inner_operator,
+                                 UINT16 inner_version,
+                                 DSL_ALGEBRAIC_RELATION relation,
+                                 DSL_ALGEBRAIC_RELATION_INFO *info);
 extern UINT32 DSL_Opcode_Register_Common_Substrate (void);
 extern UINT32 DSL_Opcode_Register_Transformer_Domain (void);
 extern UINT32 DSL_Opcode_Register_Domain_Wrapper_Examples (void);

--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -50,6 +50,7 @@ DSL_Tensor_Fold_Get_Evaluator
 
     switch (dsl_operator) {
     case OPR_DSLADD:
+    case OPR_DSLMUL:
         if (evaluator != NULL) {
             evaluator->dsl_operator = dsl_operator;
             evaluator->version = version;

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -1470,6 +1470,165 @@ Check_DSL_IR_Image_Tables(void)
 }
 
 static int
+Check_Algebraic_Canonicalization(void)
+{
+    DSL_BUILDER_TENSOR_DESCRIPTOR descriptor;
+    DSL_BUILDER_OPERATOR_ATTRIBUTE attribute;
+    DSL_BUILDER_VALUE_INFO operand_info;
+    DSL_BUILDER_VALUE kids[2];
+    DSL_BUILDER_VALUE alpha;
+    DSL_BUILDER_VALUE zeta;
+    DSL_BUILDER_VALUE zero;
+    DSL_BUILDER_VALUE canonical;
+    DSL_BUILDER_VALUE master_disabled;
+    DSL_DOMAIN_ID common_id;
+    DSL_OPCODE_ID add_id;
+    DSL_OPCODE_ID mul_id;
+    TY_IDX tensor_ty;
+    BOOL saved_wn_simp = Enable_WN_Simp;
+    BOOL saved_canonicalization = DSL_Builder_Canonicalization_Enabled();
+    int failed = 0;
+
+    DSL_Builder_Begin_Program();
+    DSL_Opcode_Register_Common_Substrate();
+    memset(&descriptor, 0, sizeof(descriptor));
+    descriptor.type_core.kind = "tensor";
+    descriptor.type_core.dtype = "int32";
+    descriptor.type_core.rank = 2;
+    descriptor.type_core.logical_shape = "[2,2]";
+    tensor_ty = DSL_Builder_Intern_Tensor_Type
+                    ("canonicalization_tensor", MTYPE_To_TY(MTYPE_I4),
+                     &descriptor);
+    common_id = DSL_Domain_Find("common");
+    add_id = DSL_Opcode_Find(common_id, DSL_OPCODE_COMMON_ADD, 1);
+    mul_id = DSL_Opcode_Find(common_id, DSL_OPCODE_COMMON_MUL, 1);
+    DSL_Builder_Create_Minimal_PU("algebraic_canonicalization_contract");
+
+    if (tensor_ty == TY_IDX_ZERO || add_id == DSL_OPCODE_INVALID_ID ||
+        mul_id == DSL_OPCODE_INVALID_ID) {
+        fprintf(stderr, "DSL algebraic operator registration failed\n");
+        failed = 1;
+    }
+
+    alpha = DSL_Builder_Create_Model_Input("alpha", tensor_ty, 0);
+    zeta = DSL_Builder_Create_Model_Input("zeta", tensor_ty, 1);
+    zero = DSL_Builder_Create_Tensor_Constant
+               ("zero", tensor_ty, "int32", 2, "[2,2]", "splat", "0");
+    if (alpha == NULL || zeta == NULL || zero == NULL) {
+        fprintf(stderr, "DSL canonicalization operand creation failed\n");
+        DSL_Builder_Set_Canonicalization_Enabled(saved_canonicalization);
+        Enable_WN_Simp = saved_wn_simp;
+        return 1;
+    }
+
+    attribute.name = "attr.broadcast_rule";
+    attribute.value = "none";
+    Enable_WN_Simp = TRUE;
+    DSL_Builder_Set_Canonicalization_Enabled(TRUE);
+
+    kids[0] = zeta;
+    kids[1] = alpha;
+    canonical = DSL_Builder_Create_Operator_With_Result
+                    (add_id, 1, kids, 2, &attribute, 1,
+                     "canonical_add", tensor_ty);
+    if (canonical == NULL ||
+        kids[0] != zeta || kids[1] != alpha ||
+        !DSL_Builder_Get_Value_Operand(canonical, 0, &operand_info) ||
+        operand_info.payload == NULL ||
+        strstr(operand_info.payload, "name=alpha") == NULL ||
+        !DSL_Builder_Get_Value_Operand(canonical, 1, &operand_info) ||
+        operand_info.payload == NULL ||
+        strstr(operand_info.payload, "name=zeta") == NULL) {
+        fprintf(stderr,
+                "DSL deterministic operand order changed: enabled=%d\n",
+                DSL_Builder_Canonicalization_Enabled());
+        if (canonical != NULL) {
+            WN *expression = WN_kid0(canonical);
+            fprintf(stderr, "  expression=%s kids=%d\n",
+                    OPERATOR_name(WN_operator(expression)),
+                    WN_kid_count(expression));
+            for (INT32 i = 0; i < WN_kid_count(expression); ++i)
+                fprintf(stderr, "  physical kid%d=%s st=%u\n", i,
+                        OPERATOR_name(WN_operator(WN_kid(expression, i))),
+                        (unsigned int)WN_st_idx(WN_kid(expression, i)));
+            fprintf(stderr, "  alpha st=%u zeta st=%u\n",
+                    (unsigned int)WN_st_idx(alpha),
+                    (unsigned int)WN_st_idx(zeta));
+        }
+        if (canonical != NULL &&
+            DSL_Builder_Get_Value_Operand(canonical, 0, &operand_info))
+            fprintf(stderr, "  kid0=%s\n",
+                    operand_info.payload == NULL ? "<null>" :
+                    operand_info.payload);
+        if (canonical != NULL &&
+            DSL_Builder_Get_Value_Operand(canonical, 1, &operand_info))
+            fprintf(stderr, "  kid1=%s\n",
+                    operand_info.payload == NULL ? "<null>" :
+                    operand_info.payload);
+        failed = 1;
+    }
+
+    kids[0] = zero;
+    kids[1] = alpha;
+    canonical = DSL_Builder_Create_Operator_With_Result
+                    (mul_id, 1, kids, 2, &attribute, 1,
+                     "canonical_mul", tensor_ty);
+    if (canonical == NULL ||
+        !DSL_Builder_Get_Value_Info(canonical, &operand_info) ||
+        operand_info.opcode_name_len != strlen(DSL_OPCODE_COMMON_MUL) ||
+        strncmp(operand_info.opcode_name, DSL_OPCODE_COMMON_MUL,
+                operand_info.opcode_name_len) != 0 ||
+        !DSL_Builder_Get_Value_Operand(canonical, 0, &operand_info) ||
+        operand_info.payload == NULL ||
+        strstr(operand_info.payload, "name=alpha") == NULL) {
+        fprintf(stderr,
+                "DSL constant-to-kid1 normalization changed: enabled=%d\n",
+                DSL_Builder_Canonicalization_Enabled());
+        if (canonical != NULL &&
+            DSL_Builder_Get_Value_Operand(canonical, 0, &operand_info))
+            fprintf(stderr, "  kid0=%s\n",
+                    operand_info.payload == NULL ? "<null>" :
+                    operand_info.payload);
+        if (canonical != NULL &&
+            DSL_Builder_Get_Value_Operand(canonical, 1, &operand_info))
+            fprintf(stderr, "  kid1=%s\n",
+                    operand_info.payload == NULL ? "<null>" :
+                    operand_info.payload);
+        failed = 1;
+    }
+
+    Enable_WN_Simp = FALSE;
+    kids[0] = zeta;
+    kids[1] = alpha;
+    master_disabled = DSL_Builder_Create_Operator_With_Result
+                          (add_id, 1, kids, 2, &attribute, 1,
+                           "master_disabled_add", tensor_ty);
+    if (DSL_Builder_Canonicalization_Enabled() ||
+        master_disabled == NULL ||
+        !DSL_Builder_Get_Value_Operand
+             (master_disabled, 0, &operand_info) ||
+        operand_info.payload == NULL ||
+        strstr(operand_info.payload, "name=zeta") == NULL) {
+        fprintf(stderr,
+                "Enable_WN_Simp master control was bypassed: enabled=%d\n",
+                DSL_Builder_Canonicalization_Enabled());
+        if (master_disabled != NULL &&
+            DSL_Builder_Get_Value_Operand
+                (master_disabled, 0, &operand_info))
+            fprintf(stderr, "  kid0=%s\n",
+                    operand_info.payload == NULL ? "<null>" :
+                    operand_info.payload);
+        failed = 1;
+    }
+
+    DSL_Builder_Set_Canonicalization_Enabled(saved_canonicalization);
+    Enable_WN_Simp = saved_wn_simp;
+    if (!failed)
+        printf("DSL builder algebraic canonicalization contract passed\n");
+    return failed;
+}
+
+static int
 Check_Native_DSL_Node_Layout(void)
 {
     DSL_BUILDER_TENSOR_TYPE_CORE type_core;
@@ -3723,6 +3882,8 @@ main(void)
         return Check_Llama2_Decode_State_Region();
     if (getenv("OPEN64_DSL_MULTI_PU_ONLY") != NULL)
         return Check_Multiple_Program_Units();
+    if (getenv("OPEN64_DSL_CANONICALIZATION_ONLY") != NULL)
+        return Check_Algebraic_Canonicalization();
 
     failed |= Check_Tensor_Type_And_Descriptor();
     failed |= Check_Symbol_Metadata();

--- a/osprey/common/com/tests/dsl_builder_simplifier_control_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_simplifier_control_test.cxx
@@ -1,0 +1,53 @@
+/*
+ * Verify that construction-time DSL canonicalization remains subordinate to
+ * the traditional WHIRL simplifier master control.
+ */
+
+#include <stdio.h>
+
+#include "defs.h"
+#include "config.h"
+#include "dsl_builder.h"
+
+/*
+ * This focused test links only the live builder control sections. The full
+ * Open64 build supplies this definition through config.o.
+ */
+BOOL Enable_WN_Simp = TRUE;
+
+int
+main(void)
+{
+    DSL_Builder_Set_Canonicalization_Enabled(FALSE);
+    if (DSL_Builder_Canonicalization_Enabled()) {
+        fprintf(stderr, "disabled builder canonicalization became active\n");
+        return 1;
+    }
+
+    DSL_Builder_Set_Canonicalization_Enabled(TRUE);
+    if (!DSL_Builder_Canonicalization_Enabled()) {
+        fprintf(stderr, "enabled builder canonicalization stayed inactive\n");
+        return 1;
+    }
+
+    Enable_WN_Simp = FALSE;
+    if (DSL_Builder_Canonicalization_Enabled()) {
+        fprintf(stderr, "builder bypassed Enable_WN_Simp master control\n");
+        return 1;
+    }
+
+    DSL_Builder_Set_Canonicalization_Enabled(TRUE);
+    if (DSL_Builder_Canonicalization_Enabled()) {
+        fprintf(stderr, "builder control re-enabled disabled wn_simp\n");
+        return 1;
+    }
+
+    Enable_WN_Simp = TRUE;
+    if (!DSL_Builder_Canonicalization_Enabled()) {
+        fprintf(stderr, "builder restriction was not restored\n");
+        return 1;
+    }
+
+    printf("DSL builder simplifier control contract passed\n");
+    return 0;
+}

--- a/osprey/common/com/tests/dsl_builder_simplifier_control_test.sh
+++ b/osprey/common/com/tests/dsl_builder_simplifier_control_test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+cxx="${CXX:-g++}"
+output="${TMPDIR:-/tmp}/dsl_builder_simplifier_control_test"
+
+"$cxx" -std=gnu++98 \
+  -DKEY \
+  -D__MIPS_AND_IA64_ELF_H \
+  -ffunction-sections \
+  -fdata-sections \
+  -I"$repo_root/osprey/linux/include" \
+  -I"$repo_root/osprey/ir_tools" \
+  -I"$repo_root/osprey/common/com" \
+  -I"$repo_root/osprey/common/com/x8664" \
+  -I"$repo_root/osprey/common/util" \
+  -I"$repo_root/osprey/include" \
+  -I"$repo_root/osprey/libdwarf/libdwarf" \
+  "$repo_root/osprey/common/com/dsl_builder.cxx" \
+  "$repo_root/osprey/common/com/tests/dsl_builder_simplifier_control_test.cxx" \
+  -Wl,--gc-sections \
+  -o "$output"
+
+"$output"

--- a/osprey/common/com/tests/dsl_canonicalization_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_canonicalization_contract_test.cxx
@@ -1,0 +1,62 @@
+/*
+ * Runtime contract checks for DSL algebraic canonicalization policy.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "dsl_domain.h"
+#include "dsl_opcode.h"
+
+int
+main(void)
+{
+    DSL_ALGEBRAIC_INFO info;
+    DSL_ALGEBRAIC_RELATION_INFO relation;
+    DSL_OPERATOR swap_equivalent;
+
+    DSL_Domain_Registry_Reset();
+    DSL_Opcode_Registry_Reset();
+    if (DSL_Opcode_Register_Common_Substrate() == 0 ||
+        DSL_Operator_Find("common.mul", strlen("common.mul"), 1) !=
+            OPR_DSLMUL ||
+        strcmp(DSL_OPERATOR_name(OPR_DSLMUL), "OPR_DSLMUL") != 0 ||
+        !DSL_Operator_Get_Algebraic_Info(OPR_DSLADD, 1, &info) ||
+        info.identity != DSL_ALGEBRAIC_IDENTITY_ZERO ||
+        !DSL_Operator_Get_Swap_Equivalent
+             (OPR_DSLADD, 1, &swap_equivalent) ||
+        swap_equivalent != OPR_DSLADD ||
+        !DSL_Operator_Get_Algebraic_Info(OPR_DSLMUL, 1, &info) ||
+        info.identity != DSL_ALGEBRAIC_IDENTITY_ONE ||
+        !DSL_Algebraic_Relation_Get
+             (OPR_DSLADD, 1, OPR_DSLMUL, 1,
+              DSL_ALGEBRAIC_RELATION_FACTOR, &relation) ||
+        relation.operand_mask != DSL_ALGEBRAIC_OPERAND_ALL) {
+        fprintf(stderr, "DSL algebraic registry contract changed\n");
+        return 1;
+    }
+
+    if (!DSL_Algebraic_Should_Swap_Binary_Operands
+             (OPR_DSLADD, 1, TRUE, TRUE, FALSE, FALSE, "zeta", "alpha") ||
+        DSL_Algebraic_Should_Swap_Binary_Operands
+             (OPR_DSLADD, 1, TRUE, TRUE, FALSE, FALSE, "alpha", "zeta") ||
+        !DSL_Algebraic_Should_Swap_Binary_Operands
+             (OPR_DSLADD, 1, TRUE, TRUE, TRUE, FALSE, "zero", "alpha") ||
+        DSL_Algebraic_Should_Swap_Binary_Operands
+             (OPR_DSLADD, 1, TRUE, TRUE, FALSE, TRUE, "alpha", "zero") ||
+        DSL_Algebraic_Should_Swap_Binary_Operands
+             (OPR_DSLADD, 1, FALSE, TRUE, FALSE, FALSE, "zeta", "alpha") ||
+        DSL_Algebraic_Should_Swap_Binary_Operands
+             (OPR_DSLADD, 1, TRUE, FALSE, FALSE, FALSE, "zeta", "alpha") ||
+        DSL_Algebraic_Should_Swap_Binary_Operands
+             (OPR_DSLMATMUL, 1, TRUE, TRUE, FALSE, FALSE,
+              "zeta", "alpha") ||
+        DSL_Algebraic_Should_Swap_Binary_Operands
+             (OPR_DSLADD, 2, TRUE, TRUE, FALSE, FALSE, "zeta", "alpha")) {
+        fprintf(stderr, "DSL canonical operand-order policy changed\n");
+        return 1;
+    }
+
+    printf("DSL canonicalization contract passed\n");
+    return 0;
+}

--- a/osprey/common/com/tests/dsl_canonicalization_contract_test.sh
+++ b/osprey/common/com/tests/dsl_canonicalization_contract_test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+cxx="${CXX:-g++}"
+output="${TMPDIR:-/tmp}/dsl_canonicalization_contract_test"
+
+"$cxx" -std=gnu++98 \
+  -I"$repo_root/osprey/linux/include" \
+  -I"$repo_root/osprey/common/com" \
+  -I"$repo_root/osprey/common/com/x8664" \
+  -I"$repo_root/osprey/common/util" \
+  -I"$repo_root/osprey/include" \
+  "$repo_root/osprey/common/com/dsl_domain.cxx" \
+  "$repo_root/osprey/common/com/dsl_opcode.cxx" \
+  "$repo_root/osprey/common/com/tests/dsl_canonicalization_contract_test.cxx" \
+  -o "$output"
+
+"$output"

--- a/osprey/common/com/tests/dsl_native_syntax_test.sh
+++ b/osprey/common/com/tests/dsl_native_syntax_test.sh
@@ -52,6 +52,8 @@ sources=(
   "osprey/common/com/dsl_ir_print.cxx"
   "osprey/common/com/dsl_tensor_fold.cxx"
   "osprey/common/com/tests/dsl_builder_contract_test.cxx"
+  "osprey/common/com/tests/dsl_builder_simplifier_control_test.cxx"
+  "osprey/common/com/tests/dsl_canonicalization_contract_test.cxx"
   "osprey/common/com/tests/dsl_common_add_print_test.cxx"
   "osprey/common/com/tests/dsl_common_matmul_print_test.cxx"
   "osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx"
@@ -69,6 +71,8 @@ for source in "${sources[@]}"; do
   echo "syntax ok: $source"
 done
 
+"$script_dir/dsl_builder_simplifier_control_test.sh"
+"$script_dir/dsl_canonicalization_contract_test.sh"
 "$script_dir/dsl_tensor_fold_contract_test.sh"
 "$script_dir/dsl_operator_layout_test.sh"
 

--- a/osprey/common/com/wn.h
+++ b/osprey/common/com/wn.h
@@ -1053,6 +1053,7 @@ extern STR_IDX WN_GetComment (const WN *wn);  /* get string idx from comment nod
 #define WN_DSL_OPERAND_PREFIX "__WHIRL_DSL_OPERAND__:"
 #define WN_DSL_NODE_CARRIER_OPERATOR OPR_EVAL
 #define DSL_OPCODE_COMMON_ADD "common.add"
+#define DSL_OPCODE_COMMON_MUL "common.mul"
 #define DSL_OPCODE_COMMON_MATMUL "common.matmul"
 #define DSL_OPCODE_COMMON_TENSOR_CONST "common.tensor_const"
 #define DSL_OPCODE_COMMON_ZERO_INIT "common.zero_init"


### PR DESCRIPTION
## Summary

- append logical `common.mul.v1` without changing the physical WHIRL operator layout
- add runtime-only algebraic contracts for `common.add.v1` and `common.mul.v1`, including commutation, reassociation, identity, factor, and distribute policy
- canonicalize integer tensor operands only when semantic TensorDescriptorIR state is equivalent
- normalize a lone constant to `kid1` and otherwise use a stable structural key
- exclude source context, compiler metadata, and lineage from canonical ordering
- make the builder-local switch subordinate to the existing `Enable_WN_Simp` master control
- document the Open64 design-continuity and `-OPT:wn_simp` debugging rules

## Staging

This is stacked on #89. It is M1 preparation, not completion: stack-local WN preparation, the traditional `wn_simp_code.h` engine call, DSL postprocessing, structured traces, and the mock tensor evaluator remain later work. Canonicalization defaults off, so existing builder behavior is preserved unless explicitly enabled.

## Compatibility

- `OPR_DSLMUL` is appended as logical ID 22
- physical `OPR_DSL` escape representation is unchanged
- no ELF section, mapped-image, type-kind, or traditional opcode layout change
- existing operator-layout compatibility matrix passes

## Validation

- clean Docker build of repository JsonCpp, backend dependencies, `ir_b2a`, and `dsl_builder_contract_test`
- `OPEN64_DSL_CANONICALIZATION_ONLY=1 dsl_builder_contract_test`
- `dsl_builder_simplifier_control_test.sh`
- `dsl_canonicalization_contract_test.sh`
- `dsl_native_syntax_test.sh`
- physical operator compatibility matrix across x8664, mips, mips-sl, key-generic, loongson, and baseline
- `git diff --check` and added-line no-tab scan passed