### PR TITLE
Complete M1 DSL simplifier foundation

### DIFF
--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -1099,8 +1099,8 @@ capability per pull request. Do not use M7 as a miscellaneous cleanup batch.
 
 | Milestone | Status | Merge dependency | Review artifact |
 | --- | --- | --- | --- |
-| M0 | PR #89 open | None | Contract/API test report |
-| M1 | Canonicalization/control preparation | M0 merged | Simplifier bridge traces |
+| M0 | Merged through PR #89/#92 | None | Contract/API test report |
+| M1 | Implementation complete; PR pending | M0 merged | Simplifier bridge traces |
 | M2 | Blocked by M1 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Blocked by M2 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |
@@ -1124,8 +1124,8 @@ The M0 tensor-folding handoff is implemented in
 `osprey/common/com/dsl_tensor_fold.{h,cxx}`. It recognizes the reviewed
 `common.add.v1` evaluator identity and defines fixed-layout candidates,
 bounded results, policies, and structured rejection reasons. The target hook
-deliberately rejects evaluation in M0; no tensor TCON is created and no
-builder behavior changes.
+remains non-folding by default; no tensor TCON is created and no builder
+behavior changes.
 
 The first M1 preparation is implemented:
 
@@ -1140,9 +1140,26 @@ The first M1 preparation is implemented:
 - the builder-local control can further restrict work but cannot override a
   disabled `Enable_WN_Simp` master control.
 
-This preparation does not complete M1. Stack-local physical WN preparation,
-the traditional `wn_simp_code.h` engine call, DSL postprocessing, structured
-traces, and the mock tensor evaluator remain required.
+The remaining M1 foundation is implemented:
+
+- `dsl_simp.{h,cxx}` validates logical operator/version, purity, canonical
+  TensorDescriptorIR equivalence, integer numeric policy, and the active
+  `Enable_WN_Simp` master control;
+- preparation initializes a temporary stack-local WN with the equivalent
+  traditional `OPR_ADD` or `OPR_MPY` opcode and disposable projected kids;
+- application invokes `WN_SimplifyExp2`, preserving its established
+  consume/delete ownership convention;
+- postprocessing classifies an unchanged result, retained `kid0`/`kid1`, or a
+  new pool-backed WN without publishing a tensor replacement;
+- stable traces expose `OPR_DSLADD`/`common.add.v1` and
+  `OPR_DSLMUL`/`common.mul.v1`, never the physical DSL escape tag; and
+- the tensor-fold mock is explicit, resettable, runtime-only, and disabled by
+  default. It exercises success, structured rejection, budget, and unchanged
+  paths without reading tensor payload bytes.
+
+The scalar operand projection remains test-only in M1. Production tensor
+projection and builder publication remain disabled until M2 establishes
+tensor TCON storage and M3 integrates the first real folding path.
 
 ## Staged Action List
 

--- a/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
+++ b/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
@@ -545,8 +545,8 @@ The clean pull-request rule is:
 
 | Milestone | Status | Merge dependency | Review artifact |
 | --- | --- | --- | --- |
-| M0 | PR #89 open | None | Contract/API test report |
-| M1 | Canonicalization/control preparation | M0 merged | Simplifier bridge traces |
+| M0 | Merged through PR #89/#92 | None | Contract/API test report |
+| M1 | Implementation complete; PR pending | M0 merged | Simplifier bridge traces |
 | M2 | Blocked by M1 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Blocked by M2 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |

--- a/osprey/common/com/dsl_simp.cxx
+++ b/osprey/common/com/dsl_simp.cxx
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2026 Open64 Project
+ */
+
+#include <string.h>
+
+#include "defs.h"
+#include "config.h"
+#include "dsl_simp.h"
+#include "mtypes.h"
+#include "opcode.h"
+#include "symtab.h"
+#include "symtab_utils.h"
+#include "wn.h"
+#include "wn_simp.h"
+
+static const char *DSL_simp_status_name[] = {
+    "not_applicable",
+    "unchanged",
+    "engine_rewrite",
+    "reject_disabled",
+    "reject_malformed",
+    "reject_unsupported_operator",
+    "reject_effectful_operator",
+    "reject_descriptor",
+    "reject_numeric_policy",
+    "reject_projection",
+    "invalid"
+};
+
+static const char *DSL_simp_replacement_name[] = {
+    "none",
+    "kid0",
+    "kid1",
+    "new_wn"
+};
+
+static void
+DSL_Simp_Set_Status
+        (DSL_SIMP_BINARY_RESULT *result,
+         DSL_SIMP_STATUS status)
+{
+    result->status = status;
+    result->rejection =
+        status >= DSL_SIMP_REJECT_DISABLED ? status : DSL_SIMP_NOT_APPLICABLE;
+}
+
+static BOOL
+DSL_Simp_Map_Binary_Operator
+        (DSL_OPERATOR dsl_operator,
+         TYPE_ID mtype,
+         OPCODE *opcode)
+{
+    OPERATOR whirl_operator;
+
+    switch (dsl_operator) {
+    case OPR_DSLADD:
+        whirl_operator = OPR_ADD;
+        break;
+    case OPR_DSLMUL:
+        whirl_operator = OPR_MPY;
+        break;
+    default:
+        return FALSE;
+    }
+
+    if (opcode != NULL)
+        *opcode = OPCODE_make_op(whirl_operator, mtype, MTYPE_V);
+    return TRUE;
+}
+
+static BOOL
+DSL_Simp_Tensor_Descriptors_Equivalent (TY_IDX first, TY_IDX second)
+{
+    return TY_is_tensor_extension(first) &&
+           TY_is_tensor_extension(second) &&
+           TY_tensor_is_canonical(first) &&
+           TY_tensor_is_canonical(second) &&
+           TY_tensor_rank(first) == TY_tensor_rank(second) &&
+           TY_tensor_attributes_are_equivalent(first, second) &&
+           TY_are_equivalent(TY_tensor_element_ty(first),
+                             TY_tensor_element_ty(second),
+                             TY_EQUIV_IGNORE_NAMES) &&
+           TY_are_equivalent(first, second, TY_EQUIV_IGNORE_NAMES);
+}
+
+const char *
+DSL_Simp_Status_Name (DSL_SIMP_STATUS status)
+{
+    UINT32 ordinal = (UINT32)status;
+
+    if (ordinal >= sizeof(DSL_simp_status_name) /
+                   sizeof(DSL_simp_status_name[0]))
+        return "unknown";
+    return DSL_simp_status_name[ordinal];
+}
+
+const char *
+DSL_Simp_Replacement_Name (DSL_SIMP_REPLACEMENT_KIND replacement)
+{
+    UINT32 ordinal = (UINT32)replacement;
+
+    if (ordinal >= sizeof(DSL_simp_replacement_name) /
+                   sizeof(DSL_simp_replacement_name[0]))
+        return "unknown";
+    return DSL_simp_replacement_name[ordinal];
+}
+
+DSL_SIMP_STATUS
+DSL_Simp_Prepare_Binary
+        (const DSL_SIMP_BINARY_CANDIDATE *candidate,
+         WN *stack_view,
+         DSL_SIMP_BINARY_RESULT *result)
+{
+    DSL_OPERATOR_INFO operator_info;
+    TY_IDX element_ty;
+    TYPE_ID mtype;
+    OPCODE opcode;
+
+    if (result != NULL)
+        memset(result, 0, sizeof(*result));
+    if (candidate == NULL || stack_view == NULL || result == NULL) {
+        if (result != NULL)
+            DSL_Simp_Set_Status(result, DSL_SIMP_REJECT_MALFORMED);
+        return DSL_SIMP_REJECT_MALFORMED;
+    }
+
+    result->dsl_operator = candidate->dsl_operator;
+    result->version = candidate->version;
+    result->projected_kid[0] = candidate->projected_kid[0];
+    result->projected_kid[1] = candidate->projected_kid[1];
+
+    if (!Enable_WN_Simp) {
+        DSL_Simp_Set_Status(result, DSL_SIMP_REJECT_DISABLED);
+        return result->status;
+    }
+    if (!DSL_Operator_Get_Info_Version(candidate->dsl_operator,
+                                       candidate->version, &operator_info) ||
+        !DSL_Operator_Get_Algebraic_Info(candidate->dsl_operator,
+                                         candidate->version,
+                                         NULL) ||
+        operator_info.nkids != 2) {
+        DSL_Simp_Set_Status(result, DSL_SIMP_REJECT_UNSUPPORTED_OPERATOR);
+        return result->status;
+    }
+    if (operator_info.effect_model != DSL_EFFECT_MODEL_PURE) {
+        DSL_Simp_Set_Status(result, DSL_SIMP_REJECT_EFFECTFUL_OPERATOR);
+        return result->status;
+    }
+    if (!DSL_Simp_Tensor_Descriptors_Equivalent
+             (candidate->result_ty, candidate->operand_ty[0]) ||
+        !DSL_Simp_Tensor_Descriptors_Equivalent
+             (candidate->result_ty, candidate->operand_ty[1])) {
+        DSL_Simp_Set_Status(result, DSL_SIMP_REJECT_DESCRIPTOR);
+        return result->status;
+    }
+
+    element_ty = TY_tensor_element_ty(candidate->result_ty);
+    mtype = TY_mtype(element_ty);
+    if (!MTYPE_is_integral(mtype)) {
+        DSL_Simp_Set_Status(result, DSL_SIMP_REJECT_NUMERIC_POLICY);
+        return result->status;
+    }
+    if (candidate->projection_kind != DSL_SIMP_PROJECTION_TEST_SCALAR ||
+        candidate->projected_kid[0] == NULL ||
+        candidate->projected_kid[1] == NULL ||
+        !OPCODE_is_expression(WN_opcode(candidate->projected_kid[0])) ||
+        !OPCODE_is_expression(WN_opcode(candidate->projected_kid[1])) ||
+        WN_rtype(candidate->projected_kid[0]) != mtype ||
+        WN_rtype(candidate->projected_kid[1]) != mtype ||
+        !DSL_Simp_Map_Binary_Operator(candidate->dsl_operator, mtype,
+                                      &opcode)) {
+        DSL_Simp_Set_Status(result, DSL_SIMP_REJECT_PROJECTION);
+        return result->status;
+    }
+
+    memset(stack_view, 0, sizeof(*stack_view));
+    WN_set_opcode(stack_view, opcode);
+    WN_set_map_id(stack_view, -1);
+    WN_kid0(stack_view) = candidate->projected_kid[0];
+    WN_kid1(stack_view) = candidate->projected_kid[1];
+    result->projected_opcode = opcode;
+    DSL_Simp_Set_Status(result, DSL_SIMP_NOT_APPLICABLE);
+    return result->status;
+}
+
+DSL_SIMP_STATUS
+DSL_Simp_Apply_Binary
+        (WN *stack_view,
+         DSL_SIMP_BINARY_RESULT *result)
+{
+    if (stack_view == NULL || result == NULL ||
+        result->status != DSL_SIMP_NOT_APPLICABLE ||
+        result->projected_opcode != WN_opcode(stack_view)) {
+        if (result != NULL)
+            DSL_Simp_Set_Status(result, DSL_SIMP_REJECT_MALFORMED);
+        return DSL_SIMP_REJECT_MALFORMED;
+    }
+
+    result->engine_result =
+        WN_SimplifyExp2(WN_opcode(stack_view),
+                        WN_kid0(stack_view), WN_kid1(stack_view));
+    result->status = result->engine_result == NULL ?
+        DSL_SIMP_UNCHANGED : DSL_SIMP_ENGINE_REWRITE;
+    return result->status;
+}
+
+DSL_SIMP_STATUS
+DSL_Simp_Postprocess_Binary (DSL_SIMP_BINARY_RESULT *result)
+{
+    if (result == NULL ||
+        (result->status != DSL_SIMP_UNCHANGED &&
+         result->status != DSL_SIMP_ENGINE_REWRITE)) {
+        if (result != NULL)
+            DSL_Simp_Set_Status(result, DSL_SIMP_REJECT_MALFORMED);
+        return DSL_SIMP_REJECT_MALFORMED;
+    }
+
+    if (result->status == DSL_SIMP_UNCHANGED)
+        result->replacement = DSL_SIMP_REPLACEMENT_NONE;
+    else if (result->engine_result == result->projected_kid[0])
+        result->replacement = DSL_SIMP_REPLACEMENT_KID0;
+    else if (result->engine_result == result->projected_kid[1])
+        result->replacement = DSL_SIMP_REPLACEMENT_KID1;
+    else
+        result->replacement = DSL_SIMP_REPLACEMENT_NEW_WN;
+    return result->status;
+}
+
+DSL_SIMP_STATUS
+DSL_Simp_Binary
+        (const DSL_SIMP_BINARY_CANDIDATE *candidate,
+         DSL_SIMP_BINARY_RESULT *result)
+{
+    WN stack_view;
+    DSL_SIMP_STATUS status =
+        DSL_Simp_Prepare_Binary(candidate, &stack_view, result);
+
+    if (status != DSL_SIMP_NOT_APPLICABLE)
+        return status;
+    status = DSL_Simp_Apply_Binary(&stack_view, result);
+    if (status != DSL_SIMP_UNCHANGED &&
+        status != DSL_SIMP_ENGINE_REWRITE)
+        return status;
+    return DSL_Simp_Postprocess_Binary(result);
+}
+
+void
+DSL_Simp_Trace_Binary
+        (FILE *file,
+         const DSL_SIMP_BINARY_RESULT *result)
+{
+    DSL_OPERATOR_INFO operator_info;
+    const char *stable_name = "unknown";
+
+    if (file == NULL || result == NULL)
+        return;
+    if (DSL_Operator_Get_Info_Version(result->dsl_operator, result->version,
+                                      &operator_info))
+        stable_name = operator_info.stable_name;
+
+    fprintf(file,
+            "DSL simplifier: operator %s (%s.v%u), status %s, "
+            "replacement %s\n",
+            DSL_OPERATOR_name(result->dsl_operator),
+            stable_name,
+            (unsigned int)result->version,
+            DSL_Simp_Status_Name(result->status),
+            DSL_Simp_Replacement_Name(result->replacement));
+}

--- a/osprey/common/com/dsl_simp.h
+++ b/osprey/common/com/dsl_simp.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Open64 Project
+ */
+
+#ifndef dsl_simp_INCLUDED
+#define dsl_simp_INCLUDED
+
+#include <stdio.h>
+
+#include "defs.h"
+#include "dsl_opcode.h"
+#include "opcode.h"
+#include "symtab_idx.h"
+
+class WN;
+
+/*
+ * M1 bridge between logical DSL expressions and the traditional WN
+ * simplifier. The scalar projection is a test-only proof vehicle until tensor
+ * constant storage and result publication have a reviewed representation.
+ */
+typedef enum {
+    DSL_SIMP_PROJECTION_NONE = 0,
+    DSL_SIMP_PROJECTION_TEST_SCALAR = 1
+} DSL_SIMP_PROJECTION_KIND;
+
+typedef enum {
+    DSL_SIMP_NOT_APPLICABLE = 0,
+    DSL_SIMP_UNCHANGED = 1,
+    DSL_SIMP_ENGINE_REWRITE = 2,
+    DSL_SIMP_REJECT_DISABLED = 3,
+    DSL_SIMP_REJECT_MALFORMED = 4,
+    DSL_SIMP_REJECT_UNSUPPORTED_OPERATOR = 5,
+    DSL_SIMP_REJECT_EFFECTFUL_OPERATOR = 6,
+    DSL_SIMP_REJECT_DESCRIPTOR = 7,
+    DSL_SIMP_REJECT_NUMERIC_POLICY = 8,
+    DSL_SIMP_REJECT_PROJECTION = 9,
+    DSL_SIMP_INVALID = 10
+} DSL_SIMP_STATUS;
+
+typedef enum {
+    DSL_SIMP_REPLACEMENT_NONE = 0,
+    DSL_SIMP_REPLACEMENT_KID0 = 1,
+    DSL_SIMP_REPLACEMENT_KID1 = 2,
+    DSL_SIMP_REPLACEMENT_NEW_WN = 3
+} DSL_SIMP_REPLACEMENT_KIND;
+
+typedef struct {
+    DSL_OPERATOR dsl_operator;
+    UINT16 version;
+    TY_IDX result_ty;
+    TY_IDX operand_ty[2];
+    DSL_SIMP_PROJECTION_KIND projection_kind;
+    WN *projected_kid[2];
+} DSL_SIMP_BINARY_CANDIDATE;
+
+typedef struct {
+    DSL_SIMP_STATUS status;
+    DSL_SIMP_STATUS rejection;
+    DSL_SIMP_REPLACEMENT_KIND replacement;
+    DSL_OPERATOR dsl_operator;
+    UINT16 version;
+    OPCODE projected_opcode;
+    WN *projected_kid[2];
+    WN *engine_result;
+} DSL_SIMP_BINARY_RESULT;
+
+extern const char *DSL_Simp_Status_Name (DSL_SIMP_STATUS status);
+extern const char *DSL_Simp_Replacement_Name
+                                (DSL_SIMP_REPLACEMENT_KIND replacement);
+
+/*
+ * The caller owns projected_kid until Apply is called. On ENGINE_REWRITE the
+ * traditional simplifier has applied its normal consume/delete convention and
+ * engine_result is the retained pool-backed result. On UNCHANGED, the caller
+ * still owns both projected kids.
+ */
+extern DSL_SIMP_STATUS DSL_Simp_Prepare_Binary
+                                (const DSL_SIMP_BINARY_CANDIDATE *candidate,
+                                 WN *stack_view,
+                                 DSL_SIMP_BINARY_RESULT *result);
+extern DSL_SIMP_STATUS DSL_Simp_Apply_Binary
+                                (WN *stack_view,
+                                 DSL_SIMP_BINARY_RESULT *result);
+extern DSL_SIMP_STATUS DSL_Simp_Postprocess_Binary
+                                (DSL_SIMP_BINARY_RESULT *result);
+extern DSL_SIMP_STATUS DSL_Simp_Binary
+                                (const DSL_SIMP_BINARY_CANDIDATE *candidate,
+                                 DSL_SIMP_BINARY_RESULT *result);
+extern void DSL_Simp_Trace_Binary
+                                (FILE *file,
+                                 const DSL_SIMP_BINARY_RESULT *result);
+
+#endif /* dsl_simp_INCLUDED */

--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -46,7 +46,7 @@ DSL_Tensor_Fold_Set_Output_Status
 
     output->status = status;
     output->rejection = DSL_Tensor_Fold_Status_Is_Rejection(status) ?
-                            status : DSL_TENSOR_FOLD_SUCCESS;
+                            status : DSL_TENSOR_FOLD_NOT_APPLICABLE;
 }
 
 void
@@ -237,7 +237,7 @@ DSL_Tensor_Fold_Apply_Mock
         output->status = response->status;
         output->rejection =
             DSL_Tensor_Fold_Status_Is_Rejection(response->status) ?
-                response->status : DSL_TENSOR_FOLD_SUCCESS;
+                response->status : DSL_TENSOR_FOLD_NOT_APPLICABLE;
         output->result_count = response->result_count;
         output->rejected_result_index = response->rejected_result_index;
 

--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -26,6 +26,29 @@ static const char *DSL_tensor_fold_status_name[] = {
     "invalid"
 };
 
+static BOOL DSL_tensor_fold_mock_enabled = FALSE;
+static DSL_TENSOR_FOLD_MOCK_RESPONSE DSL_tensor_fold_mock_response;
+
+static void
+DSL_Tensor_Fold_Clear_Output (DSL_TENSOR_FOLD_OUTPUT *output)
+{
+    if (output != NULL)
+        memset(output, 0, sizeof(*output));
+}
+
+static void
+DSL_Tensor_Fold_Set_Output_Status
+        (DSL_TENSOR_FOLD_OUTPUT *output,
+         DSL_TENSOR_FOLD_STATUS status)
+{
+    if (output == NULL)
+        return;
+
+    output->status = status;
+    output->rejection = DSL_Tensor_Fold_Status_Is_Rejection(status) ?
+                            status : DSL_TENSOR_FOLD_SUCCESS;
+}
+
 void
 DSL_Tensor_Fold_Default_Policy (DSL_TENSOR_FOLD_POLICY *policy)
 {
@@ -34,6 +57,49 @@ DSL_Tensor_Fold_Default_Policy (DSL_TENSOR_FOLD_POLICY *policy)
 
     memset(policy, 0, sizeof(*policy));
     policy->preserve_compact_splats = TRUE;
+}
+
+void
+DSL_Tensor_Fold_Reset_Mock_Evaluator (void)
+{
+    DSL_tensor_fold_mock_enabled = FALSE;
+    memset(&DSL_tensor_fold_mock_response, 0,
+           sizeof(DSL_tensor_fold_mock_response));
+}
+
+BOOL
+DSL_Tensor_Fold_Set_Mock_Response
+        (const DSL_TENSOR_FOLD_MOCK_RESPONSE *response)
+{
+    if (response == NULL ||
+        response->result_count > DSL_TENSOR_FOLD_MAX_RESULTS)
+        return FALSE;
+
+    switch (response->status) {
+    case DSL_TENSOR_FOLD_SUCCESS:
+        if (response->result_count == 0)
+            return FALSE;
+        break;
+    case DSL_TENSOR_FOLD_NOT_APPLICABLE:
+        if (response->result_count != 0)
+            return FALSE;
+        break;
+    default:
+        if (!DSL_Tensor_Fold_Status_Is_Rejection(response->status) ||
+            response->result_count != 0)
+            return FALSE;
+        break;
+    }
+
+    DSL_tensor_fold_mock_response = *response;
+    DSL_tensor_fold_mock_enabled = TRUE;
+    return TRUE;
+}
+
+BOOL
+DSL_Tensor_Fold_Mock_Evaluator_Enabled (void)
+{
+    return DSL_tensor_fold_mock_enabled;
 }
 
 BOOL
@@ -101,6 +167,7 @@ DSL_Tensor_Fold_Candidate_Valid
 {
     DSL_TENSOR_FOLD_EVALUATOR_ID evaluator;
     DSL_OPERATOR_INFO operator_info;
+    const DSL_TENSOR_FOLD_POLICY *policy;
 
     if (reason != NULL)
         *reason = DSL_TENSOR_FOLD_SUCCESS;
@@ -138,7 +205,52 @@ DSL_Tensor_Fold_Candidate_Valid
         return FALSE;
     }
 
+    policy = candidate->policy;
+    if (policy != NULL &&
+        policy->max_evaluator_work != 0 &&
+        candidate->operand_count > policy->max_evaluator_work) {
+        if (reason != NULL)
+            *reason = DSL_TENSOR_FOLD_REJECT_WORK_BUDGET;
+        return FALSE;
+    }
+
     return TRUE;
+}
+
+static DSL_TENSOR_FOLD_STATUS
+DSL_Tensor_Fold_Apply_Mock
+        (const DSL_TENSOR_FOLD_CANDIDATE *candidate,
+         DSL_TENSOR_FOLD_OUTPUT *output)
+{
+    const DSL_TENSOR_FOLD_MOCK_RESPONSE *response =
+        &DSL_tensor_fold_mock_response;
+    UINT32 i;
+
+    if (response->status == DSL_TENSOR_FOLD_SUCCESS &&
+        response->result_count > candidate->result_count) {
+        DSL_Tensor_Fold_Set_Output_Status
+            (output, DSL_TENSOR_FOLD_REJECT_RESULT_BUDGET);
+        return DSL_TENSOR_FOLD_REJECT_RESULT_BUDGET;
+    }
+
+    if (output != NULL) {
+        output->status = response->status;
+        output->rejection =
+            DSL_Tensor_Fold_Status_Is_Rejection(response->status) ?
+                response->status : DSL_TENSOR_FOLD_SUCCESS;
+        output->result_count = response->result_count;
+        output->rejected_result_index = response->rejected_result_index;
+
+        if (response->status == DSL_TENSOR_FOLD_SUCCESS) {
+            for (i = 0; i < response->result_count; ++i) {
+                output->results[i].kind = DSL_TENSOR_FOLD_RESULT_TCON;
+                output->results[i].result_ty = candidate->result_ty[i];
+                output->results[i].flags = response->flags;
+            }
+        }
+    }
+
+    return response->status;
 }
 
 DSL_TENSOR_FOLD_STATUS
@@ -148,20 +260,17 @@ Targ_DSL_WhirlOp
 {
     DSL_TENSOR_FOLD_STATUS reason;
 
-    if (output != NULL)
-        memset(output, 0, sizeof(*output));
+    DSL_Tensor_Fold_Clear_Output(output);
 
     if (!DSL_Tensor_Fold_Candidate_Valid(candidate, &reason)) {
-        if (output != NULL) {
-            output->status = reason;
-            output->rejection = reason;
-        }
+        DSL_Tensor_Fold_Set_Output_Status(output, reason);
         return reason;
     }
 
-    if (output != NULL) {
-        output->status = DSL_TENSOR_FOLD_REJECT_UNSUPPORTED_EVALUATOR;
-        output->rejection = DSL_TENSOR_FOLD_REJECT_UNSUPPORTED_EVALUATOR;
-    }
-    return DSL_TENSOR_FOLD_REJECT_UNSUPPORTED_EVALUATOR;
+    if (DSL_tensor_fold_mock_enabled)
+        return DSL_Tensor_Fold_Apply_Mock(candidate, output);
+
+    DSL_Tensor_Fold_Set_Output_Status(output,
+                                      DSL_TENSOR_FOLD_NOT_APPLICABLE);
+    return DSL_TENSOR_FOLD_NOT_APPLICABLE;
 }

--- a/osprey/common/com/dsl_tensor_fold.h
+++ b/osprey/common/com/dsl_tensor_fold.h
@@ -98,8 +98,20 @@ typedef struct {
     DSL_TENSOR_FOLD_RESULT_SLOT results[DSL_TENSOR_FOLD_MAX_RESULTS];
 } DSL_TENSOR_FOLD_OUTPUT;
 
+typedef struct {
+    DSL_TENSOR_FOLD_STATUS status;
+    UINT16 result_count;
+    UINT16 rejected_result_index;
+    UINT32 flags;
+} DSL_TENSOR_FOLD_MOCK_RESPONSE;
+
 extern void DSL_Tensor_Fold_Default_Policy
                                 (DSL_TENSOR_FOLD_POLICY *policy);
+extern void DSL_Tensor_Fold_Reset_Mock_Evaluator (void);
+extern BOOL DSL_Tensor_Fold_Set_Mock_Response
+                                (const DSL_TENSOR_FOLD_MOCK_RESPONSE
+                                     *response);
+extern BOOL DSL_Tensor_Fold_Mock_Evaluator_Enabled (void);
 extern BOOL DSL_Tensor_Fold_Get_Evaluator
                                 (DSL_OPERATOR dsl_operator,
                                  UINT16 version,

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -34,6 +34,7 @@
 #include "dsl_contract.h"
 #include "dsl_gatekeeper.h"
 #include "dsl_memory_behavior.h"
+#include "dsl_simp.h"
 
 BOOL Run_vsaopt = FALSE;
 INT8 Debug_Level = 0;
@@ -149,6 +150,111 @@ Check_Tensor_Type_And_Descriptor(void)
     }
 
     return failed;
+}
+
+static int
+Check_DSL_Simplifier_Bridge(void)
+{
+    DSL_BUILDER_TENSOR_DESCRIPTOR descriptor;
+    DSL_SIMP_BINARY_CANDIDATE candidate;
+    DSL_SIMP_BINARY_RESULT result;
+    TY_IDX tensor_ty;
+    TY_IDX different_tensor_ty;
+    WN stack_view;
+    WN *variable;
+    WN *identity;
+
+    memset(&descriptor, 0, sizeof(descriptor));
+    descriptor.type_core.kind = "tensor";
+    descriptor.type_core.dtype = "int32";
+    descriptor.type_core.rank = 2;
+    descriptor.type_core.logical_shape = "[2,2]";
+    descriptor.traits.traits = "dense";
+    descriptor.representation.layout = "row_major";
+    descriptor.representation.sharding = "replicated";
+    descriptor.representation.placement = "host";
+    descriptor.representation.memory = "contiguous";
+    descriptor.representation.quantization = "none";
+    tensor_ty = DSL_Builder_Intern_Tensor_Type
+                    ("dsl_simp_tensor", MTYPE_To_TY(MTYPE_I4), &descriptor);
+    if (TY_IDX_index(tensor_ty) == 0) {
+        fprintf(stderr, "DSL simplifier tensor descriptor setup failed\n");
+        return 1;
+    }
+
+    variable = WN_LdidPreg(MTYPE_I4, 1);
+    identity = WN_Intconst(MTYPE_I4, 0);
+    memset(&candidate, 0, sizeof(candidate));
+    candidate.dsl_operator = OPR_DSLADD;
+    candidate.version = 1;
+    candidate.result_ty = tensor_ty;
+    candidate.operand_ty[0] = tensor_ty;
+    candidate.operand_ty[1] = tensor_ty;
+    candidate.projection_kind = DSL_SIMP_PROJECTION_TEST_SCALAR;
+    candidate.projected_kid[0] = variable;
+    candidate.projected_kid[1] = identity;
+
+    if (DSL_Simp_Binary(&candidate, &result) !=
+            DSL_SIMP_ENGINE_REWRITE ||
+        result.replacement != DSL_SIMP_REPLACEMENT_KID0 ||
+        result.engine_result != variable) {
+        DSL_Simp_Trace_Binary(stderr, &result);
+        fprintf(stderr, "traditional wn_simp add-zero bridge failed\n");
+        return 1;
+    }
+    DSL_Simp_Trace_Binary(stdout, &result);
+
+    variable = WN_LdidPreg(MTYPE_I4, 2);
+    identity = WN_Intconst(MTYPE_I4, 1);
+    candidate.dsl_operator = OPR_DSLMUL;
+    candidate.projected_kid[0] = variable;
+    candidate.projected_kid[1] = identity;
+    if (DSL_Simp_Prepare_Binary(&candidate, &stack_view, &result) !=
+            DSL_SIMP_NOT_APPLICABLE ||
+        WN_operator(&stack_view) != OPR_MPY ||
+        DSL_Simp_Apply_Binary(&stack_view, &result) !=
+            DSL_SIMP_ENGINE_REWRITE ||
+        DSL_Simp_Postprocess_Binary(&result) != DSL_SIMP_ENGINE_REWRITE ||
+        result.replacement != DSL_SIMP_REPLACEMENT_KID0) {
+        DSL_Simp_Trace_Binary(stderr, &result);
+        fprintf(stderr, "three-stage wn_simp multiply-one bridge failed\n");
+        return 1;
+    }
+    DSL_Simp_Trace_Binary(stdout, &result);
+
+    Enable_WN_Simp = FALSE;
+    candidate.dsl_operator = OPR_DSLADD;
+    candidate.projected_kid[0] = WN_LdidPreg(MTYPE_I4, 3);
+    candidate.projected_kid[1] = WN_Intconst(MTYPE_I4, 0);
+    if (DSL_Simp_Binary(&candidate, &result) !=
+            DSL_SIMP_REJECT_DISABLED) {
+        fprintf(stderr, "DSL simplifier bypassed Enable_WN_Simp\n");
+        Enable_WN_Simp = TRUE;
+        return 1;
+    }
+    Enable_WN_Simp = TRUE;
+
+    candidate.projection_kind = DSL_SIMP_PROJECTION_NONE;
+    if (DSL_Simp_Binary(&candidate, &result) !=
+            DSL_SIMP_REJECT_PROJECTION) {
+        fprintf(stderr, "production tensor projection became active in M1\n");
+        return 1;
+    }
+
+    descriptor.type_core.logical_shape = "[4,1]";
+    different_tensor_ty = DSL_Builder_Intern_Tensor_Type
+                              ("dsl_simp_different_tensor",
+                               MTYPE_To_TY(MTYPE_I4), &descriptor);
+    candidate.operand_ty[1] = different_tensor_ty;
+    if (TY_IDX_index(different_tensor_ty) == 0 ||
+        DSL_Simp_Binary(&candidate, &result) !=
+            DSL_SIMP_REJECT_DESCRIPTOR) {
+        fprintf(stderr, "DSL simplifier accepted mismatched descriptors\n");
+        return 1;
+    }
+
+    DSL_Simp_Trace_Binary(stdout, &result);
+    return 0;
 }
 
 static int
@@ -3899,6 +4005,8 @@ main(void)
         return Check_Multiple_Program_Units();
     if (getenv("OPEN64_DSL_CANONICALIZATION_ONLY") != NULL)
         return Check_Algebraic_Canonicalization();
+    if (getenv("OPEN64_DSL_SIMPLIFIER_ONLY") != NULL)
+        return Check_DSL_Simplifier_Bridge();
 
     failed |= Check_Tensor_Type_And_Descriptor();
     failed |= Check_Symbol_Metadata();
@@ -3917,6 +4025,7 @@ main(void)
     failed |= Check_Llama2_Decode_State_Region();
     failed |= Check_Native_DSL_Node_Layout();
     failed |= Check_DSL_IR_Image_Tables();
+    failed |= Check_DSL_Simplifier_Bridge();
 
     return failed;
 }

--- a/osprey/common/com/tests/dsl_native_syntax_test.sh
+++ b/osprey/common/com/tests/dsl_native_syntax_test.sh
@@ -50,6 +50,7 @@ sources=(
   "osprey/common/com/dsl_ir_image.cxx"
   "osprey/common/com/dsl_region.cxx"
   "osprey/common/com/dsl_ir_print.cxx"
+  "osprey/common/com/dsl_simp.cxx"
   "osprey/common/com/dsl_tensor_fold.cxx"
   "osprey/common/com/tests/dsl_builder_contract_test.cxx"
   "osprey/common/com/tests/dsl_builder_simplifier_control_test.cxx"

--- a/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
@@ -95,11 +95,17 @@ Check_Candidate_Contract(void)
         return 1;
     }
 
+    DSL_Tensor_Fold_Reset_Mock_Evaluator();
+    if (DSL_Tensor_Fold_Mock_Evaluator_Enabled()) {
+        fprintf(stderr, "mock evaluator did not reset\n");
+        return 1;
+    }
+
     if (Targ_DSL_WhirlOp(&candidate, &output) !=
-            DSL_TENSOR_FOLD_REJECT_UNSUPPORTED_EVALUATOR ||
-        output.status != DSL_TENSOR_FOLD_REJECT_UNSUPPORTED_EVALUATOR ||
+            DSL_TENSOR_FOLD_NOT_APPLICABLE ||
+        output.status != DSL_TENSOR_FOLD_NOT_APPLICABLE ||
         output.result_count != 0) {
-        fprintf(stderr, "M0 non-evaluator result contract changed\n");
+        fprintf(stderr, "production tensor fold fallback changed\n");
         return 1;
     }
 
@@ -145,6 +151,106 @@ Check_Candidate_Contract(void)
     return 0;
 }
 
+static int
+Check_Mock_Evaluator(void)
+{
+    DSL_TENSOR_FOLD_POLICY policy;
+    DSL_TENSOR_FOLD_CANDIDATE candidate;
+    DSL_TENSOR_FOLD_MOCK_RESPONSE response;
+    DSL_TENSOR_FOLD_OUTPUT output;
+    TCON operands[2];
+    TY_IDX operand_ty[2];
+    TY_IDX result_ty[DSL_TENSOR_FOLD_MAX_RESULTS];
+
+    DSL_Tensor_Fold_Default_Policy(&policy);
+    memset(operands, 0, sizeof(operands));
+    memset(operand_ty, 0, sizeof(operand_ty));
+    memset(result_ty, 0, sizeof(result_ty));
+    memset(&candidate, 0, sizeof(candidate));
+    memset(&response, 0, sizeof(response));
+
+    Set_TY_IDX_index(result_ty[0], 41);
+    candidate.dsl_operator = OPR_DSLADD;
+    candidate.version = 1;
+    candidate.result_count = 1;
+    candidate.operand_count = 2;
+    candidate.operands = operands;
+    candidate.operand_ty = operand_ty;
+    candidate.result_ty = result_ty;
+    candidate.policy = &policy;
+
+    response.status = DSL_TENSOR_FOLD_SUCCESS;
+    response.result_count = 1;
+    response.flags = 7;
+    if (!DSL_Tensor_Fold_Set_Mock_Response(&response) ||
+        !DSL_Tensor_Fold_Mock_Evaluator_Enabled()) {
+        fprintf(stderr, "mock tensor fold evaluator did not install\n");
+        return 1;
+    }
+
+    memset(&output, 0xff, sizeof(output));
+    if (Targ_DSL_WhirlOp(&candidate, &output) !=
+            DSL_TENSOR_FOLD_SUCCESS ||
+        output.status != DSL_TENSOR_FOLD_SUCCESS ||
+        output.result_count != 1 ||
+        output.results[0].kind != DSL_TENSOR_FOLD_RESULT_TCON ||
+        output.results[0].result_ty != result_ty[0] ||
+        output.results[0].flags != 7) {
+        fprintf(stderr, "mock tensor fold success contract changed\n");
+        return 1;
+    }
+
+    response.status = DSL_TENSOR_FOLD_REJECT_MATERIALIZATION_POLICY;
+    response.result_count = 0;
+    if (!DSL_Tensor_Fold_Set_Mock_Response(&response) ||
+        Targ_DSL_WhirlOp(&candidate, &output) !=
+            DSL_TENSOR_FOLD_REJECT_MATERIALIZATION_POLICY ||
+        output.rejection !=
+            DSL_TENSOR_FOLD_REJECT_MATERIALIZATION_POLICY ||
+        output.result_count != 0) {
+        fprintf(stderr, "mock tensor fold rejection contract changed\n");
+        return 1;
+    }
+
+    response.status = DSL_TENSOR_FOLD_NOT_APPLICABLE;
+    response.result_count = 0;
+    if (!DSL_Tensor_Fold_Set_Mock_Response(&response) ||
+        Targ_DSL_WhirlOp(&candidate, &output) !=
+            DSL_TENSOR_FOLD_NOT_APPLICABLE ||
+        output.status != DSL_TENSOR_FOLD_NOT_APPLICABLE ||
+        output.result_count != 0) {
+        fprintf(stderr, "mock tensor fold unchanged path changed\n");
+        return 1;
+    }
+
+    policy.max_evaluator_work = 1;
+    if (Targ_DSL_WhirlOp(&candidate, &output) !=
+            DSL_TENSOR_FOLD_REJECT_WORK_BUDGET ||
+        output.rejection != DSL_TENSOR_FOLD_REJECT_WORK_BUDGET) {
+        fprintf(stderr, "tensor fold work-budget rejection changed\n");
+        return 1;
+    }
+
+    policy.max_evaluator_work = 0;
+    response.status = DSL_TENSOR_FOLD_SUCCESS;
+    response.result_count = 2;
+    if (!DSL_Tensor_Fold_Set_Mock_Response(&response) ||
+        Targ_DSL_WhirlOp(&candidate, &output) !=
+            DSL_TENSOR_FOLD_REJECT_RESULT_BUDGET ||
+        output.rejection != DSL_TENSOR_FOLD_REJECT_RESULT_BUDGET) {
+        fprintf(stderr, "mock tensor fold result-budget handling changed\n");
+        return 1;
+    }
+
+    DSL_Tensor_Fold_Reset_Mock_Evaluator();
+    if (DSL_Tensor_Fold_Mock_Evaluator_Enabled()) {
+        fprintf(stderr, "mock tensor fold evaluator remained installed\n");
+        return 1;
+    }
+
+    return 0;
+}
+
 int
 main(void)
 {
@@ -155,9 +261,10 @@ main(void)
 
     if (Check_Status_Names() ||
         Check_Evaluator_Identity() ||
-        Check_Candidate_Contract())
+        Check_Candidate_Contract() ||
+        Check_Mock_Evaluator())
         return 1;
 
-    printf("DSL tensor fold M0 contract passed\n");
+    printf("DSL tensor fold M1 mock contract passed\n");
     return 0;
 }

--- a/osprey/ir_tools/Makefile.gbase
+++ b/osprey/ir_tools/Makefile.gbase
@@ -190,6 +190,7 @@ COMMON_COM_CXX_SRC =	\
         dsl_region.cxx \
 	dsl_memory_behavior.cxx \
 	dsl_opcode.cxx	\
+	dsl_simp.cxx	\
 	dwarf_DST.cxx	\
 	dwarf_DST_dump.cxx	\
 	dwarf_DST_mem.cxx	\


### PR DESCRIPTION
## Summary

Completes synchronized M1 for DSL expression simplification and tensor constant-fold handoff.

- adds an explicit `prepare -> wn_simp -> postprocess` bridge for logical DSL binary expressions
- projects reviewed `common.add.v1` and `common.mul.v1` operations through stack-local traditional WHIRL views
- preserves `Enable_WN_Simp` as the master control
- validates purity, integer numeric policy, canonical TensorDescriptorIR equivalence, rank, attributes, and element type
- classifies unchanged, retained kid, and newly allocated simplifier results without publishing a tensor replacement
- adds stable logical traces without exposing physical `OPR_DSL` encoding
- adds an explicit, resettable, runtime-only tensor-fold mock behind the frozen M0 API
- keeps production tensor folding disabled and does not inspect tensor payload bytes
- updates both synchronized M1 plan dashboards

## Compatibility

- no WHIRL opcode or WN layout change
- no ELF section or mapped-image layout change
- no tensor TCON storage or side-file change
- no builder publication, VHO, WOPT, frontend, or backend behavior change
- production scalar projection remains disabled until the reviewed M2/M3 milestones

## Validation

- Linux Docker `dsl_builder_contract_test` focused M1 lane passed
- Linux Docker tensor-fold M1 mock contract passed
- Linux Docker native syntax fixture passed
- canonicalization and production-native focused lanes passed
- physical operator compatibility matrix passed for x8664, mips, mips-sl, key-generic, loongson, and baseline
- `git diff --check` and no-tab scans passed

Representative evidence:

```text
DSL simplifier: operator OPR_DSLADD (common.add.v1), status engine_rewrite, replacement kid0
DSL simplifier: operator OPR_DSLMUL (common.mul.v1), status engine_rewrite, replacement kid0
DSL simplifier: operator OPR_DSLADD (common.add.v1), status reject_descriptor, replacement none
DSL tensor fold M1 mock contract passed
```

## Known Test-Harness Limitation

The legacy mode that runs every `dsl_builder_contract_test` case in one process still aborts before the M1 check because `Check_Production_Native_Builder` attempts to start DST file scope a second time. Its focused production-native lane passes, and the focused M1 lane passes. This pre-existing aggregate harness issue is outside this PR.