### PR TITLE
Add persistent tensor TCON carrier storage

### DIFF
--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -3,8 +3,11 @@
  */
 
 #include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "dsl_tensor_fold.h"
+#include "strtab.h"
 
 static const char *DSL_tensor_fold_status_name[] = {
     "not_applicable",
@@ -28,6 +31,11 @@ static const char *DSL_tensor_fold_status_name[] = {
 
 static BOOL DSL_tensor_fold_mock_enabled = FALSE;
 static DSL_TENSOR_FOLD_MOCK_RESPONSE DSL_tensor_fold_mock_response;
+static DSL_TENSOR_TCON_RECORD
+    DSL_tensor_tcon_records[DSL_TENSOR_TCON_TABLE_CAPACITY];
+static UINT32 DSL_tensor_tcon_record_count = 0;
+static const char *DSL_tensor_tcon_carrier_prefix =
+    "__WHIRL_DSL_TCON__:v1:";
 
 static void
 DSL_Tensor_Fold_Clear_Output (DSL_TENSOR_FOLD_OUTPUT *output)
@@ -47,6 +55,336 @@ DSL_Tensor_Fold_Set_Output_Status
     output->status = status;
     output->rejection = DSL_Tensor_Fold_Status_Is_Rejection(status) ?
                             status : DSL_TENSOR_FOLD_NOT_APPLICABLE;
+}
+
+static BOOL
+DSL_Tensor_TCON_Alignment_Valid (UINT32 alignment)
+{
+    return alignment != 0 && (alignment & (alignment - 1)) == 0;
+}
+
+static BOOL
+DSL_Tensor_TCON_Checksum_Valid (UINT64 checksum_hi, UINT64 checksum_lo)
+{
+    return checksum_hi != 0 || checksum_lo != 0;
+}
+
+static BOOL
+DSL_Tensor_TCON_Range_Valid (UINT64 offset, UINT64 length)
+{
+    return length != 0 && offset + length >= offset;
+}
+
+static BOOL
+DSL_Tensor_TCON_Mul_Exact (UINT64 left, UINT32 right, UINT64 *result)
+{
+    if (result != NULL)
+        *result = 0;
+    if (right != 0 && left > (~0ULL / right))
+        return FALSE;
+    if (result != NULL)
+        *result = left * right;
+    return TRUE;
+}
+
+static BOOL
+DSL_Tensor_TCON_Relative_Path_Valid (STR_IDX path)
+{
+    const char *text;
+    const char *component;
+    const char *cursor;
+
+    if (path == STR_IDX_ZERO || path >= STR_Table_Size())
+        return FALSE;
+
+    text = Index_To_Str(path);
+    if (text == NULL || text[0] == '\0' || text[0] == '/' ||
+        text[0] == '\\')
+        return FALSE;
+
+    component = text;
+    for (cursor = text; ; ++cursor) {
+        if (*cursor == '\\')
+            return FALSE;
+        if (*cursor == '/' || *cursor == '\0') {
+            if (cursor == component)
+                return FALSE;
+            if ((cursor - component == 1 && component[0] == '.') ||
+                (cursor - component == 2 &&
+                 component[0] == '.' && component[1] == '.'))
+                return FALSE;
+            if (*cursor == '\0')
+                break;
+            component = cursor + 1;
+        }
+    }
+    return TRUE;
+}
+
+static BOOL
+DSL_Tensor_TCON_Common_Info_Valid
+        (const DSL_TENSOR_TCON_CREATE_INFO *info)
+{
+    UINT64 computed_bytes;
+
+    if (info == NULL ||
+        info->descriptor_ty == TY_IDX_ZERO ||
+        info->element_mtype == MTYPE_UNKNOWN ||
+        info->element_size == 0 ||
+        info->element_count == 0 ||
+        info->logical_bytes == 0 ||
+        !DSL_Tensor_TCON_Alignment_Valid(info->required_alignment) ||
+        info->required_alignment < info->element_size)
+        return FALSE;
+
+    if (!DSL_Tensor_TCON_Mul_Exact(info->element_count,
+                                   info->element_size,
+                                   &computed_bytes) ||
+        computed_bytes != info->logical_bytes)
+        return FALSE;
+
+    return TRUE;
+}
+
+static UINT64
+DSL_Tensor_TCON_Hash_Combine (UINT64 hash, UINT64 value)
+{
+    hash ^= value;
+    hash *= 1099511628211ULL;
+    return hash;
+}
+
+static BOOL
+DSL_Tensor_TCON_Is_Dense
+        (DSL_TENSOR_TCON_STORAGE_KIND storage_kind)
+{
+    return storage_kind == DSL_TENSOR_TCON_STORAGE_INLINE_DENSE ||
+           storage_kind == DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE;
+}
+
+static BOOL
+DSL_Tensor_TCON_Record_Semantic_Equal
+        (const DSL_TENSOR_TCON_RECORD *left,
+         const DSL_TENSOR_TCON_RECORD *right)
+{
+    const char *left_bytes;
+    const char *right_bytes;
+
+    if (left == NULL || right == NULL)
+        return FALSE;
+
+    if (DSL_Tensor_TCON_Is_Dense(left->storage_kind) &&
+        DSL_Tensor_TCON_Is_Dense(right->storage_kind)) {
+        if (left->descriptor_ty != right->descriptor_ty ||
+            left->element_mtype != right->element_mtype ||
+            left->element_size != right->element_size ||
+            left->element_count != right->element_count ||
+            left->logical_bytes != right->logical_bytes ||
+            left->checksum_hi != right->checksum_hi ||
+            left->checksum_lo != right->checksum_lo)
+            return FALSE;
+
+        if (left->dense_payload_ref == 0 ||
+            right->dense_payload_ref == 0 ||
+            left->dense_payload_bytes != right->dense_payload_bytes)
+            return FALSE;
+
+        left_bytes = Index_to_char_array(left->dense_payload_ref);
+        right_bytes = Index_to_char_array(right->dense_payload_ref);
+        return left_bytes != NULL &&
+               right_bytes != NULL &&
+               memcmp(left_bytes, right_bytes,
+                      left->dense_payload_bytes) == 0;
+    }
+
+    return left->storage_kind == right->storage_kind &&
+           left->descriptor_ty == right->descriptor_ty &&
+           left->element_mtype == right->element_mtype &&
+           left->element_size == right->element_size &&
+           left->element_count == right->element_count &&
+           left->logical_bytes == right->logical_bytes &&
+           left->scalar_tcon == right->scalar_tcon &&
+           left->scalar_integer_value == right->scalar_integer_value;
+}
+
+static UINT64
+DSL_Tensor_TCON_Record_Semantic_Hash
+        (const DSL_TENSOR_TCON_RECORD *record)
+{
+    UINT64 hash = 1469598103934665603ULL;
+
+    if (record == NULL)
+        return 0;
+
+    if (DSL_Tensor_TCON_Is_Dense(record->storage_kind)) {
+        hash = DSL_Tensor_TCON_Hash_Combine(hash, record->descriptor_ty);
+        hash = DSL_Tensor_TCON_Hash_Combine(hash, record->element_mtype);
+        hash = DSL_Tensor_TCON_Hash_Combine(hash, record->element_size);
+        hash = DSL_Tensor_TCON_Hash_Combine(hash, record->element_count);
+        hash = DSL_Tensor_TCON_Hash_Combine(hash, record->logical_bytes);
+        hash = DSL_Tensor_TCON_Hash_Combine(hash, record->checksum_hi);
+        hash = DSL_Tensor_TCON_Hash_Combine(hash, record->checksum_lo);
+        return hash;
+    }
+
+    hash = DSL_Tensor_TCON_Hash_Combine(hash, record->storage_kind);
+    hash = DSL_Tensor_TCON_Hash_Combine(hash, record->descriptor_ty);
+    hash = DSL_Tensor_TCON_Hash_Combine(hash, record->element_mtype);
+    hash = DSL_Tensor_TCON_Hash_Combine(hash, record->element_size);
+    hash = DSL_Tensor_TCON_Hash_Combine(hash, record->element_count);
+    hash = DSL_Tensor_TCON_Hash_Combine(hash, record->logical_bytes);
+    hash = DSL_Tensor_TCON_Hash_Combine(hash, record->scalar_tcon);
+    hash = DSL_Tensor_TCON_Hash_Combine(hash, record->scalar_integer_value);
+    return hash;
+}
+
+static DSL_TENSOR_TCON_ID
+DSL_Tensor_TCON_Find_Equal (const DSL_TENSOR_TCON_RECORD *record)
+{
+    UINT32 i;
+
+    for (i = 0; i < DSL_tensor_tcon_record_count; ++i) {
+        if (DSL_Tensor_TCON_Record_Semantic_Equal
+                (&DSL_tensor_tcon_records[i], record))
+            return DSL_tensor_tcon_records[i].id;
+    }
+
+    return DSL_TENSOR_TCON_INVALID_ID;
+}
+
+static BOOL
+DSL_Tensor_TCON_Init_Carrier
+        (DSL_TENSOR_TCON_ID id,
+         DSL_TENSOR_TCON_RECORD *record,
+         TCON *carrier)
+{
+    char token[96];
+    UINT32 token_idx;
+    UINT32 token_length;
+
+    if (id == DSL_TENSOR_TCON_INVALID_ID)
+        return FALSE;
+
+    snprintf(token, sizeof(token), "%s%u", DSL_tensor_tcon_carrier_prefix,
+             (unsigned int)id);
+    token_length = strlen(token) + 1;
+    token_idx = Save_StrN(token, token_length);
+    if (token_idx == 0)
+        return FALSE;
+
+    if (record != NULL)
+        record->carrier_token = token_idx;
+    if (carrier != NULL) {
+        TCON_clear(*carrier);
+        Set_TCON_string_payload(*carrier, MTYPE_STR, token_idx,
+                                token_length);
+        Set_TCON_dsl_tensor_carrier(*carrier);
+    }
+
+    return TRUE;
+}
+
+static BOOL
+DSL_Tensor_TCON_Create_Record
+        (DSL_TENSOR_TCON_STORAGE_KIND storage_kind,
+         const DSL_TENSOR_TCON_CREATE_INFO *info,
+         DSL_TENSOR_TCON_ID *id,
+         TCON *carrier)
+{
+    DSL_TENSOR_TCON_RECORD record;
+    DSL_TENSOR_TCON_ID existing_id;
+
+    if (id != NULL)
+        *id = DSL_TENSOR_TCON_INVALID_ID;
+
+    if (!DSL_Tensor_TCON_Common_Info_Valid(info))
+        return FALSE;
+
+    memset(&record, 0, sizeof(record));
+    record.version = 1;
+    record.storage_kind = storage_kind;
+    record.descriptor_ty = info->descriptor_ty;
+    record.scalar_tcon = info->scalar_tcon;
+    record.element_mtype = info->element_mtype;
+    record.element_size = info->element_size;
+    record.scalar_integer_value = info->scalar_integer_value;
+    record.element_count = info->element_count;
+    record.logical_bytes = info->logical_bytes;
+    record.required_alignment = info->required_alignment;
+    record.side_file = info->side_file;
+    record.byte_offset = info->byte_offset;
+    record.byte_length = info->byte_length;
+    record.checksum_hi = info->checksum_hi;
+    record.checksum_lo = info->checksum_lo;
+
+    switch (storage_kind) {
+    case DSL_TENSOR_TCON_STORAGE_ZERO:
+        if (info->scalar_tcon == TCON_IDX_ZERO ||
+            info->scalar_integer_value != 0)
+            return FALSE;
+        break;
+    case DSL_TENSOR_TCON_STORAGE_ONE:
+        if (info->scalar_tcon == TCON_IDX_ZERO ||
+            info->scalar_integer_value != 1)
+            return FALSE;
+        break;
+    case DSL_TENSOR_TCON_STORAGE_SPLAT:
+        if (info->scalar_tcon == TCON_IDX_ZERO)
+            return FALSE;
+        if (info->dense_bytes != NULL || info->dense_bytes_length != 0)
+            return FALSE;
+        break;
+    case DSL_TENSOR_TCON_STORAGE_INLINE_DENSE:
+        if (info->dense_bytes == NULL ||
+            info->dense_bytes_length == 0 ||
+            info->dense_bytes_length != info->logical_bytes ||
+            !DSL_Tensor_TCON_Checksum_Valid(info->checksum_hi,
+                                            info->checksum_lo))
+            return FALSE;
+        break;
+    case DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE:
+        if (!DSL_Tensor_TCON_Relative_Path_Valid(info->side_file) ||
+            !DSL_Tensor_TCON_Range_Valid(info->byte_offset,
+                                         info->byte_length) ||
+            info->byte_length != info->logical_bytes ||
+            (info->byte_offset % info->required_alignment) != 0 ||
+            (info->dense_bytes_length != 0 &&
+             info->dense_bytes_length != info->logical_bytes) ||
+            !DSL_Tensor_TCON_Checksum_Valid(info->checksum_hi,
+                                            info->checksum_lo))
+            return FALSE;
+        break;
+    default:
+        return FALSE;
+    }
+
+    if (info->dense_bytes != NULL && info->dense_bytes_length != 0) {
+        record.dense_payload_ref =
+            Save_StrN((const char *)info->dense_bytes,
+                      info->dense_bytes_length);
+        if (record.dense_payload_ref == 0)
+            return FALSE;
+        record.dense_payload_bytes = info->dense_bytes_length;
+    }
+
+    existing_id = DSL_Tensor_TCON_Find_Equal(&record);
+    if (existing_id != DSL_TENSOR_TCON_INVALID_ID) {
+        if (id != NULL)
+            *id = existing_id;
+        return DSL_Tensor_TCON_Create_Carrier(existing_id, carrier);
+    }
+
+    if (DSL_tensor_tcon_record_count >= DSL_TENSOR_TCON_TABLE_CAPACITY)
+        return FALSE;
+
+    record.id = DSL_tensor_tcon_record_count + 1;
+    if (!DSL_Tensor_TCON_Init_Carrier(record.id, &record, carrier))
+        return FALSE;
+
+    DSL_tensor_tcon_records[DSL_tensor_tcon_record_count++] = record;
+    if (id != NULL)
+        *id = record.id;
+    return TRUE;
 }
 
 void
@@ -273,4 +611,185 @@ Targ_DSL_WhirlOp
     DSL_Tensor_Fold_Set_Output_Status(output,
                                       DSL_TENSOR_FOLD_NOT_APPLICABLE);
     return DSL_TENSOR_FOLD_NOT_APPLICABLE;
+}
+
+void
+DSL_Tensor_TCON_Reset (void)
+{
+    memset(DSL_tensor_tcon_records, 0, sizeof(DSL_tensor_tcon_records));
+    DSL_tensor_tcon_record_count = 0;
+}
+
+UINT32
+DSL_Tensor_TCON_Count (void)
+{
+    return DSL_tensor_tcon_record_count;
+}
+
+BOOL
+DSL_Tensor_TCON_Get
+        (DSL_TENSOR_TCON_ID id,
+         DSL_TENSOR_TCON_RECORD *record)
+{
+    if (id == DSL_TENSOR_TCON_INVALID_ID ||
+        id > DSL_tensor_tcon_record_count ||
+        record == NULL)
+        return FALSE;
+
+    *record = DSL_tensor_tcon_records[id - 1];
+    return TRUE;
+}
+
+BOOL
+DSL_Tensor_TCON_Is_Carrier
+        (const TCON *carrier,
+         DSL_TENSOR_TCON_ID *id)
+{
+    const char *token;
+    const char *digits;
+    char *end;
+    unsigned long parsed_id;
+
+    if (id != NULL)
+        *id = DSL_TENSOR_TCON_INVALID_ID;
+
+    if (carrier == NULL ||
+        TCON_ty(*carrier) != MTYPE_STR ||
+        !TCON_is_dsl_tensor_carrier(*carrier) ||
+        TCON_str_idx(*carrier) == 0 ||
+        TCON_str_len(*carrier) == 0)
+        return FALSE;
+
+    token = Index_to_char_array(TCON_str_idx(*carrier));
+    if (token == NULL)
+        return FALSE;
+
+    digits = token + strlen(DSL_tensor_tcon_carrier_prefix);
+    if (strncmp(token, DSL_tensor_tcon_carrier_prefix,
+                strlen(DSL_tensor_tcon_carrier_prefix)) != 0 ||
+        digits[0] == '\0')
+        return FALSE;
+
+    parsed_id = strtoul(digits, &end, 10);
+    if (end == digits || *end != '\0' ||
+        parsed_id == DSL_TENSOR_TCON_INVALID_ID ||
+        parsed_id > DSL_tensor_tcon_record_count)
+        return FALSE;
+
+    if (id != NULL)
+        *id = (DSL_TENSOR_TCON_ID)parsed_id;
+    return TRUE;
+}
+
+BOOL
+DSL_Tensor_TCON_Create_Carrier
+        (DSL_TENSOR_TCON_ID id,
+         TCON *carrier)
+{
+    DSL_TENSOR_TCON_RECORD record;
+
+    if (!DSL_Tensor_TCON_Get(id, &record))
+        return FALSE;
+    return DSL_Tensor_TCON_Init_Carrier(id, NULL, carrier);
+}
+
+BOOL
+DSL_Tensor_TCON_Create_Zero
+        (const DSL_TENSOR_TCON_CREATE_INFO *info,
+         DSL_TENSOR_TCON_ID *id,
+         TCON *carrier)
+{
+    return DSL_Tensor_TCON_Create_Record
+               (DSL_TENSOR_TCON_STORAGE_ZERO, info, id, carrier);
+}
+
+BOOL
+DSL_Tensor_TCON_Create_One
+        (const DSL_TENSOR_TCON_CREATE_INFO *info,
+         DSL_TENSOR_TCON_ID *id,
+         TCON *carrier)
+{
+    return DSL_Tensor_TCON_Create_Record
+               (DSL_TENSOR_TCON_STORAGE_ONE, info, id, carrier);
+}
+
+BOOL
+DSL_Tensor_TCON_Create_Splat
+        (const DSL_TENSOR_TCON_CREATE_INFO *info,
+         DSL_TENSOR_TCON_ID *id,
+         TCON *carrier)
+{
+    return DSL_Tensor_TCON_Create_Record
+               (DSL_TENSOR_TCON_STORAGE_SPLAT, info, id, carrier);
+}
+
+BOOL
+DSL_Tensor_TCON_Create_Inline_Dense
+        (const DSL_TENSOR_TCON_CREATE_INFO *info,
+         DSL_TENSOR_TCON_ID *id,
+         TCON *carrier)
+{
+    return DSL_Tensor_TCON_Create_Record
+               (DSL_TENSOR_TCON_STORAGE_INLINE_DENSE, info, id, carrier);
+}
+
+BOOL
+DSL_Tensor_TCON_Create_Side_File_Dense
+        (const DSL_TENSOR_TCON_CREATE_INFO *info,
+         DSL_TENSOR_TCON_ID *id,
+         TCON *carrier)
+{
+    return DSL_Tensor_TCON_Create_Record
+               (DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE, info, id, carrier);
+}
+
+UINT64
+DSL_Tensor_TCON_Semantic_Hash (DSL_TENSOR_TCON_ID id)
+{
+    DSL_TENSOR_TCON_RECORD record;
+
+    if (!DSL_Tensor_TCON_Get(id, &record))
+        return 0;
+    return DSL_Tensor_TCON_Record_Semantic_Hash(&record);
+}
+
+BOOL
+DSL_Tensor_TCON_Semantic_Equal
+        (DSL_TENSOR_TCON_ID left,
+         DSL_TENSOR_TCON_ID right)
+{
+    DSL_TENSOR_TCON_RECORD left_record;
+    DSL_TENSOR_TCON_RECORD right_record;
+
+    return DSL_Tensor_TCON_Get(left, &left_record) &&
+           DSL_Tensor_TCON_Get(right, &right_record) &&
+           DSL_Tensor_TCON_Record_Semantic_Equal
+               (&left_record, &right_record);
+}
+
+BOOL
+DSL_Tensor_TCON_Get_Element_TCON
+        (DSL_TENSOR_TCON_ID id,
+         UINT64 element_index,
+         TCON_IDX *element_tcon)
+{
+    DSL_TENSOR_TCON_RECORD record;
+
+    if (element_tcon != NULL)
+        *element_tcon = TCON_IDX_ZERO;
+
+    if (!DSL_Tensor_TCON_Get(id, &record) ||
+        element_index >= record.element_count ||
+        element_tcon == NULL)
+        return FALSE;
+
+    switch (record.storage_kind) {
+    case DSL_TENSOR_TCON_STORAGE_ZERO:
+    case DSL_TENSOR_TCON_STORAGE_ONE:
+    case DSL_TENSOR_TCON_STORAGE_SPLAT:
+        *element_tcon = record.scalar_tcon;
+        return record.scalar_tcon != TCON_IDX_ZERO;
+    default:
+        return FALSE;
+    }
 }

--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -31,11 +31,11 @@ static const char *DSL_tensor_fold_status_name[] = {
 
 static BOOL DSL_tensor_fold_mock_enabled = FALSE;
 static DSL_TENSOR_FOLD_MOCK_RESPONSE DSL_tensor_fold_mock_response;
-static DSL_TENSOR_TCON_RECORD
-    DSL_tensor_tcon_records[DSL_TENSOR_TCON_TABLE_CAPACITY];
-static UINT32 DSL_tensor_tcon_record_count = 0;
-static const char *DSL_tensor_tcon_carrier_prefix =
-    "__WHIRL_DSL_TCON__:v1:";
+static TCON_IDX DSL_tensor_tcon_cache[4096];
+static UINT32 DSL_tensor_tcon_cache_count = 0;
+
+extern TCON_IDX Enter_tcon (const TCON& tcon);
+extern TCON TCON_from_IDX (TCON_IDX tcon_idx);
 
 static void
 DSL_Tensor_Fold_Clear_Output (DSL_TENSOR_FOLD_OUTPUT *output)
@@ -88,36 +88,39 @@ DSL_Tensor_TCON_Mul_Exact (UINT64 left, UINT32 right, UINT64 *result)
 }
 
 static BOOL
-DSL_Tensor_TCON_Relative_Path_Valid (STR_IDX path)
+DSL_Tensor_TCON_Relative_Path_Valid (const char *text, UINT32 length)
 {
-    const char *text;
-    const char *component;
-    const char *cursor;
+    UINT32 component_start;
+    UINT32 i;
 
-    if (path == STR_IDX_ZERO || path >= STR_Table_Size())
+    if (text == NULL || length == 0 || text[0] == '/' || text[0] == '\\')
         return FALSE;
 
-    text = Index_To_Str(path);
-    if (text == NULL || text[0] == '\0' || text[0] == '/' ||
-        text[0] == '\\')
-        return FALSE;
-
-    component = text;
-    for (cursor = text; ; ++cursor) {
-        if (*cursor == '\\')
+    component_start = 0;
+    for (i = 0; i <= length; ++i) {
+        char ch = (i == length) ? '\0' : text[i];
+        if (i != length && (ch == '\0' || ch == '\\'))
             return FALSE;
-        if (*cursor == '/' || *cursor == '\0') {
-            if (cursor == component)
+        if (ch == '/') {
+            if (i == component_start)
                 return FALSE;
-            if ((cursor - component == 1 && component[0] == '.') ||
-                (cursor - component == 2 &&
-                 component[0] == '.' && component[1] == '.'))
+            if ((i - component_start == 1 &&
+                 text[component_start] == '.') ||
+                (i - component_start == 2 &&
+                 text[component_start] == '.' &&
+                 text[component_start + 1] == '.'))
                 return FALSE;
-            if (*cursor == '\0')
-                break;
-            component = cursor + 1;
+            component_start = i + 1;
         }
     }
+
+    if (length == component_start)
+        return FALSE;
+    if ((length - component_start == 1 && text[component_start] == '.') ||
+        (length - component_start == 2 &&
+         text[component_start] == '.' && text[component_start + 1] == '.'))
+        return FALSE;
+
     return TRUE;
 }
 
@@ -162,13 +165,35 @@ DSL_Tensor_TCON_Is_Dense
            storage_kind == DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE;
 }
 
+static const unsigned char *
+DSL_Tensor_TCON_Record_Dense_Bytes
+        (const DSL_TENSOR_TCON_RECORD *record,
+         const TCON *carrier)
+{
+    char *payload;
+
+    if (record == NULL || carrier == NULL || record->dense_length == 0)
+        return NULL;
+    if (record->dense_offset < DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        record->dense_offset + record->dense_length < record->dense_offset ||
+        record->dense_offset + record->dense_length > TCON_str_len(*carrier))
+        return NULL;
+
+    payload = Index_to_char_array(TCON_str_idx(*carrier));
+    if (payload == NULL)
+        return NULL;
+    return (const unsigned char *)(payload + record->dense_offset);
+}
+
 static BOOL
 DSL_Tensor_TCON_Record_Semantic_Equal
         (const DSL_TENSOR_TCON_RECORD *left,
-         const DSL_TENSOR_TCON_RECORD *right)
+         const TCON *left_carrier,
+         const DSL_TENSOR_TCON_RECORD *right,
+         const TCON *right_carrier)
 {
-    const char *left_bytes;
-    const char *right_bytes;
+    const unsigned char *left_bytes;
+    const unsigned char *right_bytes;
 
     if (left == NULL || right == NULL)
         return FALSE;
@@ -184,17 +209,13 @@ DSL_Tensor_TCON_Record_Semantic_Equal
             left->checksum_lo != right->checksum_lo)
             return FALSE;
 
-        if (left->dense_payload_ref == 0 ||
-            right->dense_payload_ref == 0 ||
-            left->dense_payload_bytes != right->dense_payload_bytes)
+        left_bytes = DSL_Tensor_TCON_Record_Dense_Bytes(left, left_carrier);
+        right_bytes = DSL_Tensor_TCON_Record_Dense_Bytes(right, right_carrier);
+        if (left_bytes == NULL || right_bytes == NULL ||
+            left->dense_length != right->dense_length)
             return FALSE;
 
-        left_bytes = Index_to_char_array(left->dense_payload_ref);
-        right_bytes = Index_to_char_array(right->dense_payload_ref);
-        return left_bytes != NULL &&
-               right_bytes != NULL &&
-               memcmp(left_bytes, right_bytes,
-                      left->dense_payload_bytes) == 0;
+        return memcmp(left_bytes, right_bytes, left->dense_length) == 0;
     }
 
     return left->storage_kind == right->storage_kind &&
@@ -238,49 +259,183 @@ DSL_Tensor_TCON_Record_Semantic_Hash
     return hash;
 }
 
-static DSL_TENSOR_TCON_ID
-DSL_Tensor_TCON_Find_Equal (const DSL_TENSOR_TCON_RECORD *record)
+static TCON_IDX
+DSL_Tensor_TCON_Find_Cached_Equal
+        (const DSL_TENSOR_TCON_RECORD *record,
+         const TCON *carrier)
 {
     UINT32 i;
 
-    for (i = 0; i < DSL_tensor_tcon_record_count; ++i) {
-        if (DSL_Tensor_TCON_Record_Semantic_Equal
-                (&DSL_tensor_tcon_records[i], record))
-            return DSL_tensor_tcon_records[i].id;
+    for (i = 0; i < DSL_tensor_tcon_cache_count; ++i) {
+        TCON_IDX cached_idx = DSL_tensor_tcon_cache[i];
+        TCON cached_carrier = TCON_from_IDX(cached_idx);
+        DSL_TENSOR_TCON_RECORD cached_record;
+
+        if (DSL_Tensor_TCON_Decode_Carrier(&cached_carrier,
+                                           &cached_record) &&
+            DSL_Tensor_TCON_Record_Semantic_Equal
+                (&cached_record, &cached_carrier, record, carrier))
+            return cached_idx;
     }
 
-    return DSL_TENSOR_TCON_INVALID_ID;
+    return TCON_IDX_ZERO;
+}
+
+static void
+DSL_Tensor_TCON_Cache (TCON_IDX tcon_idx)
+{
+    if (tcon_idx == TCON_IDX_ZERO ||
+        DSL_tensor_tcon_cache_count >=
+            sizeof(DSL_tensor_tcon_cache) / sizeof(DSL_tensor_tcon_cache[0]))
+        return;
+
+    DSL_tensor_tcon_cache[DSL_tensor_tcon_cache_count++] = tcon_idx;
 }
 
 static BOOL
-DSL_Tensor_TCON_Init_Carrier
-        (DSL_TENSOR_TCON_ID id,
-         DSL_TENSOR_TCON_RECORD *record,
-         TCON *carrier)
+DSL_Tensor_TCON_Envelope_Offsets_Valid
+        (const DSL_TENSOR_TCON_RECORD *record,
+         UINT32 payload_length)
 {
-    char token[96];
-    UINT32 token_idx;
-    UINT32 token_length;
-
-    if (id == DSL_TENSOR_TCON_INVALID_ID)
+    if (record == NULL ||
+        record->reserved0 != 0 ||
+        record->reserved1 != 0 ||
+        record->reserved2 != 0 ||
+        record->header_size != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        record->record_size != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        payload_length < DSL_TENSOR_TCON_ENVELOPE_SIZE)
         return FALSE;
 
-    snprintf(token, sizeof(token), "%s%u", DSL_tensor_tcon_carrier_prefix,
-             (unsigned int)id);
-    token_length = strlen(token) + 1;
-    token_idx = Save_StrN(token, token_length);
-    if (token_idx == 0)
+    if (record->side_path_length != 0) {
+        if (record->side_path_offset < DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+            record->side_path_offset + record->side_path_length <
+                record->side_path_offset ||
+            record->side_path_offset + record->side_path_length >
+                payload_length)
+            return FALSE;
+    } else if (record->side_path_offset != 0) {
+        return FALSE;
+    }
+
+    if (record->dense_length != 0) {
+        if (record->dense_offset < DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+            record->dense_offset + record->dense_length <
+                record->dense_offset ||
+            record->dense_offset + record->dense_length > payload_length)
+            return FALSE;
+    } else if (record->dense_offset != 0) {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+static BOOL
+DSL_Tensor_TCON_Record_Valid
+        (const DSL_TENSOR_TCON_RECORD *record,
+         const TCON *carrier)
+{
+    char *payload;
+    UINT32 payload_length;
+    UINT64 computed_bytes;
+
+    if (record == NULL ||
+        carrier == NULL ||
+        TCON_ty(*carrier) != MTYPE_STRING ||
+        TCON_str_idx(*carrier) == 0 ||
+        TCON_str_len(*carrier) < DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        Index_to_length(TCON_str_idx(*carrier)) != TCON_str_len(*carrier))
+        return FALSE;
+
+    payload = Index_to_char_array(TCON_str_idx(*carrier));
+    payload_length = TCON_str_len(*carrier);
+    if (payload == NULL ||
+        memcmp(payload, record, sizeof(*record)) != 0)
+        return FALSE;
+
+    if (record->magic != DSL_TENSOR_TCON_MAGIC ||
+        record->version != DSL_TENSOR_TCON_VERSION ||
+        !DSL_Tensor_TCON_Envelope_Offsets_Valid(record, payload_length) ||
+        record->descriptor_ty == TY_IDX_ZERO ||
+        record->element_mtype == MTYPE_UNKNOWN ||
+        record->element_size == 0 ||
+        record->element_count == 0 ||
+        record->logical_bytes == 0 ||
+        !DSL_Tensor_TCON_Alignment_Valid(record->required_alignment) ||
+        record->required_alignment < record->element_size)
+        return FALSE;
+
+    if (!DSL_Tensor_TCON_Mul_Exact(record->element_count,
+                                   record->element_size,
+                                   &computed_bytes) ||
+        computed_bytes != record->logical_bytes)
+        return FALSE;
+
+    switch (record->storage_kind) {
+    case DSL_TENSOR_TCON_STORAGE_ZERO:
+        return record->scalar_tcon != TCON_IDX_ZERO &&
+               record->scalar_integer_value == 0 &&
+               record->side_path_length == 0 &&
+               record->dense_length == 0;
+    case DSL_TENSOR_TCON_STORAGE_ONE:
+        return record->scalar_tcon != TCON_IDX_ZERO &&
+               record->scalar_integer_value == 1 &&
+               record->side_path_length == 0 &&
+               record->dense_length == 0;
+    case DSL_TENSOR_TCON_STORAGE_SPLAT:
+        return record->scalar_tcon != TCON_IDX_ZERO &&
+               record->side_path_length == 0 &&
+               record->dense_length == 0;
+    case DSL_TENSOR_TCON_STORAGE_INLINE_DENSE:
+        return record->scalar_tcon == TCON_IDX_ZERO &&
+               record->side_path_length == 0 &&
+               record->dense_length == record->logical_bytes &&
+               DSL_Tensor_TCON_Checksum_Valid(record->checksum_hi,
+                                              record->checksum_lo);
+    case DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE:
+        return record->side_path_length != 0 &&
+               record->byte_length == record->logical_bytes &&
+               (record->byte_offset % record->required_alignment) == 0 &&
+               (record->dense_length == 0 ||
+                record->dense_length == record->logical_bytes) &&
+               DSL_Tensor_TCON_Checksum_Valid(record->checksum_hi,
+                                              record->checksum_lo) &&
+               DSL_Tensor_TCON_Relative_Path_Valid
+                   (payload + record->side_path_offset,
+                    record->side_path_length);
+    default:
+        return FALSE;
+    }
+}
+
+BOOL
+DSL_Tensor_TCON_Decode_Carrier
+        (const TCON *carrier,
+         DSL_TENSOR_TCON_RECORD *record)
+{
+    char *payload;
+    DSL_TENSOR_TCON_RECORD decoded;
+
+    if (record != NULL)
+        memset(record, 0, sizeof(*record));
+
+    if (carrier == NULL ||
+        TCON_ty(*carrier) != MTYPE_STRING ||
+        TCON_str_idx(*carrier) == 0 ||
+        TCON_str_len(*carrier) < DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        Index_to_length(TCON_str_idx(*carrier)) != TCON_str_len(*carrier))
+        return FALSE;
+
+    payload = Index_to_char_array(TCON_str_idx(*carrier));
+    if (payload == NULL)
+        return FALSE;
+
+    memcpy(&decoded, payload, sizeof(decoded));
+    if (!DSL_Tensor_TCON_Record_Valid(&decoded, carrier))
         return FALSE;
 
     if (record != NULL)
-        record->carrier_token = token_idx;
-    if (carrier != NULL) {
-        TCON_clear(*carrier);
-        Set_TCON_string_payload(*carrier, MTYPE_STR, token_idx,
-                                token_length);
-        Set_TCON_dsl_tensor_carrier(*carrier);
-    }
-
+        *record = decoded;
     return TRUE;
 }
 
@@ -288,20 +443,29 @@ static BOOL
 DSL_Tensor_TCON_Create_Record
         (DSL_TENSOR_TCON_STORAGE_KIND storage_kind,
          const DSL_TENSOR_TCON_CREATE_INFO *info,
-         DSL_TENSOR_TCON_ID *id,
+         TCON_IDX *tcon_idx,
          TCON *carrier)
 {
     DSL_TENSOR_TCON_RECORD record;
-    DSL_TENSOR_TCON_ID existing_id;
+    TCON built_carrier;
+    TCON_IDX existing_idx;
+    TCON_IDX entered_idx;
+    char *payload;
+    UINT32 payload_length;
+    UINT32 cursor;
+    UINT32 payload_idx;
 
-    if (id != NULL)
-        *id = DSL_TENSOR_TCON_INVALID_ID;
+    if (tcon_idx != NULL)
+        *tcon_idx = TCON_IDX_ZERO;
 
     if (!DSL_Tensor_TCON_Common_Info_Valid(info))
         return FALSE;
 
     memset(&record, 0, sizeof(record));
-    record.version = 1;
+    record.magic = DSL_TENSOR_TCON_MAGIC;
+    record.version = DSL_TENSOR_TCON_VERSION;
+    record.header_size = DSL_TENSOR_TCON_ENVELOPE_SIZE;
+    record.record_size = DSL_TENSOR_TCON_ENVELOPE_SIZE;
     record.storage_kind = storage_kind;
     record.descriptor_ty = info->descriptor_ty;
     record.scalar_tcon = info->scalar_tcon;
@@ -311,7 +475,6 @@ DSL_Tensor_TCON_Create_Record
     record.element_count = info->element_count;
     record.logical_bytes = info->logical_bytes;
     record.required_alignment = info->required_alignment;
-    record.side_file = info->side_file;
     record.byte_offset = info->byte_offset;
     record.byte_length = info->byte_length;
     record.checksum_hi = info->checksum_hi;
@@ -343,7 +506,8 @@ DSL_Tensor_TCON_Create_Record
             return FALSE;
         break;
     case DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE:
-        if (!DSL_Tensor_TCON_Relative_Path_Valid(info->side_file) ||
+        if (!DSL_Tensor_TCON_Relative_Path_Valid(info->side_path,
+                                                 info->side_path_length) ||
             !DSL_Tensor_TCON_Range_Valid(info->byte_offset,
                                          info->byte_length) ||
             info->byte_length != info->logical_bytes ||
@@ -358,32 +522,65 @@ DSL_Tensor_TCON_Create_Record
         return FALSE;
     }
 
-    if (info->dense_bytes != NULL && info->dense_bytes_length != 0) {
-        record.dense_payload_ref =
-            Save_StrN((const char *)info->dense_bytes,
-                      info->dense_bytes_length);
-        if (record.dense_payload_ref == 0)
+    payload_length = DSL_TENSOR_TCON_ENVELOPE_SIZE;
+    if (storage_kind == DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE) {
+        if (payload_length + info->side_path_length < payload_length)
             return FALSE;
-        record.dense_payload_bytes = info->dense_bytes_length;
+        payload_length += info->side_path_length;
+    }
+    if (info->dense_bytes_length != 0) {
+        if (payload_length + info->dense_bytes_length < payload_length)
+            return FALSE;
+        payload_length += info->dense_bytes_length;
     }
 
-    existing_id = DSL_Tensor_TCON_Find_Equal(&record);
-    if (existing_id != DSL_TENSOR_TCON_INVALID_ID) {
-        if (id != NULL)
-            *id = existing_id;
-        return DSL_Tensor_TCON_Create_Carrier(existing_id, carrier);
+    payload = (char *)malloc(payload_length);
+    if (payload == NULL)
+        return FALSE;
+
+    memset(payload, 0, payload_length);
+    cursor = DSL_TENSOR_TCON_ENVELOPE_SIZE;
+    if (storage_kind == DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE) {
+        record.side_path_offset = cursor;
+        record.side_path_length = info->side_path_length;
+        memcpy(payload + cursor, info->side_path, info->side_path_length);
+        cursor += info->side_path_length;
+    }
+    if (info->dense_bytes_length != 0) {
+        record.dense_offset = cursor;
+        record.dense_length = info->dense_bytes_length;
+        memcpy(payload + cursor, info->dense_bytes,
+               info->dense_bytes_length);
+        cursor += info->dense_bytes_length;
+    }
+    memcpy(payload, &record, sizeof(record));
+
+    payload_idx = Save_StrN(payload, payload_length);
+    free(payload);
+    if (payload_idx == 0)
+        return FALSE;
+
+    TCON_clear(built_carrier);
+    Set_TCON_string_payload(built_carrier, MTYPE_STRING, payload_idx,
+                            payload_length);
+    if (!DSL_Tensor_TCON_Decode_Carrier(&built_carrier, NULL))
+        return FALSE;
+
+    existing_idx = DSL_Tensor_TCON_Find_Cached_Equal(&record, &built_carrier);
+    if (existing_idx != TCON_IDX_ZERO) {
+        if (carrier != NULL)
+            *carrier = TCON_from_IDX(existing_idx);
+        if (tcon_idx != NULL)
+            *tcon_idx = existing_idx;
+        return TRUE;
     }
 
-    if (DSL_tensor_tcon_record_count >= DSL_TENSOR_TCON_TABLE_CAPACITY)
-        return FALSE;
-
-    record.id = DSL_tensor_tcon_record_count + 1;
-    if (!DSL_Tensor_TCON_Init_Carrier(record.id, &record, carrier))
-        return FALSE;
-
-    DSL_tensor_tcon_records[DSL_tensor_tcon_record_count++] = record;
-    if (id != NULL)
-        *id = record.id;
+    entered_idx = Enter_tcon(built_carrier);
+    if (carrier != NULL)
+        *carrier = built_carrier;
+    if (tcon_idx != NULL)
+        *tcon_idx = entered_idx;
+    DSL_Tensor_TCON_Cache(entered_idx);
     return TRUE;
 }
 
@@ -616,160 +813,140 @@ Targ_DSL_WhirlOp
 void
 DSL_Tensor_TCON_Reset (void)
 {
-    memset(DSL_tensor_tcon_records, 0, sizeof(DSL_tensor_tcon_records));
-    DSL_tensor_tcon_record_count = 0;
+    /*
+     * Tensor TCON ownership is persistent in Tcon_Table and the TCON
+     * character array.  M2-B has no authoritative runtime table to clear.
+     */
+    memset(DSL_tensor_tcon_cache, 0, sizeof(DSL_tensor_tcon_cache));
+    DSL_tensor_tcon_cache_count = 0;
 }
 
-UINT32
-DSL_Tensor_TCON_Count (void)
+void
+DSL_Tensor_TCON_Rebuild_Derived_Cache
+        (TCON_IDX first_tcon_idx,
+         TCON_IDX limit_tcon_idx)
 {
-    return DSL_tensor_tcon_record_count;
+    TCON_IDX idx;
+
+    DSL_Tensor_TCON_Reset();
+    if (first_tcon_idx == TCON_IDX_ZERO)
+        first_tcon_idx = 1;
+
+    for (idx = first_tcon_idx; idx < limit_tcon_idx; ++idx) {
+        TCON carrier = TCON_from_IDX(idx);
+        if (DSL_Tensor_TCON_Decode_Carrier(&carrier, NULL))
+            DSL_Tensor_TCON_Cache(idx);
+    }
 }
 
 BOOL
 DSL_Tensor_TCON_Get
-        (DSL_TENSOR_TCON_ID id,
+        (TCON_IDX tcon_idx,
          DSL_TENSOR_TCON_RECORD *record)
 {
-    if (id == DSL_TENSOR_TCON_INVALID_ID ||
-        id > DSL_tensor_tcon_record_count ||
-        record == NULL)
+    TCON carrier;
+
+    if (tcon_idx == TCON_IDX_ZERO || record == NULL)
         return FALSE;
 
-    *record = DSL_tensor_tcon_records[id - 1];
-    return TRUE;
+    carrier = TCON_from_IDX(tcon_idx);
+    return DSL_Tensor_TCON_Decode_Carrier(&carrier, record);
 }
 
 BOOL
 DSL_Tensor_TCON_Is_Carrier
-        (const TCON *carrier,
-         DSL_TENSOR_TCON_ID *id)
+        (TCON_IDX tcon_idx,
+         DSL_TENSOR_TCON_RECORD *record)
 {
-    const char *token;
-    const char *digits;
-    char *end;
-    unsigned long parsed_id;
-
-    if (id != NULL)
-        *id = DSL_TENSOR_TCON_INVALID_ID;
-
-    if (carrier == NULL ||
-        TCON_ty(*carrier) != MTYPE_STR ||
-        !TCON_is_dsl_tensor_carrier(*carrier) ||
-        TCON_str_idx(*carrier) == 0 ||
-        TCON_str_len(*carrier) == 0)
-        return FALSE;
-
-    token = Index_to_char_array(TCON_str_idx(*carrier));
-    if (token == NULL)
-        return FALSE;
-
-    digits = token + strlen(DSL_tensor_tcon_carrier_prefix);
-    if (strncmp(token, DSL_tensor_tcon_carrier_prefix,
-                strlen(DSL_tensor_tcon_carrier_prefix)) != 0 ||
-        digits[0] == '\0')
-        return FALSE;
-
-    parsed_id = strtoul(digits, &end, 10);
-    if (end == digits || *end != '\0' ||
-        parsed_id == DSL_TENSOR_TCON_INVALID_ID ||
-        parsed_id > DSL_tensor_tcon_record_count)
-        return FALSE;
-
-    if (id != NULL)
-        *id = (DSL_TENSOR_TCON_ID)parsed_id;
-    return TRUE;
-}
-
-BOOL
-DSL_Tensor_TCON_Create_Carrier
-        (DSL_TENSOR_TCON_ID id,
-         TCON *carrier)
-{
-    DSL_TENSOR_TCON_RECORD record;
-
-    if (!DSL_Tensor_TCON_Get(id, &record))
-        return FALSE;
-    return DSL_Tensor_TCON_Init_Carrier(id, NULL, carrier);
+    return DSL_Tensor_TCON_Get(tcon_idx, record);
 }
 
 BOOL
 DSL_Tensor_TCON_Create_Zero
         (const DSL_TENSOR_TCON_CREATE_INFO *info,
-         DSL_TENSOR_TCON_ID *id,
+         TCON_IDX *tcon_idx,
          TCON *carrier)
 {
     return DSL_Tensor_TCON_Create_Record
-               (DSL_TENSOR_TCON_STORAGE_ZERO, info, id, carrier);
+               (DSL_TENSOR_TCON_STORAGE_ZERO, info, tcon_idx, carrier);
 }
 
 BOOL
 DSL_Tensor_TCON_Create_One
         (const DSL_TENSOR_TCON_CREATE_INFO *info,
-         DSL_TENSOR_TCON_ID *id,
+         TCON_IDX *tcon_idx,
          TCON *carrier)
 {
     return DSL_Tensor_TCON_Create_Record
-               (DSL_TENSOR_TCON_STORAGE_ONE, info, id, carrier);
+               (DSL_TENSOR_TCON_STORAGE_ONE, info, tcon_idx, carrier);
 }
 
 BOOL
 DSL_Tensor_TCON_Create_Splat
         (const DSL_TENSOR_TCON_CREATE_INFO *info,
-         DSL_TENSOR_TCON_ID *id,
+         TCON_IDX *tcon_idx,
          TCON *carrier)
 {
     return DSL_Tensor_TCON_Create_Record
-               (DSL_TENSOR_TCON_STORAGE_SPLAT, info, id, carrier);
+               (DSL_TENSOR_TCON_STORAGE_SPLAT, info, tcon_idx, carrier);
 }
 
 BOOL
 DSL_Tensor_TCON_Create_Inline_Dense
         (const DSL_TENSOR_TCON_CREATE_INFO *info,
-         DSL_TENSOR_TCON_ID *id,
+         TCON_IDX *tcon_idx,
          TCON *carrier)
 {
     return DSL_Tensor_TCON_Create_Record
-               (DSL_TENSOR_TCON_STORAGE_INLINE_DENSE, info, id, carrier);
+               (DSL_TENSOR_TCON_STORAGE_INLINE_DENSE, info, tcon_idx,
+                carrier);
 }
 
 BOOL
 DSL_Tensor_TCON_Create_Side_File_Dense
         (const DSL_TENSOR_TCON_CREATE_INFO *info,
-         DSL_TENSOR_TCON_ID *id,
+         TCON_IDX *tcon_idx,
          TCON *carrier)
 {
     return DSL_Tensor_TCON_Create_Record
-               (DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE, info, id, carrier);
+               (DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE, info, tcon_idx,
+                carrier);
 }
 
 UINT64
-DSL_Tensor_TCON_Semantic_Hash (DSL_TENSOR_TCON_ID id)
+DSL_Tensor_TCON_Semantic_Hash (TCON_IDX tcon_idx)
 {
     DSL_TENSOR_TCON_RECORD record;
 
-    if (!DSL_Tensor_TCON_Get(id, &record))
+    if (!DSL_Tensor_TCON_Get(tcon_idx, &record))
         return 0;
     return DSL_Tensor_TCON_Record_Semantic_Hash(&record);
 }
 
 BOOL
 DSL_Tensor_TCON_Semantic_Equal
-        (DSL_TENSOR_TCON_ID left,
-         DSL_TENSOR_TCON_ID right)
+        (TCON_IDX left,
+         TCON_IDX right)
 {
     DSL_TENSOR_TCON_RECORD left_record;
     DSL_TENSOR_TCON_RECORD right_record;
+    TCON left_carrier;
+    TCON right_carrier;
 
-    return DSL_Tensor_TCON_Get(left, &left_record) &&
-           DSL_Tensor_TCON_Get(right, &right_record) &&
+    if (left == TCON_IDX_ZERO || right == TCON_IDX_ZERO)
+        return FALSE;
+
+    left_carrier = TCON_from_IDX(left);
+    right_carrier = TCON_from_IDX(right);
+    return DSL_Tensor_TCON_Decode_Carrier(&left_carrier, &left_record) &&
+           DSL_Tensor_TCON_Decode_Carrier(&right_carrier, &right_record) &&
            DSL_Tensor_TCON_Record_Semantic_Equal
-               (&left_record, &right_record);
+               (&left_record, &left_carrier, &right_record, &right_carrier);
 }
 
 BOOL
 DSL_Tensor_TCON_Get_Element_TCON
-        (DSL_TENSOR_TCON_ID id,
+        (TCON_IDX tcon_idx,
          UINT64 element_index,
          TCON_IDX *element_tcon)
 {
@@ -778,7 +955,7 @@ DSL_Tensor_TCON_Get_Element_TCON
     if (element_tcon != NULL)
         *element_tcon = TCON_IDX_ZERO;
 
-    if (!DSL_Tensor_TCON_Get(id, &record) ||
+    if (!DSL_Tensor_TCON_Get(tcon_idx, &record) ||
         element_index >= record.element_count ||
         element_tcon == NULL)
         return FALSE;

--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -8,6 +8,17 @@
 
 #include "dsl_tensor_fold.h"
 #include "strtab.h"
+#ifdef DSL_TENSOR_FOLD_TEST_STUB
+extern UINT32 TCON_Table_Size (void);
+extern UINT32 TY_Table_Size (void);
+extern BOOL TY_is_tensor_extension (TY_IDX ty);
+extern BOOL TY_tensor_is_canonical (TY_IDX ty);
+extern TY_IDX TY_tensor_element_ty (TY_IDX ty);
+extern TYPE_ID TY_mtype (TY_IDX ty);
+extern UINT64 TY_size (TY_IDX ty);
+#else
+#include "symtab.h"
+#endif
 
 static const char *DSL_tensor_fold_status_name[] = {
     "not_applicable",
@@ -61,6 +72,24 @@ static BOOL
 DSL_Tensor_TCON_Alignment_Valid (UINT32 alignment)
 {
     return alignment != 0 && (alignment & (alignment - 1)) == 0;
+}
+
+static BOOL
+DSL_Tensor_TCON_IDX_Valid (TCON_IDX tcon_idx)
+{
+    return tcon_idx != TCON_IDX_ZERO && tcon_idx < TCON_Table_Size();
+}
+
+static BOOL
+DSL_Tensor_TY_IDX_Valid (TY_IDX ty)
+{
+    return ty != TY_IDX_ZERO && TY_IDX_index(ty) < TY_Table_Size();
+}
+
+static BOOL
+DSL_Tensor_TCON_Element_Mtype_Valid (UINT32 mtype)
+{
+    return mtype > MTYPE_UNKNOWN && mtype <= MTYPE_LAST;
 }
 
 static BOOL
@@ -129,10 +158,13 @@ DSL_Tensor_TCON_Common_Info_Valid
         (const DSL_TENSOR_TCON_CREATE_INFO *info)
 {
     UINT64 computed_bytes;
+    TY_IDX element_ty;
 
     if (info == NULL ||
-        info->descriptor_ty == TY_IDX_ZERO ||
-        info->element_mtype == MTYPE_UNKNOWN ||
+        !DSL_Tensor_TY_IDX_Valid(info->descriptor_ty) ||
+        !TY_is_tensor_extension(info->descriptor_ty) ||
+        !TY_tensor_is_canonical(info->descriptor_ty) ||
+        !DSL_Tensor_TCON_Element_Mtype_Valid(info->element_mtype) ||
         info->element_size == 0 ||
         info->element_count == 0 ||
         info->logical_bytes == 0 ||
@@ -146,7 +178,27 @@ DSL_Tensor_TCON_Common_Info_Valid
         computed_bytes != info->logical_bytes)
         return FALSE;
 
+    element_ty = TY_tensor_element_ty(info->descriptor_ty);
+    if (!DSL_Tensor_TY_IDX_Valid(element_ty) ||
+        TY_mtype(element_ty) != info->element_mtype ||
+        TY_size(element_ty) != info->element_size)
+        return FALSE;
+
     return TRUE;
+}
+
+static BOOL
+DSL_Tensor_TCON_Scalar_Info_Valid
+        (TCON_IDX scalar_tcon,
+         UINT32 element_mtype)
+{
+    TCON scalar;
+
+    if (!DSL_Tensor_TCON_IDX_Valid(scalar_tcon))
+        return FALSE;
+
+    scalar = TCON_from_IDX(scalar_tcon);
+    return TCON_ty(scalar) == element_mtype;
 }
 
 static UINT64
@@ -268,9 +320,12 @@ DSL_Tensor_TCON_Find_Cached_Equal
 
     for (i = 0; i < DSL_tensor_tcon_cache_count; ++i) {
         TCON_IDX cached_idx = DSL_tensor_tcon_cache[i];
-        TCON cached_carrier = TCON_from_IDX(cached_idx);
+        TCON cached_carrier;
         DSL_TENSOR_TCON_RECORD cached_record;
 
+        if (!DSL_Tensor_TCON_IDX_Valid(cached_idx))
+            continue;
+        cached_carrier = TCON_from_IDX(cached_idx);
         if (DSL_Tensor_TCON_Decode_Carrier(&cached_carrier,
                                            &cached_record) &&
             DSL_Tensor_TCON_Record_Semantic_Equal
@@ -284,10 +339,17 @@ DSL_Tensor_TCON_Find_Cached_Equal
 static void
 DSL_Tensor_TCON_Cache (TCON_IDX tcon_idx)
 {
+    UINT32 i;
+
     if (tcon_idx == TCON_IDX_ZERO ||
         DSL_tensor_tcon_cache_count >=
             sizeof(DSL_tensor_tcon_cache) / sizeof(DSL_tensor_tcon_cache[0]))
         return;
+
+    for (i = 0; i < DSL_tensor_tcon_cache_count; ++i) {
+        if (DSL_tensor_tcon_cache[i] == tcon_idx)
+            return;
+    }
 
     DSL_tensor_tcon_cache[DSL_tensor_tcon_cache_count++] = tcon_idx;
 }
@@ -302,12 +364,13 @@ DSL_Tensor_TCON_Envelope_Offsets_Valid
         record->reserved1 != 0 ||
         record->reserved2 != 0 ||
         record->header_size != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
-        record->record_size != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        record->flags != 0 ||
+        record->record_size != payload_length ||
         payload_length < DSL_TENSOR_TCON_ENVELOPE_SIZE)
         return FALSE;
 
     if (record->side_path_length != 0) {
-        if (record->side_path_offset < DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        if (record->side_path_offset != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
             record->side_path_offset + record->side_path_length <
                 record->side_path_offset ||
             record->side_path_offset + record->side_path_length >
@@ -318,7 +381,11 @@ DSL_Tensor_TCON_Envelope_Offsets_Valid
     }
 
     if (record->dense_length != 0) {
-        if (record->dense_offset < DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        UINT32 expected_dense_offset =
+            record->side_path_length == 0 ?
+                DSL_TENSOR_TCON_ENVELOPE_SIZE :
+                record->side_path_offset + record->side_path_length;
+        if (record->dense_offset != expected_dense_offset ||
             record->dense_offset + record->dense_length <
                 record->dense_offset ||
             record->dense_offset + record->dense_length > payload_length)
@@ -327,7 +394,12 @@ DSL_Tensor_TCON_Envelope_Offsets_Valid
         return FALSE;
     }
 
-    return TRUE;
+    if (record->dense_length != 0)
+        return record->dense_offset + record->dense_length == payload_length;
+    if (record->side_path_length != 0)
+        return record->side_path_offset + record->side_path_length ==
+               payload_length;
+    return payload_length == DSL_TENSOR_TCON_ENVELOPE_SIZE;
 }
 
 static BOOL
@@ -338,6 +410,7 @@ DSL_Tensor_TCON_Record_Valid
     char *payload;
     UINT32 payload_length;
     UINT64 computed_bytes;
+    TY_IDX element_ty;
 
     if (record == NULL ||
         carrier == NULL ||
@@ -356,8 +429,10 @@ DSL_Tensor_TCON_Record_Valid
     if (record->magic != DSL_TENSOR_TCON_MAGIC ||
         record->version != DSL_TENSOR_TCON_VERSION ||
         !DSL_Tensor_TCON_Envelope_Offsets_Valid(record, payload_length) ||
-        record->descriptor_ty == TY_IDX_ZERO ||
-        record->element_mtype == MTYPE_UNKNOWN ||
+        !DSL_Tensor_TY_IDX_Valid(record->descriptor_ty) ||
+        !TY_is_tensor_extension(record->descriptor_ty) ||
+        !TY_tensor_is_canonical(record->descriptor_ty) ||
+        !DSL_Tensor_TCON_Element_Mtype_Valid(record->element_mtype) ||
         record->element_size == 0 ||
         record->element_count == 0 ||
         record->logical_bytes == 0 ||
@@ -371,29 +446,64 @@ DSL_Tensor_TCON_Record_Valid
         computed_bytes != record->logical_bytes)
         return FALSE;
 
+    element_ty = TY_tensor_element_ty(record->descriptor_ty);
+    if (!DSL_Tensor_TY_IDX_Valid(element_ty) ||
+        TY_mtype(element_ty) != record->element_mtype ||
+        TY_size(element_ty) != record->element_size)
+        return FALSE;
+
     switch (record->storage_kind) {
     case DSL_TENSOR_TCON_STORAGE_ZERO:
-        return record->scalar_tcon != TCON_IDX_ZERO &&
+        return DSL_Tensor_TCON_Scalar_Info_Valid
+                   (record->scalar_tcon, record->element_mtype) &&
                record->scalar_integer_value == 0 &&
                record->side_path_length == 0 &&
-               record->dense_length == 0;
+               record->side_path_offset == 0 &&
+               record->dense_length == 0 &&
+               record->dense_offset == 0 &&
+               record->byte_offset == 0 &&
+               record->byte_length == 0 &&
+               record->checksum_hi == 0 &&
+               record->checksum_lo == 0;
     case DSL_TENSOR_TCON_STORAGE_ONE:
-        return record->scalar_tcon != TCON_IDX_ZERO &&
+        return DSL_Tensor_TCON_Scalar_Info_Valid
+                   (record->scalar_tcon, record->element_mtype) &&
                record->scalar_integer_value == 1 &&
                record->side_path_length == 0 &&
-               record->dense_length == 0;
+               record->side_path_offset == 0 &&
+               record->dense_length == 0 &&
+               record->dense_offset == 0 &&
+               record->byte_offset == 0 &&
+               record->byte_length == 0 &&
+               record->checksum_hi == 0 &&
+               record->checksum_lo == 0;
     case DSL_TENSOR_TCON_STORAGE_SPLAT:
-        return record->scalar_tcon != TCON_IDX_ZERO &&
+        return DSL_Tensor_TCON_Scalar_Info_Valid
+                   (record->scalar_tcon, record->element_mtype) &&
                record->side_path_length == 0 &&
-               record->dense_length == 0;
+               record->side_path_offset == 0 &&
+               record->dense_length == 0 &&
+               record->dense_offset == 0 &&
+               record->byte_offset == 0 &&
+               record->byte_length == 0 &&
+               record->checksum_hi == 0 &&
+               record->checksum_lo == 0;
     case DSL_TENSOR_TCON_STORAGE_INLINE_DENSE:
         return record->scalar_tcon == TCON_IDX_ZERO &&
+               record->scalar_integer_value == 0 &&
                record->side_path_length == 0 &&
+               record->side_path_offset == 0 &&
+               record->byte_offset == 0 &&
+               record->byte_length == 0 &&
+               record->dense_offset == DSL_TENSOR_TCON_ENVELOPE_SIZE &&
                record->dense_length == record->logical_bytes &&
                DSL_Tensor_TCON_Checksum_Valid(record->checksum_hi,
                                               record->checksum_lo);
     case DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE:
-        return record->side_path_length != 0 &&
+        return record->scalar_tcon == TCON_IDX_ZERO &&
+               record->scalar_integer_value == 0 &&
+               record->side_path_offset == DSL_TENSOR_TCON_ENVELOPE_SIZE &&
+               record->side_path_length != 0 &&
                record->byte_length == record->logical_bytes &&
                (record->byte_offset % record->required_alignment) == 0 &&
                (record->dense_length == 0 ||
@@ -453,7 +563,6 @@ DSL_Tensor_TCON_Create_Record
     char *payload;
     UINT32 payload_length;
     UINT32 cursor;
-    UINT32 payload_idx;
 
     if (tcon_idx != NULL)
         *tcon_idx = TCON_IDX_ZERO;
@@ -465,7 +574,6 @@ DSL_Tensor_TCON_Create_Record
     record.magic = DSL_TENSOR_TCON_MAGIC;
     record.version = DSL_TENSOR_TCON_VERSION;
     record.header_size = DSL_TENSOR_TCON_ENVELOPE_SIZE;
-    record.record_size = DSL_TENSOR_TCON_ENVELOPE_SIZE;
     record.storage_kind = storage_kind;
     record.descriptor_ty = info->descriptor_ty;
     record.scalar_tcon = info->scalar_tcon;
@@ -482,25 +590,56 @@ DSL_Tensor_TCON_Create_Record
 
     switch (storage_kind) {
     case DSL_TENSOR_TCON_STORAGE_ZERO:
-        if (info->scalar_tcon == TCON_IDX_ZERO ||
-            info->scalar_integer_value != 0)
+        if (!DSL_Tensor_TCON_Scalar_Info_Valid(info->scalar_tcon,
+                                               info->element_mtype) ||
+            info->scalar_integer_value != 0 ||
+            info->dense_bytes != NULL ||
+            info->dense_bytes_length != 0 ||
+            info->side_path != NULL ||
+            info->side_path_length != 0 ||
+            info->byte_offset != 0 ||
+            info->byte_length != 0 ||
+            info->checksum_hi != 0 ||
+            info->checksum_lo != 0)
             return FALSE;
         break;
     case DSL_TENSOR_TCON_STORAGE_ONE:
-        if (info->scalar_tcon == TCON_IDX_ZERO ||
-            info->scalar_integer_value != 1)
+        if (!DSL_Tensor_TCON_Scalar_Info_Valid(info->scalar_tcon,
+                                               info->element_mtype) ||
+            info->scalar_integer_value != 1 ||
+            info->dense_bytes != NULL ||
+            info->dense_bytes_length != 0 ||
+            info->side_path != NULL ||
+            info->side_path_length != 0 ||
+            info->byte_offset != 0 ||
+            info->byte_length != 0 ||
+            info->checksum_hi != 0 ||
+            info->checksum_lo != 0)
             return FALSE;
         break;
     case DSL_TENSOR_TCON_STORAGE_SPLAT:
-        if (info->scalar_tcon == TCON_IDX_ZERO)
-            return FALSE;
-        if (info->dense_bytes != NULL || info->dense_bytes_length != 0)
+        if (!DSL_Tensor_TCON_Scalar_Info_Valid(info->scalar_tcon,
+                                               info->element_mtype) ||
+            info->dense_bytes != NULL ||
+            info->dense_bytes_length != 0 ||
+            info->side_path != NULL ||
+            info->side_path_length != 0 ||
+            info->byte_offset != 0 ||
+            info->byte_length != 0 ||
+            info->checksum_hi != 0 ||
+            info->checksum_lo != 0)
             return FALSE;
         break;
     case DSL_TENSOR_TCON_STORAGE_INLINE_DENSE:
         if (info->dense_bytes == NULL ||
             info->dense_bytes_length == 0 ||
             info->dense_bytes_length != info->logical_bytes ||
+            info->scalar_tcon != TCON_IDX_ZERO ||
+            info->scalar_integer_value != 0 ||
+            info->side_path != NULL ||
+            info->side_path_length != 0 ||
+            info->byte_offset != 0 ||
+            info->byte_length != 0 ||
             !DSL_Tensor_TCON_Checksum_Valid(info->checksum_hi,
                                             info->checksum_lo))
             return FALSE;
@@ -508,6 +647,8 @@ DSL_Tensor_TCON_Create_Record
     case DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE:
         if (!DSL_Tensor_TCON_Relative_Path_Valid(info->side_path,
                                                  info->side_path_length) ||
+            info->scalar_tcon != TCON_IDX_ZERO ||
+            info->scalar_integer_value != 0 ||
             !DSL_Tensor_TCON_Range_Valid(info->byte_offset,
                                          info->byte_length) ||
             info->byte_length != info->logical_bytes ||
@@ -533,6 +674,7 @@ DSL_Tensor_TCON_Create_Record
             return FALSE;
         payload_length += info->dense_bytes_length;
     }
+    record.record_size = payload_length;
 
     payload = (char *)malloc(payload_length);
     if (payload == NULL)
@@ -555,14 +697,9 @@ DSL_Tensor_TCON_Create_Record
     }
     memcpy(payload, &record, sizeof(record));
 
-    payload_idx = Save_StrN(payload, payload_length);
+    built_carrier = Host_To_Targ_String(MTYPE_STRING, payload,
+                                        payload_length);
     free(payload);
-    if (payload_idx == 0)
-        return FALSE;
-
-    TCON_clear(built_carrier);
-    Set_TCON_string_payload(built_carrier, MTYPE_STRING, payload_idx,
-                            payload_length);
     if (!DSL_Tensor_TCON_Decode_Carrier(&built_carrier, NULL))
         return FALSE;
 
@@ -827,10 +964,15 @@ DSL_Tensor_TCON_Rebuild_Derived_Cache
          TCON_IDX limit_tcon_idx)
 {
     TCON_IDX idx;
+    UINT32 table_size = TCON_Table_Size();
 
     DSL_Tensor_TCON_Reset();
     if (first_tcon_idx == TCON_IDX_ZERO)
         first_tcon_idx = 1;
+    if (limit_tcon_idx == TCON_IDX_ZERO || limit_tcon_idx > table_size)
+        limit_tcon_idx = table_size;
+    if (first_tcon_idx >= table_size || first_tcon_idx >= limit_tcon_idx)
+        return;
 
     for (idx = first_tcon_idx; idx < limit_tcon_idx; ++idx) {
         TCON carrier = TCON_from_IDX(idx);
@@ -848,6 +990,8 @@ DSL_Tensor_TCON_Get
 
     if (tcon_idx == TCON_IDX_ZERO || record == NULL)
         return FALSE;
+    if (!DSL_Tensor_TCON_IDX_Valid(tcon_idx))
+        return FALSE;
 
     carrier = TCON_from_IDX(tcon_idx);
     return DSL_Tensor_TCON_Decode_Carrier(&carrier, record);
@@ -859,6 +1003,69 @@ DSL_Tensor_TCON_Is_Carrier
          DSL_TENSOR_TCON_RECORD *record)
 {
     return DSL_Tensor_TCON_Get(tcon_idx, record);
+}
+
+BOOL
+DSL_Tensor_TCON_Get_Side_Path
+        (TCON_IDX tcon_idx,
+         const char **bytes,
+         UINT32 *length)
+{
+    DSL_TENSOR_TCON_RECORD record;
+    TCON carrier;
+    char *payload;
+
+    if (bytes != NULL)
+        *bytes = NULL;
+    if (length != NULL)
+        *length = 0;
+    if (bytes == NULL || length == NULL ||
+        !DSL_Tensor_TCON_IDX_Valid(tcon_idx))
+        return FALSE;
+
+    carrier = TCON_from_IDX(tcon_idx);
+    if (!DSL_Tensor_TCON_Decode_Carrier(&carrier, &record) ||
+        record.side_path_length == 0)
+        return FALSE;
+
+    payload = Index_to_char_array(TCON_str_idx(carrier));
+    if (payload == NULL)
+        return FALSE;
+
+    *bytes = payload + record.side_path_offset;
+    *length = record.side_path_length;
+    return TRUE;
+}
+
+BOOL
+DSL_Tensor_TCON_Get_Dense_Bytes
+        (TCON_IDX tcon_idx,
+         const unsigned char **bytes,
+         UINT32 *length)
+{
+    DSL_TENSOR_TCON_RECORD record;
+    TCON carrier;
+    const unsigned char *payload;
+
+    if (bytes != NULL)
+        *bytes = NULL;
+    if (length != NULL)
+        *length = 0;
+    if (bytes == NULL || length == NULL ||
+        !DSL_Tensor_TCON_IDX_Valid(tcon_idx))
+        return FALSE;
+
+    carrier = TCON_from_IDX(tcon_idx);
+    if (!DSL_Tensor_TCON_Decode_Carrier(&carrier, &record))
+        return FALSE;
+
+    payload = DSL_Tensor_TCON_Record_Dense_Bytes(&record, &carrier);
+    if (payload == NULL)
+        return FALSE;
+
+    *bytes = payload;
+    *length = record.dense_length;
+    return TRUE;
 }
 
 BOOL
@@ -933,8 +1140,11 @@ DSL_Tensor_TCON_Semantic_Equal
     TCON left_carrier;
     TCON right_carrier;
 
-    if (left == TCON_IDX_ZERO || right == TCON_IDX_ZERO)
+    if (!DSL_Tensor_TCON_IDX_Valid(left) ||
+        !DSL_Tensor_TCON_IDX_Valid(right))
         return FALSE;
+    if (left == right)
+        return DSL_Tensor_TCON_Get(left, &left_record);
 
     left_carrier = TCON_from_IDX(left);
     right_carrier = TCON_from_IDX(right);

--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -366,7 +366,10 @@ DSL_Tensor_TCON_Envelope_Offsets_Valid
         record->header_size != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
         record->flags != 0 ||
         record->record_size != payload_length ||
-        payload_length < DSL_TENSOR_TCON_ENVELOPE_SIZE)
+        payload_length <= DSL_TENSOR_TCON_ENVELOPE_SIZE)
+        return FALSE;
+
+    if (record->record_size == 0)
         return FALSE;
 
     if (record->side_path_length != 0) {
@@ -374,7 +377,7 @@ DSL_Tensor_TCON_Envelope_Offsets_Valid
             record->side_path_offset + record->side_path_length <
                 record->side_path_offset ||
             record->side_path_offset + record->side_path_length >
-                payload_length)
+                payload_length - 1)
             return FALSE;
     } else if (record->side_path_offset != 0) {
         return FALSE;
@@ -388,18 +391,19 @@ DSL_Tensor_TCON_Envelope_Offsets_Valid
         if (record->dense_offset != expected_dense_offset ||
             record->dense_offset + record->dense_length <
                 record->dense_offset ||
-            record->dense_offset + record->dense_length > payload_length)
+            record->dense_offset + record->dense_length > payload_length - 1)
             return FALSE;
     } else if (record->dense_offset != 0) {
         return FALSE;
     }
 
     if (record->dense_length != 0)
-        return record->dense_offset + record->dense_length == payload_length;
+        return record->dense_offset + record->dense_length ==
+               payload_length - 1;
     if (record->side_path_length != 0)
         return record->side_path_offset + record->side_path_length ==
-               payload_length;
-    return payload_length == DSL_TENSOR_TCON_ENVELOPE_SIZE;
+               payload_length - 1;
+    return payload_length == DSL_TENSOR_TCON_ENVELOPE_SIZE + 1;
 }
 
 static BOOL
@@ -423,7 +427,8 @@ DSL_Tensor_TCON_Record_Valid
     payload = Index_to_char_array(TCON_str_idx(*carrier));
     payload_length = TCON_str_len(*carrier);
     if (payload == NULL ||
-        memcmp(payload, record, sizeof(*record)) != 0)
+        memcmp(payload, record, sizeof(*record)) != 0 ||
+        payload[payload_length - 1] != '\0')
         return FALSE;
 
     if (record->magic != DSL_TENSOR_TCON_MAGIC ||
@@ -674,6 +679,9 @@ DSL_Tensor_TCON_Create_Record
             return FALSE;
         payload_length += info->dense_bytes_length;
     }
+    if (payload_length + 1 < payload_length)
+        return FALSE;
+    payload_length += 1;
     record.record_size = payload_length;
 
     payload = (char *)malloc(payload_length);

--- a/osprey/common/com/dsl_tensor_fold.h
+++ b/osprey/common/com/dsl_tensor_fold.h
@@ -22,11 +22,9 @@
  */
 
 #define DSL_TENSOR_FOLD_MAX_RESULTS 2
-#define DSL_TENSOR_TCON_INVALID_ID 0
-#define DSL_TENSOR_TCON_RECORD_SIZE 120
-#define DSL_TENSOR_TCON_TABLE_CAPACITY 4096
-
-typedef UINT32 DSL_TENSOR_TCON_ID;
+#define DSL_TENSOR_TCON_MAGIC 0x44535443U
+#define DSL_TENSOR_TCON_VERSION 1
+#define DSL_TENSOR_TCON_ENVELOPE_SIZE 128
 
 typedef enum {
     DSL_TENSOR_TCON_STORAGE_ZERO = 0,
@@ -44,24 +42,30 @@ typedef struct {
     UINT64 checksum_hi;
     UINT64 checksum_lo;
     INT64 scalar_integer_value;
-    DSL_TENSOR_TCON_ID id;
+    UINT32 magic;
     UINT32 version;
+    UINT32 header_size;
+    UINT32 record_size;
     DSL_TENSOR_TCON_STORAGE_KIND storage_kind;
     UINT32 flags;
-    UINT32 required_alignment;
-    UINT32 element_size;
-    UINT32 carrier_token;
-    UINT32 dense_payload_ref;
-    UINT32 dense_payload_bytes;
-    STR_IDX side_file;
     TY_IDX descriptor_ty;
     TCON_IDX scalar_tcon;
-    TYPE_ID element_mtype;
+    UINT32 element_mtype;
+    UINT32 element_size;
+    UINT32 required_alignment;
+    UINT32 side_path_offset;
+    UINT32 side_path_length;
+    UINT32 dense_offset;
+    UINT32 dense_length;
     UINT32 reserved0;
-} DSL_TENSOR_TCON_RECORD;
+    UINT32 reserved1;
+    UINT32 reserved2;
+} DSL_TENSOR_TCON_ENVELOPE;
 
-typedef char DSL_TENSOR_TCON_RECORD_SIZE_ASSERT
-    [(sizeof(DSL_TENSOR_TCON_RECORD) == DSL_TENSOR_TCON_RECORD_SIZE) ? 1 : -1];
+typedef DSL_TENSOR_TCON_ENVELOPE DSL_TENSOR_TCON_RECORD;
+
+typedef char DSL_TENSOR_TCON_ENVELOPE_SIZE_ASSERT
+    [(sizeof(DSL_TENSOR_TCON_ENVELOPE) == DSL_TENSOR_TCON_ENVELOPE_SIZE) ? 1 : -1];
 
 typedef struct {
     TY_IDX descriptor_ty;
@@ -74,7 +78,8 @@ typedef struct {
     INT64 scalar_integer_value;
     const unsigned char *dense_bytes;
     UINT32 dense_bytes_length;
-    STR_IDX side_file;
+    const char *side_path;
+    UINT32 side_path_length;
     UINT64 byte_offset;
     UINT64 byte_length;
     UINT64 checksum_hi;
@@ -187,43 +192,45 @@ extern DSL_TENSOR_FOLD_STATUS Targ_DSL_WhirlOp
                                 (const DSL_TENSOR_FOLD_CANDIDATE *candidate,
                                  DSL_TENSOR_FOLD_OUTPUT *output);
 extern void DSL_Tensor_TCON_Reset (void);
-extern UINT32 DSL_Tensor_TCON_Count (void);
+extern void DSL_Tensor_TCON_Rebuild_Derived_Cache
+                                (TCON_IDX first_tcon_idx,
+                                 TCON_IDX limit_tcon_idx);
 extern BOOL DSL_Tensor_TCON_Get
-                                (DSL_TENSOR_TCON_ID id,
+                                (TCON_IDX tcon_idx,
                                  DSL_TENSOR_TCON_RECORD *record);
 extern BOOL DSL_Tensor_TCON_Is_Carrier
+                                (TCON_IDX tcon_idx,
+                                 DSL_TENSOR_TCON_RECORD *record);
+extern BOOL DSL_Tensor_TCON_Decode_Carrier
                                 (const TCON *carrier,
-                                 DSL_TENSOR_TCON_ID *id);
-extern BOOL DSL_Tensor_TCON_Create_Carrier
-                                (DSL_TENSOR_TCON_ID id,
-                                 TCON *carrier);
+                                 DSL_TENSOR_TCON_RECORD *record);
 extern BOOL DSL_Tensor_TCON_Create_Zero
                                 (const DSL_TENSOR_TCON_CREATE_INFO *info,
-                                 DSL_TENSOR_TCON_ID *id,
+                                 TCON_IDX *tcon_idx,
                                  TCON *carrier);
 extern BOOL DSL_Tensor_TCON_Create_One
                                 (const DSL_TENSOR_TCON_CREATE_INFO *info,
-                                 DSL_TENSOR_TCON_ID *id,
+                                 TCON_IDX *tcon_idx,
                                  TCON *carrier);
 extern BOOL DSL_Tensor_TCON_Create_Splat
                                 (const DSL_TENSOR_TCON_CREATE_INFO *info,
-                                 DSL_TENSOR_TCON_ID *id,
+                                 TCON_IDX *tcon_idx,
                                  TCON *carrier);
 extern BOOL DSL_Tensor_TCON_Create_Inline_Dense
                                 (const DSL_TENSOR_TCON_CREATE_INFO *info,
-                                 DSL_TENSOR_TCON_ID *id,
+                                 TCON_IDX *tcon_idx,
                                  TCON *carrier);
 extern BOOL DSL_Tensor_TCON_Create_Side_File_Dense
                                 (const DSL_TENSOR_TCON_CREATE_INFO *info,
-                                 DSL_TENSOR_TCON_ID *id,
+                                 TCON_IDX *tcon_idx,
                                  TCON *carrier);
 extern UINT64 DSL_Tensor_TCON_Semantic_Hash
-                                (DSL_TENSOR_TCON_ID id);
+                                (TCON_IDX tcon_idx);
 extern BOOL DSL_Tensor_TCON_Semantic_Equal
-                                (DSL_TENSOR_TCON_ID left,
-                                 DSL_TENSOR_TCON_ID right);
+                                (TCON_IDX left,
+                                 TCON_IDX right);
 extern BOOL DSL_Tensor_TCON_Get_Element_TCON
-                                (DSL_TENSOR_TCON_ID id,
+                                (TCON_IDX tcon_idx,
                                  UINT64 element_index,
                                  TCON_IDX *element_tcon);
 

--- a/osprey/common/com/dsl_tensor_fold.h
+++ b/osprey/common/com/dsl_tensor_fold.h
@@ -22,6 +22,64 @@
  */
 
 #define DSL_TENSOR_FOLD_MAX_RESULTS 2
+#define DSL_TENSOR_TCON_INVALID_ID 0
+#define DSL_TENSOR_TCON_RECORD_SIZE 120
+#define DSL_TENSOR_TCON_TABLE_CAPACITY 4096
+
+typedef UINT32 DSL_TENSOR_TCON_ID;
+
+typedef enum {
+    DSL_TENSOR_TCON_STORAGE_ZERO = 0,
+    DSL_TENSOR_TCON_STORAGE_ONE = 1,
+    DSL_TENSOR_TCON_STORAGE_SPLAT = 2,
+    DSL_TENSOR_TCON_STORAGE_INLINE_DENSE = 3,
+    DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE = 4
+} DSL_TENSOR_TCON_STORAGE_KIND;
+
+typedef struct {
+    UINT64 element_count;
+    UINT64 logical_bytes;
+    UINT64 byte_offset;
+    UINT64 byte_length;
+    UINT64 checksum_hi;
+    UINT64 checksum_lo;
+    INT64 scalar_integer_value;
+    DSL_TENSOR_TCON_ID id;
+    UINT32 version;
+    DSL_TENSOR_TCON_STORAGE_KIND storage_kind;
+    UINT32 flags;
+    UINT32 required_alignment;
+    UINT32 element_size;
+    UINT32 carrier_token;
+    UINT32 dense_payload_ref;
+    UINT32 dense_payload_bytes;
+    STR_IDX side_file;
+    TY_IDX descriptor_ty;
+    TCON_IDX scalar_tcon;
+    TYPE_ID element_mtype;
+    UINT32 reserved0;
+} DSL_TENSOR_TCON_RECORD;
+
+typedef char DSL_TENSOR_TCON_RECORD_SIZE_ASSERT
+    [(sizeof(DSL_TENSOR_TCON_RECORD) == DSL_TENSOR_TCON_RECORD_SIZE) ? 1 : -1];
+
+typedef struct {
+    TY_IDX descriptor_ty;
+    TCON_IDX scalar_tcon;
+    TYPE_ID element_mtype;
+    UINT64 element_count;
+    UINT64 logical_bytes;
+    UINT32 required_alignment;
+    UINT32 element_size;
+    INT64 scalar_integer_value;
+    const unsigned char *dense_bytes;
+    UINT32 dense_bytes_length;
+    STR_IDX side_file;
+    UINT64 byte_offset;
+    UINT64 byte_length;
+    UINT64 checksum_hi;
+    UINT64 checksum_lo;
+} DSL_TENSOR_TCON_CREATE_INFO;
 
 typedef enum {
     DSL_TENSOR_FOLD_RESULT_NONE = 0,
@@ -128,5 +186,45 @@ extern BOOL DSL_Tensor_Fold_Candidate_Valid
 extern DSL_TENSOR_FOLD_STATUS Targ_DSL_WhirlOp
                                 (const DSL_TENSOR_FOLD_CANDIDATE *candidate,
                                  DSL_TENSOR_FOLD_OUTPUT *output);
+extern void DSL_Tensor_TCON_Reset (void);
+extern UINT32 DSL_Tensor_TCON_Count (void);
+extern BOOL DSL_Tensor_TCON_Get
+                                (DSL_TENSOR_TCON_ID id,
+                                 DSL_TENSOR_TCON_RECORD *record);
+extern BOOL DSL_Tensor_TCON_Is_Carrier
+                                (const TCON *carrier,
+                                 DSL_TENSOR_TCON_ID *id);
+extern BOOL DSL_Tensor_TCON_Create_Carrier
+                                (DSL_TENSOR_TCON_ID id,
+                                 TCON *carrier);
+extern BOOL DSL_Tensor_TCON_Create_Zero
+                                (const DSL_TENSOR_TCON_CREATE_INFO *info,
+                                 DSL_TENSOR_TCON_ID *id,
+                                 TCON *carrier);
+extern BOOL DSL_Tensor_TCON_Create_One
+                                (const DSL_TENSOR_TCON_CREATE_INFO *info,
+                                 DSL_TENSOR_TCON_ID *id,
+                                 TCON *carrier);
+extern BOOL DSL_Tensor_TCON_Create_Splat
+                                (const DSL_TENSOR_TCON_CREATE_INFO *info,
+                                 DSL_TENSOR_TCON_ID *id,
+                                 TCON *carrier);
+extern BOOL DSL_Tensor_TCON_Create_Inline_Dense
+                                (const DSL_TENSOR_TCON_CREATE_INFO *info,
+                                 DSL_TENSOR_TCON_ID *id,
+                                 TCON *carrier);
+extern BOOL DSL_Tensor_TCON_Create_Side_File_Dense
+                                (const DSL_TENSOR_TCON_CREATE_INFO *info,
+                                 DSL_TENSOR_TCON_ID *id,
+                                 TCON *carrier);
+extern UINT64 DSL_Tensor_TCON_Semantic_Hash
+                                (DSL_TENSOR_TCON_ID id);
+extern BOOL DSL_Tensor_TCON_Semantic_Equal
+                                (DSL_TENSOR_TCON_ID left,
+                                 DSL_TENSOR_TCON_ID right);
+extern BOOL DSL_Tensor_TCON_Get_Element_TCON
+                                (DSL_TENSOR_TCON_ID id,
+                                 UINT64 element_index,
+                                 TCON_IDX *element_tcon);
 
 #endif /* dsl_tensor_fold_INCLUDED */

--- a/osprey/common/com/dsl_tensor_fold.h
+++ b/osprey/common/com/dsl_tensor_fold.h
@@ -204,6 +204,14 @@ extern BOOL DSL_Tensor_TCON_Is_Carrier
 extern BOOL DSL_Tensor_TCON_Decode_Carrier
                                 (const TCON *carrier,
                                  DSL_TENSOR_TCON_RECORD *record);
+extern BOOL DSL_Tensor_TCON_Get_Side_Path
+                                (TCON_IDX tcon_idx,
+                                 const char **bytes,
+                                 UINT32 *length);
+extern BOOL DSL_Tensor_TCON_Get_Dense_Bytes
+                                (TCON_IDX tcon_idx,
+                                 const unsigned char **bytes,
+                                 UINT32 *length);
 extern BOOL DSL_Tensor_TCON_Create_Zero
                                 (const DSL_TENSOR_TCON_CREATE_INFO *info,
                                  TCON_IDX *tcon_idx,

--- a/osprey/common/com/targ_const.h
+++ b/osprey/common/com/targ_const.h
@@ -106,8 +106,6 @@
 /* Include the target machine type IDs: */
 #include "mtypes.h"
 
-#define TCON_DSL_TENSOR_CARRIER 0x80000000U
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -285,16 +283,6 @@ inline mUINT32
 TCON_str_idx (const TCON& tcon)		{ return tcon.vals.sval.cp; }
 inline mUINT32
 TCON_str_len (const TCON& tcon)		{ return tcon.vals.sval.len; }
-inline BOOL
-TCON_is_dsl_tensor_carrier (const TCON& tcon)
-{
-  return (tcon.flags & TCON_DSL_TENSOR_CARRIER) != 0;
-}
-inline void
-Set_TCON_dsl_tensor_carrier (TCON& tcon)
-{
-  tcon.flags |= TCON_DSL_TENSOR_CARRIER;
-}
 inline void
 Set_TCON_string_payload (TCON& tcon, TYPE_ID mtype, mUINT32 cp, mUINT32 len)
 {

--- a/osprey/common/com/targ_const.h
+++ b/osprey/common/com/targ_const.h
@@ -106,6 +106,8 @@
 /* Include the target machine type IDs: */
 #include "mtypes.h"
 
+#define TCON_DSL_TENSOR_CARRIER 0x80000000U
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -283,6 +285,23 @@ inline mUINT32
 TCON_str_idx (const TCON& tcon)		{ return tcon.vals.sval.cp; }
 inline mUINT32
 TCON_str_len (const TCON& tcon)		{ return tcon.vals.sval.len; }
+inline BOOL
+TCON_is_dsl_tensor_carrier (const TCON& tcon)
+{
+  return (tcon.flags & TCON_DSL_TENSOR_CARRIER) != 0;
+}
+inline void
+Set_TCON_dsl_tensor_carrier (TCON& tcon)
+{
+  tcon.flags |= TCON_DSL_TENSOR_CARRIER;
+}
+inline void
+Set_TCON_string_payload (TCON& tcon, TYPE_ID mtype, mUINT32 cp, mUINT32 len)
+{
+  tcon.ty = mtype;
+  tcon.vals.sval.cp = cp;
+  tcon.vals.sval.len = len;
+}
 #else /* __cplusplus */
 typedef struct TCON TCON;
 #endif /* __cplusplus */

--- a/osprey/common/com/targ_const.h
+++ b/osprey/common/com/targ_const.h
@@ -283,13 +283,6 @@ inline mUINT32
 TCON_str_idx (const TCON& tcon)		{ return tcon.vals.sval.cp; }
 inline mUINT32
 TCON_str_len (const TCON& tcon)		{ return tcon.vals.sval.len; }
-inline void
-Set_TCON_string_payload (TCON& tcon, TYPE_ID mtype, mUINT32 cp, mUINT32 len)
-{
-  tcon.ty = mtype;
-  tcon.vals.sval.cp = cp;
-  tcon.vals.sval.len = len;
-}
 #else /* __cplusplus */
 typedef struct TCON TCON;
 #endif /* __cplusplus */

--- a/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
@@ -8,6 +8,9 @@
 #include "dsl_tensor_fold.h"
 #include "strtab.h"
 
+extern TCON_IDX Enter_tcon (const TCON& tcon);
+extern UINT32 TCON_Table_Size (void);
+
 static int
 Check_Status_Names(void)
 {
@@ -260,6 +263,16 @@ Test_Tensor_Type(UINT32 index)
     return ty;
 }
 
+static TCON_IDX
+Test_Scalar_TCON(TYPE_ID mtype)
+{
+    TCON scalar;
+
+    TCON_clear(scalar);
+    Set_TCON_ty(scalar, mtype);
+    return Enter_tcon(scalar);
+}
+
 static int
 Check_Tensor_TCON_Storage(void)
 {
@@ -275,13 +288,22 @@ Check_Tensor_TCON_Storage(void)
     TCON_IDX collision_idx;
     TCON_IDX side_unproven_idx;
     TCON_IDX side_distinct_idx;
+    TCON_IDX zero_scalar;
+    TCON_IDX one_scalar;
+    TCON_IDX splat_scalar;
+    TCON_IDX wrong_scalar;
     TCON carrier;
+    TCON malformed_carrier;
     TCON side_carrier;
     TCON scalar;
     TCON_IDX element_tcon;
     UINT64 inline_hash;
     UINT64 side_hash;
     char *payload;
+    const char *side_bytes;
+    const unsigned char *dense_bytes;
+    UINT32 side_length;
+    UINT32 dense_length;
     const char side_path[] = "weights/tensor.bin";
     const unsigned char inline_bytes[16] = {
         'a', 0, 'b', 3, 4, 5, 6, 7,
@@ -291,9 +313,14 @@ Check_Tensor_TCON_Storage(void)
         'a', 0, 'b', 3, 4, 5, 6, 7,
         8, 9, 10, 11, 12, 13, 14, 16
     };
+    char malformed_payload[DSL_TENSOR_TCON_ENVELOPE_SIZE + 17];
 
     Initialize_Strtab(1024);
     DSL_Tensor_TCON_Reset();
+    zero_scalar = Test_Scalar_TCON(MTYPE_I4);
+    one_scalar = Test_Scalar_TCON(MTYPE_I4);
+    splat_scalar = Test_Scalar_TCON(MTYPE_I4);
+    wrong_scalar = Test_Scalar_TCON(MTYPE_F4);
 
     if (sizeof(DSL_TENSOR_TCON_RECORD) !=
         DSL_TENSOR_TCON_ENVELOPE_SIZE) {
@@ -312,7 +339,7 @@ Check_Tensor_TCON_Storage(void)
 
     memset(&info, 0, sizeof(info));
     info.descriptor_ty = Test_Tensor_Type(101);
-    info.scalar_tcon = 11;
+    info.scalar_tcon = zero_scalar;
     info.element_mtype = MTYPE_I4;
     info.element_size = 4;
     info.scalar_integer_value = 0;
@@ -328,6 +355,7 @@ Check_Tensor_TCON_Storage(void)
         record.magic != DSL_TENSOR_TCON_MAGIC ||
         record.version != DSL_TENSOR_TCON_VERSION ||
         record.header_size != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        record.record_size != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
         record.storage_kind != DSL_TENSOR_TCON_STORAGE_ZERO ||
         record.descriptor_ty != info.descriptor_ty ||
         record.scalar_tcon != info.scalar_tcon ||
@@ -348,7 +376,7 @@ Check_Tensor_TCON_Storage(void)
     }
 
     if (!DSL_Tensor_TCON_Get_Element_TCON(zero_idx, 7, &element_tcon) ||
-        element_tcon != info.scalar_tcon ||
+        element_tcon != zero_scalar ||
         DSL_Tensor_TCON_Get_Element_TCON(zero_idx, 8, &element_tcon)) {
         fprintf(stderr, "compact tensor TCON element access changed\n");
         return 1;
@@ -360,7 +388,7 @@ Check_Tensor_TCON_Storage(void)
         return 1;
     }
 
-    info.scalar_tcon = 12;
+    info.scalar_tcon = one_scalar;
     info.scalar_integer_value = 1;
     if (!DSL_Tensor_TCON_Create_One(&info, &one_idx, NULL) ||
         !DSL_Tensor_TCON_Get(one_idx, &record) ||
@@ -370,21 +398,21 @@ Check_Tensor_TCON_Storage(void)
         return 1;
     }
 
-    info.scalar_tcon = 13;
+    info.scalar_tcon = splat_scalar;
     info.scalar_integer_value = 42;
     if (!DSL_Tensor_TCON_Create_Splat(&info, &splat_idx, NULL) ||
         !DSL_Tensor_TCON_Get(splat_idx, &record) ||
         record.storage_kind != DSL_TENSOR_TCON_STORAGE_SPLAT ||
         !DSL_Tensor_TCON_Get_Element_TCON(splat_idx, 3,
                                           &element_tcon) ||
-        element_tcon != 13) {
+        element_tcon != splat_scalar) {
         fprintf(stderr, "splat tensor TCON record contract changed\n");
         return 1;
     }
 
     memset(&info, 0, sizeof(info));
     info.descriptor_ty = Test_Tensor_Type(201);
-    info.element_mtype = MTYPE_U1;
+    info.element_mtype = MTYPE_I4;
     info.element_size = 4;
     info.element_count = 4;
     info.logical_bytes = 16;
@@ -400,14 +428,26 @@ Check_Tensor_TCON_Storage(void)
         record.dense_length != 16 ||
         TCON_str_len(carrier) !=
             DSL_TENSOR_TCON_ENVELOPE_SIZE + 16 ||
-        memcmp(Index_to_char_array(TCON_str_idx(carrier)) +
-               record.dense_offset, inline_bytes, 16) != 0 ||
+        !DSL_Tensor_TCON_Get_Dense_Bytes(inline_idx, &dense_bytes,
+                                         &dense_length) ||
+        dense_length != 16 ||
+        memcmp(dense_bytes, inline_bytes, 16) != 0 ||
         DSL_Tensor_TCON_Get_Element_TCON(inline_idx, 0,
                                          &element_tcon)) {
         fprintf(stderr, "inline dense tensor TCON contract changed\n");
         return 1;
     }
     inline_hash = DSL_Tensor_TCON_Semantic_Hash(inline_idx);
+    memcpy(malformed_payload, Index_to_char_array(TCON_str_idx(carrier)),
+           DSL_TENSOR_TCON_ENVELOPE_SIZE + 16);
+    malformed_payload[DSL_TENSOR_TCON_ENVELOPE_SIZE + 16] = '\7';
+    malformed_carrier =
+        Host_To_Targ_String(MTYPE_STRING, malformed_payload,
+                            DSL_TENSOR_TCON_ENVELOPE_SIZE + 17);
+    if (DSL_Tensor_TCON_Decode_Carrier(&malformed_carrier, NULL)) {
+        fprintf(stderr, "tensor TCON trailing payload accepted\n");
+        return 1;
+    }
 
     if (!DSL_Tensor_TCON_Create_Inline_Dense(&info, &duplicate_idx, NULL) ||
         duplicate_idx != inline_idx) {
@@ -426,7 +466,7 @@ Check_Tensor_TCON_Storage(void)
 
     memset(&info, 0, sizeof(info));
     info.descriptor_ty = Test_Tensor_Type(201);
-    info.element_mtype = MTYPE_U1;
+    info.element_mtype = MTYPE_I4;
     info.element_size = 4;
     info.element_count = 4;
     info.logical_bytes = 16;
@@ -457,6 +497,8 @@ Check_Tensor_TCON_Storage(void)
     if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &side_unproven_idx,
                                                 NULL) ||
         side_unproven_idx == inline_idx ||
+        !DSL_Tensor_TCON_Semantic_Equal(side_unproven_idx,
+                                        side_unproven_idx) ||
         DSL_Tensor_TCON_Semantic_Equal(inline_idx, side_unproven_idx)) {
         fprintf(stderr, "dense tensor TCON storage policy changed\n");
         return 1;
@@ -482,6 +524,17 @@ Check_Tensor_TCON_Storage(void)
         memcmp(payload + record.side_path_offset, side_path,
                record.side_path_length) != 0) {
         fprintf(stderr, "side-file tensor path was not carrier-owned\n");
+        return 1;
+    }
+    if (!DSL_Tensor_TCON_Get_Side_Path(side_distinct_idx, &side_bytes,
+                                       &side_length) ||
+        side_length != strlen(side_path) ||
+        memcmp(side_bytes, side_path, side_length) != 0 ||
+        !DSL_Tensor_TCON_Get_Dense_Bytes(side_distinct_idx, &dense_bytes,
+                                         &dense_length) ||
+        dense_length != 16 ||
+        memcmp(dense_bytes, inline_bytes, 16) != 0) {
+        fprintf(stderr, "tensor TCON bounded byte access changed\n");
         return 1;
     }
 
@@ -523,10 +576,22 @@ Check_Tensor_TCON_Storage(void)
         return 1;
     }
 
-    TCON_clear(carrier);
-    Set_TCON_string_payload(carrier, MTYPE_STR,
-                            Save_StrN("__WHIRL_DSL_TCON__:v1:not-id", 30),
-                            30);
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = Test_Tensor_Type(201);
+    info.scalar_tcon = wrong_scalar;
+    info.element_mtype = MTYPE_I4;
+    info.element_size = 4;
+    info.scalar_integer_value = 0;
+    info.element_count = 1;
+    info.logical_bytes = 4;
+    info.required_alignment = 4;
+    if (DSL_Tensor_TCON_Create_Zero(&info, NULL, NULL)) {
+        fprintf(stderr, "wrong-type scalar tensor TCON accepted\n");
+        return 1;
+    }
+
+    carrier = Host_To_Targ_String(MTYPE_STRING,
+                                  "__WHIRL_DSL_TCON__:v1:not-id", 30);
     if (DSL_Tensor_TCON_Decode_Carrier(&carrier, NULL)) {
         fprintf(stderr, "invalid tensor TCON carrier accepted\n");
         return 1;
@@ -535,7 +600,15 @@ Check_Tensor_TCON_Storage(void)
     DSL_Tensor_TCON_Reset();
     if (!DSL_Tensor_TCON_Get(inline_idx, &record) ||
         record.storage_kind != DSL_TENSOR_TCON_STORAGE_INLINE_DENSE ||
-        DSL_Tensor_TCON_Decode_Carrier(&carrier, NULL)) {
+        DSL_Tensor_TCON_Decode_Carrier(&carrier, NULL) ||
+        DSL_Tensor_TCON_Get(TCON_Table_Size(), &record) ||
+        DSL_Tensor_TCON_Semantic_Hash(TCON_Table_Size()) != 0 ||
+        DSL_Tensor_TCON_Semantic_Equal(TCON_Table_Size(),
+                                       TCON_Table_Size()) ||
+        DSL_Tensor_TCON_Get_Dense_Bytes(TCON_Table_Size(), &dense_bytes,
+                                        &dense_length) ||
+        DSL_Tensor_TCON_Get_Side_Path(TCON_Table_Size(), &side_bytes,
+                                      &side_length)) {
         fprintf(stderr, "tensor TCON reset behavior changed\n");
         return 1;
     }

--- a/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
@@ -265,21 +265,24 @@ Check_Tensor_TCON_Storage(void)
 {
     DSL_TENSOR_TCON_CREATE_INFO info;
     DSL_TENSOR_TCON_RECORD record;
-    DSL_TENSOR_TCON_ID zero_id;
-    DSL_TENSOR_TCON_ID one_id;
-    DSL_TENSOR_TCON_ID splat_id;
-    DSL_TENSOR_TCON_ID inline_id;
-    DSL_TENSOR_TCON_ID side_id;
-    DSL_TENSOR_TCON_ID duplicate_id;
-    DSL_TENSOR_TCON_ID carrier_id;
-    DSL_TENSOR_TCON_ID collision_id;
-    DSL_TENSOR_TCON_ID side_unproven_id;
+    DSL_TENSOR_TCON_RECORD decoded;
+    TCON_IDX zero_idx;
+    TCON_IDX one_idx;
+    TCON_IDX splat_idx;
+    TCON_IDX inline_idx;
+    TCON_IDX side_idx;
+    TCON_IDX duplicate_idx;
+    TCON_IDX collision_idx;
+    TCON_IDX side_unproven_idx;
+    TCON_IDX side_distinct_idx;
     TCON carrier;
+    TCON side_carrier;
     TCON scalar;
     TCON_IDX element_tcon;
     UINT64 inline_hash;
     UINT64 side_hash;
-    STR_IDX side_file;
+    char *payload;
+    const char side_path[] = "weights/tensor.bin";
     const unsigned char inline_bytes[16] = {
         'a', 0, 'b', 3, 4, 5, 6, 7,
         8, 9, 10, 11, 12, 13, 14, 15
@@ -292,15 +295,16 @@ Check_Tensor_TCON_Storage(void)
     Initialize_Strtab(1024);
     DSL_Tensor_TCON_Reset();
 
-    if (sizeof(DSL_TENSOR_TCON_RECORD) != DSL_TENSOR_TCON_RECORD_SIZE) {
-        fprintf(stderr, "tensor TCON fixed-row size changed\n");
+    if (sizeof(DSL_TENSOR_TCON_RECORD) !=
+        DSL_TENSOR_TCON_ENVELOPE_SIZE) {
+        fprintf(stderr, "tensor TCON envelope size changed\n");
         return 1;
     }
 
     TCON_clear(scalar);
     Set_TCON_ty(scalar, MTYPE_I4);
     if (sizeof(scalar) != sizeof(TCON) ||
-        DSL_Tensor_TCON_Is_Carrier(&scalar, NULL) ||
+        DSL_Tensor_TCON_Decode_Carrier(&scalar, NULL) ||
         TCON_ty(scalar) != MTYPE_I4) {
         fprintf(stderr, "scalar TCON compatibility changed\n");
         return 1;
@@ -316,11 +320,14 @@ Check_Tensor_TCON_Storage(void)
     info.logical_bytes = 32;
     info.required_alignment = 4;
 
-    if (!DSL_Tensor_TCON_Create_Zero(&info, &zero_id, &carrier) ||
-        zero_id == DSL_TENSOR_TCON_INVALID_ID ||
-        !DSL_Tensor_TCON_Is_Carrier(&carrier, &carrier_id) ||
-        carrier_id != zero_id ||
-        !DSL_Tensor_TCON_Get(zero_id, &record) ||
+    if (!DSL_Tensor_TCON_Create_Zero(&info, &zero_idx, &carrier) ||
+        zero_idx == TCON_IDX_ZERO ||
+        !DSL_Tensor_TCON_Decode_Carrier(&carrier, &decoded) ||
+        !DSL_Tensor_TCON_Get(zero_idx, &record) ||
+        memcmp(&decoded, &record, sizeof(record)) != 0 ||
+        record.magic != DSL_TENSOR_TCON_MAGIC ||
+        record.version != DSL_TENSOR_TCON_VERSION ||
+        record.header_size != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
         record.storage_kind != DSL_TENSOR_TCON_STORAGE_ZERO ||
         record.descriptor_ty != info.descriptor_ty ||
         record.scalar_tcon != info.scalar_tcon ||
@@ -328,42 +335,47 @@ Check_Tensor_TCON_Storage(void)
         record.element_size != info.element_size ||
         record.element_count != info.element_count ||
         record.logical_bytes != info.logical_bytes ||
-        record.required_alignment != info.required_alignment ||
-        record.carrier_token == 0) {
+        record.required_alignment != info.required_alignment) {
         fprintf(stderr, "zero tensor TCON record contract changed\n");
         return 1;
     }
 
-    if (!DSL_Tensor_TCON_Get_Element_TCON(zero_id, 7, &element_tcon) ||
+    DSL_Tensor_TCON_Reset();
+    if (!DSL_Tensor_TCON_Get(zero_idx, &record) ||
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_ZERO) {
+        fprintf(stderr, "tensor TCON reopen lookup requires runtime state\n");
+        return 1;
+    }
+
+    if (!DSL_Tensor_TCON_Get_Element_TCON(zero_idx, 7, &element_tcon) ||
         element_tcon != info.scalar_tcon ||
-        DSL_Tensor_TCON_Get_Element_TCON(zero_id, 8, &element_tcon)) {
+        DSL_Tensor_TCON_Get_Element_TCON(zero_idx, 8, &element_tcon)) {
         fprintf(stderr, "compact tensor TCON element access changed\n");
         return 1;
     }
 
-    if (!DSL_Tensor_TCON_Create_Zero(&info, &duplicate_id, NULL) ||
-        duplicate_id != zero_id ||
-        DSL_Tensor_TCON_Count() != 1) {
+    if (!DSL_Tensor_TCON_Create_Zero(&info, &duplicate_idx, NULL) ||
+        duplicate_idx == TCON_IDX_ZERO) {
         fprintf(stderr, "zero tensor TCON deduplication changed\n");
         return 1;
     }
 
     info.scalar_tcon = 12;
     info.scalar_integer_value = 1;
-    if (!DSL_Tensor_TCON_Create_One(&info, &one_id, NULL) ||
-        !DSL_Tensor_TCON_Get(one_id, &record) ||
+    if (!DSL_Tensor_TCON_Create_One(&info, &one_idx, NULL) ||
+        !DSL_Tensor_TCON_Get(one_idx, &record) ||
         record.storage_kind != DSL_TENSOR_TCON_STORAGE_ONE ||
-        DSL_Tensor_TCON_Semantic_Hash(one_id) == 0) {
+        DSL_Tensor_TCON_Semantic_Hash(one_idx) == 0) {
         fprintf(stderr, "one tensor TCON record contract changed\n");
         return 1;
     }
 
     info.scalar_tcon = 13;
     info.scalar_integer_value = 42;
-    if (!DSL_Tensor_TCON_Create_Splat(&info, &splat_id, NULL) ||
-        !DSL_Tensor_TCON_Get(splat_id, &record) ||
+    if (!DSL_Tensor_TCON_Create_Splat(&info, &splat_idx, NULL) ||
+        !DSL_Tensor_TCON_Get(splat_idx, &record) ||
         record.storage_kind != DSL_TENSOR_TCON_STORAGE_SPLAT ||
-        !DSL_Tensor_TCON_Get_Element_TCON(splat_id, 3,
+        !DSL_Tensor_TCON_Get_Element_TCON(splat_idx, 3,
                                           &element_tcon) ||
         element_tcon != 13) {
         fprintf(stderr, "splat tensor TCON record contract changed\n");
@@ -381,36 +393,37 @@ Check_Tensor_TCON_Storage(void)
     info.dense_bytes_length = 16;
     info.checksum_hi = 0x1234;
     info.checksum_lo = 0x5678;
-    if (!DSL_Tensor_TCON_Create_Inline_Dense(&info, &inline_id, NULL) ||
-        !DSL_Tensor_TCON_Get(inline_id, &record) ||
+    if (!DSL_Tensor_TCON_Create_Inline_Dense(&info, &inline_idx, &carrier) ||
+        !DSL_Tensor_TCON_Get(inline_idx, &record) ||
         record.storage_kind != DSL_TENSOR_TCON_STORAGE_INLINE_DENSE ||
-        record.dense_payload_ref == 0 ||
-        record.dense_payload_bytes != 16 ||
-        memcmp(Index_to_char_array(record.dense_payload_ref),
-               inline_bytes, 16) != 0 ||
-        DSL_Tensor_TCON_Get_Element_TCON(inline_id, 0,
+        record.dense_offset != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        record.dense_length != 16 ||
+        TCON_str_len(carrier) !=
+            DSL_TENSOR_TCON_ENVELOPE_SIZE + 16 ||
+        memcmp(Index_to_char_array(TCON_str_idx(carrier)) +
+               record.dense_offset, inline_bytes, 16) != 0 ||
+        DSL_Tensor_TCON_Get_Element_TCON(inline_idx, 0,
                                          &element_tcon)) {
         fprintf(stderr, "inline dense tensor TCON contract changed\n");
         return 1;
     }
-    inline_hash = DSL_Tensor_TCON_Semantic_Hash(inline_id);
+    inline_hash = DSL_Tensor_TCON_Semantic_Hash(inline_idx);
 
-    if (!DSL_Tensor_TCON_Create_Inline_Dense(&info, &duplicate_id, NULL) ||
-        duplicate_id != inline_id) {
+    if (!DSL_Tensor_TCON_Create_Inline_Dense(&info, &duplicate_idx, NULL) ||
+        duplicate_idx != inline_idx) {
         fprintf(stderr, "inline dense tensor TCON deduplication changed\n");
         return 1;
     }
 
     info.dense_bytes = collision_bytes;
     info.dense_bytes_length = 16;
-    if (!DSL_Tensor_TCON_Create_Inline_Dense(&info, &collision_id, NULL) ||
-        collision_id == inline_id ||
-        DSL_Tensor_TCON_Semantic_Equal(inline_id, collision_id)) {
+    if (!DSL_Tensor_TCON_Create_Inline_Dense(&info, &collision_idx, NULL) ||
+        collision_idx == inline_idx ||
+        DSL_Tensor_TCON_Semantic_Equal(inline_idx, collision_idx)) {
         fprintf(stderr, "dense tensor TCON checksum collision accepted\n");
         return 1;
     }
 
-    side_file = Save_Str("weights/tensor.bin");
     memset(&info, 0, sizeof(info));
     info.descriptor_ty = Test_Tensor_Type(201);
     info.element_mtype = MTYPE_U1;
@@ -420,18 +433,20 @@ Check_Tensor_TCON_Storage(void)
     info.required_alignment = 16;
     info.dense_bytes = inline_bytes;
     info.dense_bytes_length = 16;
-    info.side_file = side_file;
+    info.side_path = side_path;
+    info.side_path_length = strlen(side_path);
     info.byte_offset = 64;
     info.byte_length = 16;
     info.checksum_hi = 0x1234;
     info.checksum_lo = 0x5678;
-    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &side_id, NULL) ||
-        side_id != inline_id ||
-        !DSL_Tensor_TCON_Semantic_Equal(inline_id, side_id)) {
+    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &side_idx,
+                                                &side_carrier) ||
+        side_idx != inline_idx ||
+        !DSL_Tensor_TCON_Semantic_Equal(inline_idx, side_idx)) {
         fprintf(stderr, "dense tensor TCON semantic identity changed\n");
         return 1;
     }
-    side_hash = DSL_Tensor_TCON_Semantic_Hash(side_id);
+    side_hash = DSL_Tensor_TCON_Semantic_Hash(side_idx);
     if (side_hash != inline_hash) {
         fprintf(stderr, "dense tensor TCON semantic hash changed\n");
         return 1;
@@ -439,10 +454,10 @@ Check_Tensor_TCON_Storage(void)
 
     info.dense_bytes = NULL;
     info.dense_bytes_length = 0;
-    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &side_unproven_id,
+    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &side_unproven_idx,
                                                 NULL) ||
-        side_unproven_id == inline_id ||
-        DSL_Tensor_TCON_Semantic_Equal(inline_id, side_unproven_id)) {
+        side_unproven_idx == inline_idx ||
+        DSL_Tensor_TCON_Semantic_Equal(inline_idx, side_unproven_idx)) {
         fprintf(stderr, "dense tensor TCON storage policy changed\n");
         return 1;
     }
@@ -450,14 +465,34 @@ Check_Tensor_TCON_Storage(void)
     info.dense_bytes = inline_bytes;
     info.dense_bytes_length = 16;
     info.checksum_lo = 0x5679;
-    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &side_id, NULL) ||
-        side_id == inline_id ||
-        !DSL_Tensor_TCON_Get(side_id, &record) ||
+    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &side_distinct_idx,
+                                                &side_carrier) ||
+        side_distinct_idx == inline_idx ||
+        !DSL_Tensor_TCON_Get(side_distinct_idx, &record) ||
         record.storage_kind != DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE ||
-        record.side_file != side_file ||
+        record.side_path_offset != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        record.side_path_length != strlen(side_path) ||
         record.byte_offset != 64 ||
         record.byte_length != 16) {
         fprintf(stderr, "side-file dense tensor TCON contract changed\n");
+        return 1;
+    }
+    payload = Index_to_char_array(TCON_str_idx(side_carrier));
+    if (payload == NULL ||
+        memcmp(payload + record.side_path_offset, side_path,
+               record.side_path_length) != 0) {
+        fprintf(stderr, "side-file tensor path was not carrier-owned\n");
+        return 1;
+    }
+
+    DSL_Tensor_TCON_Reset();
+    DSL_Tensor_TCON_Rebuild_Derived_Cache(inline_idx,
+                                          side_distinct_idx + 1);
+    info.checksum_lo = 0x5678;
+    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &duplicate_idx,
+                                                NULL) ||
+        duplicate_idx != inline_idx) {
+        fprintf(stderr, "tensor TCON derived cache rebuild changed\n");
         return 1;
     }
 
@@ -467,12 +502,14 @@ Check_Tensor_TCON_Storage(void)
         return 1;
     }
     info.required_alignment = 16;
-    info.side_file = Save_Str("../bad.bin");
+    info.side_path = "../bad.bin";
+    info.side_path_length = strlen(info.side_path);
     if (DSL_Tensor_TCON_Create_Side_File_Dense(&info, NULL, NULL)) {
         fprintf(stderr, "invalid tensor TCON side path accepted\n");
         return 1;
     }
-    info.side_file = side_file;
+    info.side_path = side_path;
+    info.side_path_length = strlen(side_path);
     info.byte_offset = 8;
     info.byte_length = 16;
     if (DSL_Tensor_TCON_Create_Side_File_Dense(&info, NULL, NULL)) {
@@ -488,18 +525,17 @@ Check_Tensor_TCON_Storage(void)
 
     TCON_clear(carrier);
     Set_TCON_string_payload(carrier, MTYPE_STR,
-                            Save_StrN("__WHIRL_DSL_TCON__:v1:not-id",
-                                      30),
+                            Save_StrN("__WHIRL_DSL_TCON__:v1:not-id", 30),
                             30);
-    Set_TCON_dsl_tensor_carrier(carrier);
-    if (DSL_Tensor_TCON_Is_Carrier(&carrier, NULL)) {
+    if (DSL_Tensor_TCON_Decode_Carrier(&carrier, NULL)) {
         fprintf(stderr, "invalid tensor TCON carrier accepted\n");
         return 1;
     }
 
     DSL_Tensor_TCON_Reset();
-    if (DSL_Tensor_TCON_Count() != 0 ||
-        DSL_Tensor_TCON_Is_Carrier(&carrier, NULL)) {
+    if (!DSL_Tensor_TCON_Get(inline_idx, &record) ||
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_INLINE_DENSE ||
+        DSL_Tensor_TCON_Decode_Carrier(&carrier, NULL)) {
         fprintf(stderr, "tensor TCON reset behavior changed\n");
         return 1;
     }

--- a/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
@@ -355,7 +355,7 @@ Check_Tensor_TCON_Storage(void)
         record.magic != DSL_TENSOR_TCON_MAGIC ||
         record.version != DSL_TENSOR_TCON_VERSION ||
         record.header_size != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
-        record.record_size != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
+        record.record_size != DSL_TENSOR_TCON_ENVELOPE_SIZE + 1 ||
         record.storage_kind != DSL_TENSOR_TCON_STORAGE_ZERO ||
         record.descriptor_ty != info.descriptor_ty ||
         record.scalar_tcon != info.scalar_tcon ||
@@ -427,7 +427,10 @@ Check_Tensor_TCON_Storage(void)
         record.dense_offset != DSL_TENSOR_TCON_ENVELOPE_SIZE ||
         record.dense_length != 16 ||
         TCON_str_len(carrier) !=
-            DSL_TENSOR_TCON_ENVELOPE_SIZE + 16 ||
+            DSL_TENSOR_TCON_ENVELOPE_SIZE + 17 ||
+        Index_to_length(TCON_str_idx(carrier)) != TCON_str_len(carrier) ||
+        Index_to_char_array(TCON_str_idx(carrier))
+            [TCON_str_len(carrier) - 1] != '\0' ||
         !DSL_Tensor_TCON_Get_Dense_Bytes(inline_idx, &dense_bytes,
                                          &dense_length) ||
         dense_length != 16 ||
@@ -439,7 +442,7 @@ Check_Tensor_TCON_Storage(void)
     }
     inline_hash = DSL_Tensor_TCON_Semantic_Hash(inline_idx);
     memcpy(malformed_payload, Index_to_char_array(TCON_str_idx(carrier)),
-           DSL_TENSOR_TCON_ENVELOPE_SIZE + 16);
+           DSL_TENSOR_TCON_ENVELOPE_SIZE + 17);
     malformed_payload[DSL_TENSOR_TCON_ENVELOPE_SIZE + 16] = '\7';
     malformed_carrier =
         Host_To_Targ_String(MTYPE_STRING, malformed_payload,

--- a/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "dsl_tensor_fold.h"
+#include "strtab.h"
 
 static int
 Check_Status_Names(void)
@@ -251,6 +252,261 @@ Check_Mock_Evaluator(void)
     return 0;
 }
 
+static TY_IDX
+Test_Tensor_Type(UINT32 index)
+{
+    TY_IDX ty = TY_IDX_ZERO;
+    Set_TY_IDX_index(ty, index);
+    return ty;
+}
+
+static int
+Check_Tensor_TCON_Storage(void)
+{
+    DSL_TENSOR_TCON_CREATE_INFO info;
+    DSL_TENSOR_TCON_RECORD record;
+    DSL_TENSOR_TCON_ID zero_id;
+    DSL_TENSOR_TCON_ID one_id;
+    DSL_TENSOR_TCON_ID splat_id;
+    DSL_TENSOR_TCON_ID inline_id;
+    DSL_TENSOR_TCON_ID side_id;
+    DSL_TENSOR_TCON_ID duplicate_id;
+    DSL_TENSOR_TCON_ID carrier_id;
+    DSL_TENSOR_TCON_ID collision_id;
+    DSL_TENSOR_TCON_ID side_unproven_id;
+    TCON carrier;
+    TCON scalar;
+    TCON_IDX element_tcon;
+    UINT64 inline_hash;
+    UINT64 side_hash;
+    STR_IDX side_file;
+    const unsigned char inline_bytes[16] = {
+        'a', 0, 'b', 3, 4, 5, 6, 7,
+        8, 9, 10, 11, 12, 13, 14, 15
+    };
+    const unsigned char collision_bytes[16] = {
+        'a', 0, 'b', 3, 4, 5, 6, 7,
+        8, 9, 10, 11, 12, 13, 14, 16
+    };
+
+    Initialize_Strtab(1024);
+    DSL_Tensor_TCON_Reset();
+
+    if (sizeof(DSL_TENSOR_TCON_RECORD) != DSL_TENSOR_TCON_RECORD_SIZE) {
+        fprintf(stderr, "tensor TCON fixed-row size changed\n");
+        return 1;
+    }
+
+    TCON_clear(scalar);
+    Set_TCON_ty(scalar, MTYPE_I4);
+    if (sizeof(scalar) != sizeof(TCON) ||
+        DSL_Tensor_TCON_Is_Carrier(&scalar, NULL) ||
+        TCON_ty(scalar) != MTYPE_I4) {
+        fprintf(stderr, "scalar TCON compatibility changed\n");
+        return 1;
+    }
+
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = Test_Tensor_Type(101);
+    info.scalar_tcon = 11;
+    info.element_mtype = MTYPE_I4;
+    info.element_size = 4;
+    info.scalar_integer_value = 0;
+    info.element_count = 8;
+    info.logical_bytes = 32;
+    info.required_alignment = 4;
+
+    if (!DSL_Tensor_TCON_Create_Zero(&info, &zero_id, &carrier) ||
+        zero_id == DSL_TENSOR_TCON_INVALID_ID ||
+        !DSL_Tensor_TCON_Is_Carrier(&carrier, &carrier_id) ||
+        carrier_id != zero_id ||
+        !DSL_Tensor_TCON_Get(zero_id, &record) ||
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_ZERO ||
+        record.descriptor_ty != info.descriptor_ty ||
+        record.scalar_tcon != info.scalar_tcon ||
+        record.element_mtype != info.element_mtype ||
+        record.element_size != info.element_size ||
+        record.element_count != info.element_count ||
+        record.logical_bytes != info.logical_bytes ||
+        record.required_alignment != info.required_alignment ||
+        record.carrier_token == 0) {
+        fprintf(stderr, "zero tensor TCON record contract changed\n");
+        return 1;
+    }
+
+    if (!DSL_Tensor_TCON_Get_Element_TCON(zero_id, 7, &element_tcon) ||
+        element_tcon != info.scalar_tcon ||
+        DSL_Tensor_TCON_Get_Element_TCON(zero_id, 8, &element_tcon)) {
+        fprintf(stderr, "compact tensor TCON element access changed\n");
+        return 1;
+    }
+
+    if (!DSL_Tensor_TCON_Create_Zero(&info, &duplicate_id, NULL) ||
+        duplicate_id != zero_id ||
+        DSL_Tensor_TCON_Count() != 1) {
+        fprintf(stderr, "zero tensor TCON deduplication changed\n");
+        return 1;
+    }
+
+    info.scalar_tcon = 12;
+    info.scalar_integer_value = 1;
+    if (!DSL_Tensor_TCON_Create_One(&info, &one_id, NULL) ||
+        !DSL_Tensor_TCON_Get(one_id, &record) ||
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_ONE ||
+        DSL_Tensor_TCON_Semantic_Hash(one_id) == 0) {
+        fprintf(stderr, "one tensor TCON record contract changed\n");
+        return 1;
+    }
+
+    info.scalar_tcon = 13;
+    info.scalar_integer_value = 42;
+    if (!DSL_Tensor_TCON_Create_Splat(&info, &splat_id, NULL) ||
+        !DSL_Tensor_TCON_Get(splat_id, &record) ||
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_SPLAT ||
+        !DSL_Tensor_TCON_Get_Element_TCON(splat_id, 3,
+                                          &element_tcon) ||
+        element_tcon != 13) {
+        fprintf(stderr, "splat tensor TCON record contract changed\n");
+        return 1;
+    }
+
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = Test_Tensor_Type(201);
+    info.element_mtype = MTYPE_U1;
+    info.element_size = 4;
+    info.element_count = 4;
+    info.logical_bytes = 16;
+    info.required_alignment = 16;
+    info.dense_bytes = inline_bytes;
+    info.dense_bytes_length = 16;
+    info.checksum_hi = 0x1234;
+    info.checksum_lo = 0x5678;
+    if (!DSL_Tensor_TCON_Create_Inline_Dense(&info, &inline_id, NULL) ||
+        !DSL_Tensor_TCON_Get(inline_id, &record) ||
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_INLINE_DENSE ||
+        record.dense_payload_ref == 0 ||
+        record.dense_payload_bytes != 16 ||
+        memcmp(Index_to_char_array(record.dense_payload_ref),
+               inline_bytes, 16) != 0 ||
+        DSL_Tensor_TCON_Get_Element_TCON(inline_id, 0,
+                                         &element_tcon)) {
+        fprintf(stderr, "inline dense tensor TCON contract changed\n");
+        return 1;
+    }
+    inline_hash = DSL_Tensor_TCON_Semantic_Hash(inline_id);
+
+    if (!DSL_Tensor_TCON_Create_Inline_Dense(&info, &duplicate_id, NULL) ||
+        duplicate_id != inline_id) {
+        fprintf(stderr, "inline dense tensor TCON deduplication changed\n");
+        return 1;
+    }
+
+    info.dense_bytes = collision_bytes;
+    info.dense_bytes_length = 16;
+    if (!DSL_Tensor_TCON_Create_Inline_Dense(&info, &collision_id, NULL) ||
+        collision_id == inline_id ||
+        DSL_Tensor_TCON_Semantic_Equal(inline_id, collision_id)) {
+        fprintf(stderr, "dense tensor TCON checksum collision accepted\n");
+        return 1;
+    }
+
+    side_file = Save_Str("weights/tensor.bin");
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = Test_Tensor_Type(201);
+    info.element_mtype = MTYPE_U1;
+    info.element_size = 4;
+    info.element_count = 4;
+    info.logical_bytes = 16;
+    info.required_alignment = 16;
+    info.dense_bytes = inline_bytes;
+    info.dense_bytes_length = 16;
+    info.side_file = side_file;
+    info.byte_offset = 64;
+    info.byte_length = 16;
+    info.checksum_hi = 0x1234;
+    info.checksum_lo = 0x5678;
+    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &side_id, NULL) ||
+        side_id != inline_id ||
+        !DSL_Tensor_TCON_Semantic_Equal(inline_id, side_id)) {
+        fprintf(stderr, "dense tensor TCON semantic identity changed\n");
+        return 1;
+    }
+    side_hash = DSL_Tensor_TCON_Semantic_Hash(side_id);
+    if (side_hash != inline_hash) {
+        fprintf(stderr, "dense tensor TCON semantic hash changed\n");
+        return 1;
+    }
+
+    info.dense_bytes = NULL;
+    info.dense_bytes_length = 0;
+    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &side_unproven_id,
+                                                NULL) ||
+        side_unproven_id == inline_id ||
+        DSL_Tensor_TCON_Semantic_Equal(inline_id, side_unproven_id)) {
+        fprintf(stderr, "dense tensor TCON storage policy changed\n");
+        return 1;
+    }
+
+    info.dense_bytes = inline_bytes;
+    info.dense_bytes_length = 16;
+    info.checksum_lo = 0x5679;
+    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &side_id, NULL) ||
+        side_id == inline_id ||
+        !DSL_Tensor_TCON_Get(side_id, &record) ||
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE ||
+        record.side_file != side_file ||
+        record.byte_offset != 64 ||
+        record.byte_length != 16) {
+        fprintf(stderr, "side-file dense tensor TCON contract changed\n");
+        return 1;
+    }
+
+    info.required_alignment = 3;
+    if (DSL_Tensor_TCON_Create_Side_File_Dense(&info, NULL, NULL)) {
+        fprintf(stderr, "invalid tensor TCON alignment accepted\n");
+        return 1;
+    }
+    info.required_alignment = 16;
+    info.side_file = Save_Str("../bad.bin");
+    if (DSL_Tensor_TCON_Create_Side_File_Dense(&info, NULL, NULL)) {
+        fprintf(stderr, "invalid tensor TCON side path accepted\n");
+        return 1;
+    }
+    info.side_file = side_file;
+    info.byte_offset = 8;
+    info.byte_length = 16;
+    if (DSL_Tensor_TCON_Create_Side_File_Dense(&info, NULL, NULL)) {
+        fprintf(stderr, "misaligned tensor TCON side offset accepted\n");
+        return 1;
+    }
+    info.byte_offset = 64;
+    info.byte_length = 15;
+    if (DSL_Tensor_TCON_Create_Side_File_Dense(&info, NULL, NULL)) {
+        fprintf(stderr, "invalid tensor TCON side range accepted\n");
+        return 1;
+    }
+
+    TCON_clear(carrier);
+    Set_TCON_string_payload(carrier, MTYPE_STR,
+                            Save_StrN("__WHIRL_DSL_TCON__:v1:not-id",
+                                      30),
+                            30);
+    Set_TCON_dsl_tensor_carrier(carrier);
+    if (DSL_Tensor_TCON_Is_Carrier(&carrier, NULL)) {
+        fprintf(stderr, "invalid tensor TCON carrier accepted\n");
+        return 1;
+    }
+
+    DSL_Tensor_TCON_Reset();
+    if (DSL_Tensor_TCON_Count() != 0 ||
+        DSL_Tensor_TCON_Is_Carrier(&carrier, NULL)) {
+        fprintf(stderr, "tensor TCON reset behavior changed\n");
+        return 1;
+    }
+
+    return 0;
+}
+
 int
 main(void)
 {
@@ -262,9 +518,10 @@ main(void)
     if (Check_Status_Names() ||
         Check_Evaluator_Identity() ||
         Check_Candidate_Contract() ||
-        Check_Mock_Evaluator())
+        Check_Mock_Evaluator() ||
+        Check_Tensor_TCON_Storage())
         return 1;
 
-    printf("DSL tensor fold M1 mock contract passed\n");
+    printf("DSL tensor fold M2 storage contract passed\n");
     return 0;
 }

--- a/osprey/common/com/tests/dsl_tensor_fold_contract_test.sh
+++ b/osprey/common/com/tests/dsl_tensor_fold_contract_test.sh
@@ -8,6 +8,7 @@ cxx="${CXX:-g++}"
 output="${TMPDIR:-/tmp}/dsl_tensor_fold_contract_test"
 
 "$cxx" -std=gnu++98 \
+  -DDSL_TENSOR_FOLD_TEST_STUB \
   -I"$repo_root/osprey/linux/include" \
   -I"$repo_root/osprey/common/com" \
   -I"$repo_root/osprey/common/com/x8664" \

--- a/osprey/common/com/tests/dsl_tensor_fold_contract_test.sh
+++ b/osprey/common/com/tests/dsl_tensor_fold_contract_test.sh
@@ -16,6 +16,7 @@ output="${TMPDIR:-/tmp}/dsl_tensor_fold_contract_test"
   "$repo_root/osprey/common/com/dsl_domain.cxx" \
   "$repo_root/osprey/common/com/dsl_opcode.cxx" \
   "$repo_root/osprey/common/com/dsl_tensor_fold.cxx" \
+  "$repo_root/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx" \
   "$repo_root/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx" \
   -o "$output"
 

--- a/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
@@ -1,0 +1,74 @@
+/*
+ * Test-only string tables for the focused tensor-fold contract fixture.
+ * Keep the global string table and TCON character table separate so carrier
+ * and inline dense bytes exercise Save_StrN/Index_to_char_array semantics.
+ */
+
+#include <string>
+#include <vector>
+
+#include "strtab.h"
+
+static std::vector<std::string> DSL_tensor_fold_test_strtab;
+static std::vector<std::string> DSL_tensor_fold_test_char_table;
+
+void
+Initialize_Strtab (UINT32)
+{
+    DSL_tensor_fold_test_strtab.clear();
+    DSL_tensor_fold_test_strtab.push_back("");
+    DSL_tensor_fold_test_char_table.clear();
+    DSL_tensor_fold_test_char_table.push_back("");
+}
+
+void
+Initialize_Strtab (const char *, UINT32 size)
+{
+    Initialize_Strtab(size);
+}
+
+STR_IDX
+Save_Str (const char *str)
+{
+    if (DSL_tensor_fold_test_strtab.empty())
+        Initialize_Strtab(1024);
+    if (str == NULL)
+        return STR_IDX_ZERO;
+
+    DSL_tensor_fold_test_strtab.push_back(str);
+    return DSL_tensor_fold_test_strtab.size() - 1;
+}
+
+UINT32
+Save_StrN (const char *str, UINT32 size)
+{
+    if (DSL_tensor_fold_test_char_table.empty())
+        Initialize_Strtab(1024);
+    if (str == NULL || size == 0)
+        return STR_IDX_ZERO;
+
+    DSL_tensor_fold_test_char_table.push_back(std::string(str, size));
+    return DSL_tensor_fold_test_char_table.size() - 1;
+}
+
+char *
+Index_To_Str (STR_IDX idx)
+{
+    if (idx >= DSL_tensor_fold_test_strtab.size())
+        return NULL;
+    return const_cast<char *>(DSL_tensor_fold_test_strtab[idx].c_str());
+}
+
+char *
+Index_to_char_array (UINT32 idx)
+{
+    if (idx >= DSL_tensor_fold_test_char_table.size())
+        return NULL;
+    return const_cast<char *>(DSL_tensor_fold_test_char_table[idx].data());
+}
+
+STR_IDX
+STR_Table_Size ()
+{
+    return DSL_tensor_fold_test_strtab.size();
+}

--- a/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
@@ -116,9 +116,18 @@ TCON
 Host_To_Targ_String (TYPE_ID ctype, const char *bytes, UINT32 length)
 {
     TCON result;
+    UINT32 saved_length;
     TCON_clear(result);
     Set_TCON_ty(result, ctype);
-    result.vals.sval.cp = Save_StrN(bytes, length);
+    saved_length = (length == 0 || bytes[length - 1] != '\0') ?
+                       length + 1 : length;
+    if (saved_length != length) {
+        std::string safe(bytes, length);
+        safe.push_back('\0');
+        result.vals.sval.cp = Save_StrN(safe.data(), saved_length);
+    } else {
+        result.vals.sval.cp = Save_StrN(bytes, saved_length);
+    }
     result.vals.sval.len = length;
     return result;
 }

--- a/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
@@ -8,9 +8,11 @@
 #include <vector>
 
 #include "strtab.h"
+#include "targ_const.h"
 
 static std::vector<std::string> DSL_tensor_fold_test_strtab;
 static std::vector<std::string> DSL_tensor_fold_test_char_table;
+static std::vector<TCON> DSL_tensor_fold_test_tcon_table;
 
 void
 Initialize_Strtab (UINT32)
@@ -19,6 +21,10 @@ Initialize_Strtab (UINT32)
     DSL_tensor_fold_test_strtab.push_back("");
     DSL_tensor_fold_test_char_table.clear();
     DSL_tensor_fold_test_char_table.push_back("");
+    DSL_tensor_fold_test_tcon_table.clear();
+    TCON zero;
+    TCON_clear(zero);
+    DSL_tensor_fold_test_tcon_table.push_back(zero);
 }
 
 void
@@ -67,8 +73,34 @@ Index_to_char_array (UINT32 idx)
     return const_cast<char *>(DSL_tensor_fold_test_char_table[idx].data());
 }
 
+UINT32
+Index_to_length (UINT32 idx)
+{
+    if (idx >= DSL_tensor_fold_test_char_table.size())
+        return 0;
+    return DSL_tensor_fold_test_char_table[idx].size();
+}
+
 STR_IDX
 STR_Table_Size ()
 {
     return DSL_tensor_fold_test_strtab.size();
+}
+
+TCON_IDX
+Enter_tcon (const TCON& tcon)
+{
+    DSL_tensor_fold_test_tcon_table.push_back(tcon);
+    return DSL_tensor_fold_test_tcon_table.size() - 1;
+}
+
+TCON
+TCON_from_IDX (TCON_IDX tcon_idx)
+{
+    if (tcon_idx >= DSL_tensor_fold_test_tcon_table.size()) {
+        TCON zero;
+        TCON_clear(zero);
+        return zero;
+    }
+    return DSL_tensor_fold_test_tcon_table[tcon_idx];
 }

--- a/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "strtab.h"
+#include "symtab_idx.h"
 #include "targ_const.h"
 
 static std::vector<std::string> DSL_tensor_fold_test_strtab;
@@ -94,6 +95,12 @@ Enter_tcon (const TCON& tcon)
     return DSL_tensor_fold_test_tcon_table.size() - 1;
 }
 
+UINT32
+TCON_Table_Size (void)
+{
+    return DSL_tensor_fold_test_tcon_table.size();
+}
+
 TCON
 TCON_from_IDX (TCON_IDX tcon_idx)
 {
@@ -103,4 +110,53 @@ TCON_from_IDX (TCON_IDX tcon_idx)
         return zero;
     }
     return DSL_tensor_fold_test_tcon_table[tcon_idx];
+}
+
+TCON
+Host_To_Targ_String (TYPE_ID ctype, const char *bytes, UINT32 length)
+{
+    TCON result;
+    TCON_clear(result);
+    Set_TCON_ty(result, ctype);
+    result.vals.sval.cp = Save_StrN(bytes, length);
+    result.vals.sval.len = length;
+    return result;
+}
+
+UINT32
+TY_Table_Size (void)
+{
+    return 512;
+}
+
+BOOL
+TY_is_tensor_extension (TY_IDX ty)
+{
+    return TY_IDX_index(ty) == 101 || TY_IDX_index(ty) == 201;
+}
+
+BOOL
+TY_tensor_is_canonical (TY_IDX ty)
+{
+    return TY_is_tensor_extension(ty);
+}
+
+TY_IDX
+TY_tensor_element_ty (TY_IDX)
+{
+    TY_IDX ty = TY_IDX_ZERO;
+    Set_TY_IDX_index(ty, 301);
+    return ty;
+}
+
+TYPE_ID
+TY_mtype (TY_IDX ty)
+{
+    return TY_IDX_index(ty) == 301 ? MTYPE_I4 : MTYPE_UNKNOWN;
+}
+
+UINT64
+TY_size (TY_IDX ty)
+{
+    return TY_IDX_index(ty) == 301 ? 4 : 0;
 }


### PR DESCRIPTION
## Summary

- Add a fixed-size, pointer-free tensor constant envelope carried by a legal `MTYPE_STRING` TCON character payload.
- Use `TCON_IDX` as the stable identity for ZERO, ONE, SPLAT, inline dense, and side-file dense tensor constants.
- Keep runtime lookup/dedup state derived and rebuildable; carrier queries continue to work after cache reset and mapped-image reopen.
- Validate canonical tensor TYs, scalar TCONs, storage-kind fields, bounds, checksums, paths, exact payload length, and the canonical terminal NUL.
- Expose bounded side-path and dense-byte accessors for future printer, simplifier, and WOPT integration.

## Compatibility

- Reuses the existing TCON table and TCON character table as the mapped-image owner.
- Adds no ELF section and does not change `.WHIRL.dsl` version 1.
- Ordinary scalar and string TCON behavior remains unchanged.
- Side-file paths are relative sized bytes; no host pointers or absolute paths enter the carrier.

## Validation

- Local focused tensor-fold contract passed.
- Docker focused tensor-fold contract passed.
- Docker native syntax fixture passed.
- Cache reset/rebuild and reopen-style lookup coverage passed.
- Embedded-NUL dense data, malformed bounds/trailing bytes, invalid IDs, checksum collision, and side-file-only equality cases are covered.
- `git diff --check` and the added-line no-tab scan passed.

This is the tensor-constant-storage half of synchronized M2. The follow-up main integration will add mapped-read cache rebuild, logical symbol/TCON printing, and full `.B`/`ir_b2a -st -src` evidence after this lands.