### PR TITLE
Complete M2 tensor TCON mapped-image integration

### DIFF
--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -1108,7 +1108,7 @@ capability per pull request. Do not use M7 as a miscellaneous cleanup batch.
 | --- | --- | --- | --- |
 | M0 | Merged through PR #89/#92 | None | Contract/API test report |
 | M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
-| M2 | Active on coordinated main/Lagrange branches | M1 merged | Tensor TCON `.B` and `.T` |
+| M2 | Storage merged through PR #94; main integration under review | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Blocked by M2 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |
 | M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |
@@ -1167,6 +1167,15 @@ The remaining M1 foundation is implemented:
 The scalar operand projection remains test-only in M1. Production tensor
 projection and builder publication remain disabled until M2 establishes
 tensor TCON storage and M3 integrates the first real folding path.
+
+The M2 tensor TCON storage implementation merged through PR #94. The
+coordinated main integration rebuilds the derived tensor TCON cache after the
+standard global TCON tables are mapped, links the tensor TCON service into
+Open64 phases that use the shared symbol-table implementation, and makes
+symbol-table and global-TCON dumps print the logical tensor constant instead
+of its private string-TCON carrier. The retained M2 fixture reopens
+`tensor_tcon.B` through `ir_b2a -st -src` and records compact ZERO and
+SIDE_FILE_DENSE constants in `tensor_tcon.T`.
 
 ## Staged Action List
 

--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -991,6 +991,13 @@ parts of 13 through 15: tensor TCON escape records, ZERO/ONE/SPLAT,
 INLINE_DENSE, SIDE_FILE_DENSE, target-format element access, identity,
 printing, verification, and mapped-image reopen.
 
+The M2 persistent representation uses a legal string TCON whose sized
+character-array payload carries the fixed-layout tensor envelope and optional
+inline bytes. `TCON_IDX` is the stable tensor-constant identity. The existing
+TCON table and TCON character-array table own the mapped image; runtime lookup
+or deduplication indexes are derived and rebuildable. Do not append tensor
+rows to or bump the strict version-1 `.WHIRL.dsl` image for this milestone.
+
 **Exit criteria:** tensor constants can be created, deduplicated, printed,
 written, reopened, and verified without invoking the simplifier. Existing
 `sizeof(TCON)`, scalar TCON behavior, and old-reader compatibility remain
@@ -1100,8 +1107,8 @@ capability per pull request. Do not use M7 as a miscellaneous cleanup batch.
 | Milestone | Status | Merge dependency | Review artifact |
 | --- | --- | --- | --- |
 | M0 | Merged through PR #89/#92 | None | Contract/API test report |
-| M1 | Implementation complete; PR pending | M0 merged | Simplifier bridge traces |
-| M2 | Blocked by M1 | M1 merged | Tensor TCON `.B` and `.T` |
+| M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
+| M2 | Active on coordinated main/Lagrange branches | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Blocked by M2 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |
 | M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |

--- a/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
+++ b/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
@@ -554,11 +554,19 @@ The clean pull-request rule is:
 6. Each pull request must retain the milestone-specific `.B`, side payload,
    and `ir_b2a -st -src` artifacts identified by the authoritative plan.
 
+PR #94 completed the M2 storage side. The coordinated main integration calls
+`DSL_Tensor_TCON_Rebuild_Derived_Cache()` after the existing global TCON and
+TCON character-array tables are mapped, prints logical tensor constants from
+both symbol and global TCON dumps, and hides the private `MTYPE_STRING`
+carrier. Its retained `tensor_tcon.B` and `tensor_tcon.T` fixture covers a
+compact ZERO and an aligned SIDE_FILE_DENSE reference with filename, byte
+range, and checksum.
+
 | Milestone | Status | Merge dependency | Review artifact |
 | --- | --- | --- | --- |
 | M0 | Merged through PR #89/#92 | None | Contract/API test report |
 | M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
-| M2 | Active on coordinated main/Lagrange branches | M1 merged | Tensor TCON `.B` and `.T` |
+| M2 | Storage merged through PR #94; main integration under review | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Blocked by M2 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |
 | M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |

--- a/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
+++ b/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
@@ -44,46 +44,50 @@ that would require a separately reviewed, versioned WHIRL change.
 ## Tensor TCON Escape Representation
 
 The first compatible physical representation uses an existing legal string
-TCON as the private escape carrier:
+TCON as the private escape carrier. Its sized character-array payload begins
+with a fixed-layout tensor envelope:
 
 ```text
-TCON.ty       = MTYPE_STR
-TCON.flags   |= TCON_DSL_TENSOR
-TCON.sval.cp  = STR_IDX of a valid escape token
-TCON.sval.len = escape-token byte length
-
-escape token:
-  __WHIRL_DSL_TCON__:v1:<tensor_tcon_id>
-```
-
-The token must be a valid TCON string so an older reader or diagnostic printer
-can inspect it without dereferencing an invalid string-table index. DSL-aware
-compiler code must use `TCON_is_tensor()` and tensor TCON accessors; it must
-not test `MTYPE_STR`, parse the token, or inspect the private value fields.
-Logical dumps print the tensor constant, never the string escape.
-
-`TENSOR_TCON_ID` indexes a fixed-row tensor constant table carried through the
-existing optional DSL mapped-image section. A normative record needs at least:
-
-```text
-id
-carrier TCON_IDX
-TY_IDX
-TensorDescriptorIR ID
+magic
+version
+envelope size
 storage kind
+flags and reserved fields
+canonical TensorDescriptorIR TY_IDX
 element count
 logical byte count
 required alignment
-payload STR_IDX or external-reference ID
-splat element TCON_IDX
-content checksum STR_IDX
-flags and reserved fields
+compact scalar TCON_IDX, when applicable
+side-file or inline payload offsets and lengths
+content checksum
 ```
 
-The fixed row contains only sized scalars, table IDs, `TY_IDX`, `TCON_IDX`, and
-`STR_IDX`. It contains no pointers or STL containers. The carrier TCON and
-tensor constant row must reference each other consistently, and the
-gatekeeper must reject missing, duplicate, or mismatched relationships.
+The existing TCON table owns the carrier and its `TCON_IDX` is the stable
+tensor-constant identity. The existing TCON character-array table owns the
+sized envelope and any inline bytes. Both tables already participate in the
+standard global-symbol-table mapped-image write and reopen path. No tensor
+record is appended to the strict version-1 `.WHIRL.dsl` image, and no new ELF
+section is required for this stage.
+
+The envelope contains only explicitly sized scalars and Open64 table IDs. It
+contains no host pointers or STL ownership. INLINE_DENSE may place arbitrary
+bytes, including embedded NUL bytes, after the envelope; all offsets and
+lengths are validated against the carrier's `TCON_str_len`. SIDE_FILE_DENSE
+stores a relative location contract without a host pointer or absolute
+producer path.
+
+Older readers continue to see a legal `MTYPE_STRING` TCON and preserve its
+sized bytes even though they do not interpret the tensor envelope. DSL-aware
+compiler code must use `TCON_is_tensor()` and tensor TCON accessors; it must
+not test `MTYPE_STR`, parse envelope fields directly, or inspect private TCON
+value fields. Logical dumps print the tensor constant, never the physical
+escape representation.
+
+Runtime lookup, hashing, and deduplication indexes may accelerate access, but
+they are derived state. Clearing them must not make a reopened tensor TCON
+unqueryable. The gatekeeper validates envelope magic, version, record size,
+reserved fields, descriptor identity, bounds, alignment, checksum, and
+storage-kind-specific contracts directly from the mapped TCON image.
 
 The escape is a compatibility mechanism, not the logical tensor constant
 type. A future native tensor MTYPE may replace it only through a versioned
@@ -99,7 +103,7 @@ Use a closed, versioned storage-kind enum. The initial kinds are:
 | `TENSOR_TCON_ZERO` | Every logical element is semantic zero | No dense payload |
 | `TENSOR_TCON_ONE` | Every logical element is semantic one | No dense payload |
 | `TENSOR_TCON_SPLAT` | Every logical element equals one target-format scalar TCON | One `TCON_IDX` |
-| `TENSOR_TCON_INLINE_DENSE` | Small dense target-format tensor | Sized bytes in mapped string/blob storage |
+| `TENSOR_TCON_INLINE_DENSE` | Small dense target-format tensor | Sized bytes following the TCON envelope |
 | `TENSOR_TCON_SIDE_FILE_DENSE` | Large dense target-format tensor | External tensor reference |
 
 ZERO and ONE are specialized splats because they are common algebraic
@@ -117,7 +121,8 @@ compact representation whenever legal.
 INLINE_DENSE is for bounded constants whose bytes are small enough to remain
 in the mapped image under the active materialization policy. The bytes are in
 target element format and logical tensor layout, not an arbitrary host-native
-array representation.
+array representation. The TCON character-array table is binary-safe; normal
+symbol-string APIs such as `Save_Str` are not suitable for this payload.
 
 SIDE_FILE_DENSE is the normal representation for model parameters and large
 folded results. An LLM weight matrix is a constant tensor even though its bytes
@@ -479,12 +484,13 @@ hidden under a general positive/negative test item.
 ### Open64 integration and compatibility
 
 1. `sizeof(TCON)` and existing TCON field offsets remain unchanged.
-2. The string-TCON escape contains a valid string-table reference and older
-   tools can inspect it without failure.
+2. The string-TCON escape contains a valid sized TCON character-array
+   reference and older tools can preserve or inspect it without failure.
 3. DSL-aware diagnostics and `ir_b2a -st -src` hide the escape and print ZERO,
    ONE, SPLAT, INLINE_DENSE, or SIDE_FILE_DENSE logically.
-4. Tensor TCON records survive mapped-image write, reopen, and table
-   verification with carrier relationships intact.
+4. Tensor TCON envelopes survive mapped-image write and reopen through the
+   existing TCON table and TCON character-array table. Query and verification
+   still succeed after all runtime-derived lookup state is cleared.
 5. WN construction and adapted WOPT produce equivalent tensor TCONs and typed
    constant symbols for the same request.
 6. `Enter_tcon()` and constant-symbol merging distinguish semantic identity
@@ -493,11 +499,14 @@ hidden under a general positive/negative test item.
    printing occurs only under an explicit diagnostic control.
 8. Retained `.B`, side payload, and `ir_b2a -st -src` artifacts provide
    reviewable evidence for every storage kind.
-9. Matching tensor DIV and REM share one projectable DIVREM in WOPT when
+9. The strict version-1 `.WHIRL.dsl` image is unchanged by tensor-TCON
+   storage, and its existing reader still accepts files both with and without
+   tensor constants.
+10. Matching tensor DIV and REM share one projectable DIVREM in WOPT when
    enabled and profitable; differing operands or descriptors remain separate.
-10. A sole live DIVPART or REMPART reconstructs standalone tensor DIV or REM,
+11. A sole live DIVPART or REMPART reconstructs standalone tensor DIV or REM,
     while two live projections retain the shared operation.
-11. `-WOPT:divrem=on|off` and a target-declined combination produce equivalent
+12. `-WOPT:divrem=on|off` and a target-declined combination produce equivalent
     results with reviewable structural differences.
 
 This matrix incorporates the useful comparison scenarios:
@@ -534,7 +543,9 @@ The clean pull-request rule is:
 2. Never publish a simplifier candidate producer that requires an evaluator
    absent from the same milestone or an already merged milestone.
 3. M2 may land independently because it exposes tested tensor TCON
-   construction/storage APIs without changing simplifier behavior.
+   construction/storage APIs without changing simplifier behavior. Its
+   persistent owner is the existing TCON table plus TCON character-array
+   table; `.WHIRL.dsl` version 1 remains unchanged.
 4. M3 is the first pull request allowed to change actual DSL expression
    construction through tensor folding.
 5. M6 must land as one coherent projectable-operation feature. Do not split
@@ -546,8 +557,8 @@ The clean pull-request rule is:
 | Milestone | Status | Merge dependency | Review artifact |
 | --- | --- | --- | --- |
 | M0 | Merged through PR #89/#92 | None | Contract/API test report |
-| M1 | Implementation complete; PR pending | M0 merged | Simplifier bridge traces |
-| M2 | Blocked by M1 | M1 merged | Tensor TCON `.B` and `.T` |
+| M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
+| M2 | Active on coordinated main/Lagrange branches | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Blocked by M2 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |
 | M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |
@@ -566,8 +577,10 @@ The milestone mapping above controls when each action may begin integration.
 3. [ ] Add tensor TCON creation, query, target-format element access, hashing,
    comparison, printing, and verification APIs.
 4. [x] Define result-size and evaluator-work budgets.
-5. [ ] Add the fixed-row tensor TCON table and backward-compatible string-TCON
-   escape carrier without changing `sizeof(TCON)`.
+5. [ ] Add the fixed-layout tensor envelope in a backward-compatible
+   string-TCON carrier without changing `sizeof(TCON)`. Use `TCON_IDX` as the
+   stable identity and the existing TCON character-array table as persistent
+   byte ownership; any runtime lookup table is derived and rebuildable.
 6. [ ] Implement ZERO, ONE, and general SPLAT preservation.
 7. [ ] Implement INLINE_DENSE and SIDE_FILE_DENSE readers independent of
    Python and backend CG.

--- a/osprey/be/be/Makefile.gbase
+++ b/osprey/be/be/Makefile.gbase
@@ -324,6 +324,7 @@ COMMON_COM_CXX_SRCS = \
   dsl_region.cxx       \
   dsl_memory_behavior.cxx \
   dsl_opcode.cxx       \
+  dsl_tensor_fold.cxx  \
   dra_demangle.cxx	\
   dwarf_DST.cxx		\
   dwarf_DST_dump.cxx	\

--- a/osprey/clang2whirl/Makefile.gbase
+++ b/osprey/clang2whirl/Makefile.gbase
@@ -197,6 +197,7 @@ COMMON_COM_CXX_SRCS =   \
    dsl_region.cxx       \
    dsl_memory_behavior.cxx \
    dsl_opcode.cxx       \
+   dsl_tensor_fold.cxx  \
    dwarf_DST.cxx        \
    dwarf_DST_dump.cxx   \
    dwarf_DST_mem.cxx    \

--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -1076,6 +1076,79 @@ DSL_Tensor_TCON_Get_Dense_Bytes
     return TRUE;
 }
 
+static const char *
+DSL_Tensor_TCON_Storage_Name (DSL_TENSOR_TCON_STORAGE_KIND storage_kind)
+{
+    static const char *storage_name[] = {
+        "zero",
+        "one",
+        "splat",
+        "inline_dense",
+        "side_file"
+    };
+    UINT32 index = (UINT32)storage_kind;
+
+    if (index >= sizeof(storage_name) / sizeof(storage_name[0]))
+        return "unknown";
+    return storage_name[index];
+}
+
+BOOL
+DSL_Tensor_TCON_Print (FILE *file, TCON_IDX tcon_idx)
+{
+    DSL_TENSOR_TCON_RECORD record;
+    const char *side_path;
+    UINT32 side_path_length;
+
+    if (file == NULL || !DSL_Tensor_TCON_Get(tcon_idx, &record))
+        return FALSE;
+
+    fprintf(file,
+            "tensor_tcon storage=%s descriptor_ty=%u element=%s"
+            " elements=%llu bytes=%llu alignment=%u",
+            DSL_Tensor_TCON_Storage_Name(record.storage_kind),
+            (UINT32)record.descriptor_ty,
+            MTYPE_name((TYPE_ID)record.element_mtype),
+            (unsigned long long)record.element_count,
+            (unsigned long long)record.logical_bytes,
+            record.required_alignment);
+
+    switch (record.storage_kind) {
+    case DSL_TENSOR_TCON_STORAGE_ZERO:
+    case DSL_TENSOR_TCON_STORAGE_ONE:
+    case DSL_TENSOR_TCON_STORAGE_SPLAT:
+        fprintf(file, " scalar_tcon=%u scalar=%lld",
+                (UINT32)record.scalar_tcon,
+                (long long)record.scalar_integer_value);
+        break;
+    case DSL_TENSOR_TCON_STORAGE_INLINE_DENSE:
+        fprintf(file,
+                " inline_bytes=%u checksum=%016llx%016llx",
+                record.dense_length,
+                (unsigned long long)record.checksum_hi,
+                (unsigned long long)record.checksum_lo);
+        break;
+    case DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE:
+        if (!DSL_Tensor_TCON_Get_Side_Path
+                 (tcon_idx, &side_path, &side_path_length))
+            return FALSE;
+        fputs(" side_file=", file);
+        fwrite(side_path, 1, side_path_length, file);
+        fprintf(file,
+                " byte_offset=%llu byte_length=%llu"
+                " available_bytes=%u checksum=%016llx%016llx",
+                (unsigned long long)record.byte_offset,
+                (unsigned long long)record.byte_length,
+                record.dense_length,
+                (unsigned long long)record.checksum_hi,
+                (unsigned long long)record.checksum_lo);
+        break;
+    default:
+        return FALSE;
+    }
+    return TRUE;
+}
+
 BOOL
 DSL_Tensor_TCON_Create_Zero
         (const DSL_TENSOR_TCON_CREATE_INFO *info,

--- a/osprey/common/com/dsl_tensor_fold.h
+++ b/osprey/common/com/dsl_tensor_fold.h
@@ -5,6 +5,8 @@
 #ifndef dsl_tensor_fold_INCLUDED
 #define dsl_tensor_fold_INCLUDED
 
+#include <stdio.h>
+
 #include "defs.h"
 #include "dsl_ir_image.h"
 #include "dsl_opcode.h"
@@ -212,6 +214,9 @@ extern BOOL DSL_Tensor_TCON_Get_Dense_Bytes
                                 (TCON_IDX tcon_idx,
                                  const unsigned char **bytes,
                                  UINT32 *length);
+extern BOOL DSL_Tensor_TCON_Print
+                                (FILE *file,
+                                 TCON_IDX tcon_idx);
 extern BOOL DSL_Tensor_TCON_Create_Zero
                                 (const DSL_TENSOR_TCON_CREATE_INFO *info,
                                  TCON_IDX *tcon_idx,

--- a/osprey/common/com/ir_bread.cxx
+++ b/osprey/common/com/ir_bread.cxx
@@ -88,6 +88,7 @@
 #include "irbdata.h"		    /* for init_data */
 #include "wn_core.h"		    /* for WN */
 #include "wn.h"		            /* for max_region_id */
+#include "dsl_tensor_fold.h"
 #include "wn_map.h"		    /* for WN maps */
 
 #define USE_DST_INTERNALS
@@ -1626,6 +1627,7 @@ Read_Global_Info (INT32 *p_num_PUs)
     if ((INT) WN_get_global_symtab (global_fhandle) == -1) {
 	ErrMsg ( EC_IR_Scn_Read, "global symtab", global_ir_file);
     }
+    DSL_Tensor_TCON_Rebuild_Derived_Cache(1, TCON_Table_Size());
 
     if (WN_get_dsl_ir_image(global_fhandle) == -1) {
         ErrMsg (EC_IR_Scn_Read, "DSL image", global_ir_file);

--- a/osprey/common/com/symtab.cxx
+++ b/osprey/common/com/symtab.cxx
@@ -74,6 +74,7 @@
 #include "ttype.h"
 #include "targ_sim.h"
 #include "config_asm.h"
+#include "dsl_tensor_fold.h"
 
 extern void IR_Srcpos_Filename (SRCPOS srcpos,
                                 const char **fname,
@@ -2671,6 +2672,54 @@ Print_tensor_symbol_storage (FILE *f, ST_IDX st, TY_IDX ty)
     fprintf (f, "\n");
 }
 
+static BOOL
+Print_tensor_tcon_value (std::ostream &os, TCON_IDX tcon_idx)
+{
+    DSL_TENSOR_TCON_RECORD record;
+    const char *side_path;
+    UINT32 side_path_length;
+
+    if (!DSL_Tensor_TCON_Get(tcon_idx, &record))
+        return FALSE;
+
+    static const char *storage_name[] = {
+        "zero", "one", "splat", "inline_dense", "side_file"
+    };
+    UINT32 storage = (UINT32)record.storage_kind;
+    os << "tensor_tcon storage="
+       << (storage < sizeof(storage_name) / sizeof(storage_name[0]) ?
+               storage_name[storage] : "unknown")
+       << " descriptor_ty=" << (UINT32)record.descriptor_ty
+       << " element=" << MTYPE_name((TYPE_ID)record.element_mtype)
+       << " elements=" << (unsigned long long)record.element_count
+       << " bytes=" << (unsigned long long)record.logical_bytes
+       << " alignment=" << record.required_alignment;
+
+    if (record.storage_kind <= DSL_TENSOR_TCON_STORAGE_SPLAT) {
+        os << " scalar_tcon=" << (UINT32)record.scalar_tcon
+           << " scalar=" << (long long)record.scalar_integer_value;
+    } else if (record.storage_kind ==
+                   DSL_TENSOR_TCON_STORAGE_INLINE_DENSE) {
+        os << " inline_bytes=" << record.dense_length
+           << " checksum=" << std::hex << record.checksum_hi
+           << record.checksum_lo << std::dec;
+    } else if (record.storage_kind ==
+                   DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE &&
+               DSL_Tensor_TCON_Get_Side_Path
+                   (tcon_idx, &side_path, &side_path_length)) {
+        os << " side_file=";
+        os.write(side_path, side_path_length);
+        os << " byte_offset=" << (unsigned long long)record.byte_offset
+           << " byte_length=" << (unsigned long long)record.byte_length
+           << " available_bytes=" << record.dense_length
+           << " checksum=" << std::hex << record.checksum_hi
+           << record.checksum_lo << std::dec;
+    } else {
+        return FALSE;
+    }
+    return TRUE;
+}
+
 void
 ST::Print (FILE *f, BOOL verbose) const
 {
@@ -2846,8 +2895,12 @@ ST::Print (FILE *f, BOOL verbose) const
 	}
     }
 	
-    if (sym_class == CLASS_CONST)
-	fprintf (f, "\t\tvalue: %s\n", Targ_Print (NULL, Tcon_Table[u1.tcon]));
+    if (sym_class == CLASS_CONST) {
+        fputs("\t\tvalue: ", f);
+        if (!DSL_Tensor_TCON_Print(f, u1.tcon))
+            fputs(Targ_Print(NULL, Tcon_Table[u1.tcon]), f);
+        fputc('\n', f);
+    }
 
     if (verbose) {
 	// Print address
@@ -3208,9 +3261,12 @@ std::ostream& operator<<(std::ostream &os, const ST &st )
 	}
     }
 	
-    if (st.sym_class == CLASS_CONST)
-        os << "\t\tvalue: " 
-           << Targ_Print (NULL, Tcon_Table[st.u1.tcon]) << std::endl;
+    if (st.sym_class == CLASS_CONST) {
+        os << "\t\tvalue: ";
+        if (!Print_tensor_tcon_value(os, st.u1.tcon))
+            os << Targ_Print(NULL, Tcon_Table[st.u1.tcon]);
+        os << std::endl;
+    }
 
     if (verbose) {
 	// Print address
@@ -3680,7 +3736,11 @@ template<>
 inline void
 print_op<TCON>::operator () (UINT idx, TCON *c) const
 {
-    fprintf (fid, "[%d] %s: %s\n", idx, MTYPE_name(TCON_ty(*c)),Targ_Print (NULL, *c));
+    fprintf(fid, "[%d] ", idx);
+    if (!DSL_Tensor_TCON_Print(fid, idx))
+        fprintf(fid, "%s: %s", MTYPE_name(TCON_ty(*c)),
+                Targ_Print(NULL, *c));
+    fputc('\n', fid);
 } // print_op<TCON>::operator ()
 
 

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -35,6 +35,7 @@
 #include "dsl_gatekeeper.h"
 #include "dsl_memory_behavior.h"
 #include "dsl_simp.h"
+#include "dsl_tensor_fold.h"
 
 BOOL Run_vsaopt = FALSE;
 INT8 Debug_Level = 0;
@@ -3973,6 +3974,108 @@ Check_Multiple_Program_Units(void)
     return 0;
 }
 
+static int
+Check_Tensor_TCON_Mapped_Image(void)
+{
+    const char *artifact = getenv("OPEN64_DSL_TENSOR_TCON_ARTIFACT");
+    DSL_BUILDER_TENSOR_TYPE_CORE core;
+    DSL_BUILDER_MAPPED_IMAGE_REQUEST request;
+    DSL_BUILDER_PROGRAM_UNIT pu;
+    DSL_TENSOR_TCON_CREATE_INFO info;
+    TCON scalar;
+    TCON_IDX scalar_idx;
+    TCON_IDX zero_idx;
+    TCON_IDX side_idx;
+    TY_IDX tensor_ty;
+    ST *zero_st;
+    ST *side_st;
+    USRCPOS source_position;
+    UINT32 file_id;
+    const char side_path[] = "weights/tensor.bin";
+
+    if (artifact == NULL || artifact[0] == '\0')
+        artifact = "tensor_tcon_mapped_image.B";
+
+    if (!DSL_Builder_Begin_Program()) {
+        fprintf(stderr, "tensor TCON program initialization failed\n");
+        return 1;
+    }
+
+    memset(&core, 0, sizeof(core));
+    core.kind = "tensor";
+    core.dtype = "int32";
+    core.rank = 2;
+    core.logical_shape = "[2,2]";
+    tensor_ty = DSL_Builder_Create_Tensor_Type_Core
+                    ("tensor_tcon_i32_2x2", MTYPE_To_TY(MTYPE_I4), &core);
+    pu = DSL_Builder_Create_Minimal_PU("tensor_tcon_mapped_image");
+    file_id = DSL_Builder_Register_Source_File(pu, __FILE__);
+    if (tensor_ty == TY_IDX_ZERO || !TY_tensor_seal(tensor_ty) ||
+        pu == NULL || file_id == 0) {
+        fprintf(stderr, "tensor TCON type, PU, or source setup failed\n");
+        return 1;
+    }
+
+    scalar = Host_To_Targ(MTYPE_I4, 0);
+    scalar_idx = Enter_tcon(scalar);
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = tensor_ty;
+    info.scalar_tcon = scalar_idx;
+    info.element_mtype = MTYPE_I4;
+    info.element_count = 4;
+    info.logical_bytes = 16;
+    info.required_alignment = 16;
+    info.element_size = 4;
+    if (!DSL_Tensor_TCON_Create_Zero(&info, &zero_idx, NULL)) {
+        fprintf(stderr, "tensor zero TCON creation failed\n");
+        return 1;
+    }
+
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = tensor_ty;
+    info.element_mtype = MTYPE_I4;
+    info.element_count = 4;
+    info.logical_bytes = 16;
+    info.required_alignment = 16;
+    info.element_size = 4;
+    info.side_path = side_path;
+    info.side_path_length = strlen(side_path);
+    info.byte_length = 16;
+    info.checksum_hi = 0x1234;
+    info.checksum_lo = 0x5678;
+    if (!DSL_Tensor_TCON_Create_Side_File_Dense
+             (&info, &side_idx, NULL)) {
+        fprintf(stderr, "tensor side-file TCON creation failed\n");
+        return 1;
+    }
+
+    USRCPOS_clear(source_position);
+    USRCPOS_filenum(source_position) = file_id;
+    USRCPOS_linenum(source_position) = __LINE__ + 1;
+    zero_st = New_ST(GLOBAL_SYMTAB);
+    ST_Init(zero_st, Save_Str("tensor_zero"), CLASS_CONST,
+            SCLASS_FSTATIC, EXPORT_LOCAL, tensor_ty);
+    Set_ST_tcon(zero_st, zero_idx);
+    Set_ST_is_initialized(zero_st);
+    Set_ST_Srcpos(*zero_st, USRCPOS_srcpos(source_position));
+
+    USRCPOS_linenum(source_position) = __LINE__ + 1;
+    side_st = New_ST(GLOBAL_SYMTAB);
+    ST_Init(side_st, Save_Str("tensor_side_file"), CLASS_CONST,
+            SCLASS_FSTATIC, EXPORT_LOCAL, tensor_ty);
+    Set_ST_tcon(side_st, side_idx);
+    Set_ST_is_initialized(side_st);
+    Set_ST_Srcpos(*side_st, USRCPOS_srcpos(source_position));
+
+    request.path = artifact;
+    request.flags = 0;
+    if (!DSL_Builder_Finalize_Mapped_Image(&request)) {
+        fprintf(stderr, "tensor TCON mapped-image finalization failed\n");
+        return 1;
+    }
+    return 0;
+}
+
 int
 main(void)
 {
@@ -4007,6 +4110,8 @@ main(void)
         return Check_Algebraic_Canonicalization();
     if (getenv("OPEN64_DSL_SIMPLIFIER_ONLY") != NULL)
         return Check_DSL_Simplifier_Bridge();
+    if (getenv("OPEN64_DSL_TENSOR_TCON_ONLY") != NULL)
+        return Check_Tensor_TCON_Mapped_Image();
 
     failed |= Check_Tensor_Type_And_Descriptor();
     failed |= Check_Symbol_Metadata();

--- a/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
@@ -15,6 +15,8 @@ static std::vector<std::string> DSL_tensor_fold_test_strtab;
 static std::vector<std::string> DSL_tensor_fold_test_char_table;
 static std::vector<TCON> DSL_tensor_fold_test_tcon_table;
 
+TYPE_DESC Machine_Types[MTYPE_LAST + 1];
+
 void
 Initialize_Strtab (UINT32)
 {
@@ -26,6 +28,7 @@ Initialize_Strtab (UINT32)
     TCON zero;
     TCON_clear(zero);
     DSL_tensor_fold_test_tcon_table.push_back(zero);
+    Machine_Types[MTYPE_I4].name = "I4";
 }
 
 void

--- a/osprey/common/com/tests/dsl_tensor_tcon_image_test.sh
+++ b/osprey/common/com/tests/dsl_tensor_tcon_image_test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Preserve mapped-image and logical ir_b2a evidence for tensor TCON carriers.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+build_dir="${OPEN64_BUILD_DIR:-$repo_root/build}"
+producer="${OPEN64_DSL_CONTRACT_TEST:-$build_dir/osprey/targdir/ir_tools/dsl_builder_contract_test}"
+ir_b2a="${OPEN64_IR_B2A:-$build_dir/osprey/targdir/ir_tools/ir_b2a}"
+artifact_dir="${OPEN64_DSL_TENSOR_TCON_ARTIFACT_DIR:-$repo_root/artifacts/m2-tensor-tcon}"
+image="$artifact_dir/tensor_tcon.B"
+trace="$artifact_dir/tensor_tcon.T"
+
+for executable in "$producer" "$ir_b2a"; do
+  if [[ ! -x "$executable" ]]; then
+    echo "missing executable: $executable" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$artifact_dir"
+find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -delete
+
+OPEN64_DSL_TENSOR_TCON_ONLY=1 \
+OPEN64_DSL_TENSOR_TCON_ARTIFACT="$image" \
+  "$producer" > "$artifact_dir/producer.log" 2>&1
+
+"$ir_b2a" -st -src "$image" > "$trace"
+
+for evidence in \
+  "tensor_tcon storage=zero" \
+  "element=I4 elements=4 bytes=16 alignment=16" \
+  "tensor_tcon storage=side_file" \
+  "side_file=weights/tensor.bin" \
+  "byte_offset=0 byte_length=16"; do
+  if ! grep -Fq "$evidence" "$trace"; then
+    echo "missing tensor TCON evidence '$evidence' in $trace" >&2
+    exit 1
+  fi
+done
+
+if grep -Fq "MTYPE_STRING" "$trace"; then
+  echo "physical tensor TCON carrier leaked into $trace" >&2
+  exit 1
+fi
+
+cat > "$artifact_dir/certification.txt" <<EOF
+mapped_image_reopen=passed
+derived_cache_rebuild=passed
+logical_tcon_print=passed
+logical_symbol_print=passed
+ir_b2a_st_src=passed
+physical_carrier_hidden=passed
+EOF
+
+echo "tensor TCON mapped-image fixture passed"
+echo "review artifacts: $artifact_dir"

--- a/osprey/crayf90/sgi/Makefile.gbase
+++ b/osprey/crayf90/sgi/Makefile.gbase
@@ -195,6 +195,7 @@ COMMON_COM_CXX_SRCS =	\
   dsl_region.cxx        \
   dsl_memory_behavior.cxx \
   dsl_opcode.cxx        \
+  dsl_tensor_fold.cxx   \
   dwarf_DST.cxx		\
   dwarf_DST_dump.cxx	\
   dwarf_DST_mem.cxx	\

--- a/osprey/ir_tools/Makefile.gbase
+++ b/osprey/ir_tools/Makefile.gbase
@@ -191,6 +191,7 @@ COMMON_COM_CXX_SRC =	\
 	dsl_memory_behavior.cxx \
 	dsl_opcode.cxx	\
 	dsl_simp.cxx	\
+        dsl_tensor_fold.cxx \
 	dwarf_DST.cxx	\
 	dwarf_DST_dump.cxx	\
 	dwarf_DST_mem.cxx	\

--- a/osprey/jfe/libb2w/wgen-java/wgen/Makefile.gbase
+++ b/osprey/jfe/libb2w/wgen-java/wgen/Makefile.gbase
@@ -182,6 +182,7 @@ COMMON_COM_CXX_SRCS =   \
    dsl_region.cxx       \
    dsl_memory_behavior.cxx \
    dsl_opcode.cxx       \
+   dsl_tensor_fold.cxx  \
    dwarf_DST.cxx                \
    dwarf_DST_dump.cxx   \
    dwarf_DST_mem.cxx    \

--- a/osprey/kg++fe/Makefile.gbase
+++ b/osprey/kg++fe/Makefile.gbase
@@ -233,6 +233,7 @@ COMMON_COM_CXX_SRCS =	\
   dsl_region.cxx        \
   dsl_memory_behavior.cxx \
   dsl_opcode.cxx        \
+  dsl_tensor_fold.cxx   \
   dwarf_DST.cxx		\
   dwarf_DST_dump.cxx	\
   dwarf_DST_mem.cxx	\

--- a/osprey/kgccfe/Makefile.gbase
+++ b/osprey/kgccfe/Makefile.gbase
@@ -228,6 +228,7 @@ COMMON_COM_CXX_SRCS =	\
   dsl_region.cxx        \
   dsl_memory_behavior.cxx \
   dsl_opcode.cxx        \
+  dsl_tensor_fold.cxx   \
   dwarf_DST.cxx		\
   dwarf_DST_dump.cxx	\
   dwarf_DST_mem.cxx	\

--- a/osprey/libwffi/Makefile.gbase
+++ b/osprey/libwffi/Makefile.gbase
@@ -136,6 +136,7 @@ COMMON_COM_CXX_SRC =	\
         dsl_region.cxx  \
         dsl_memory_behavior.cxx \
         dsl_opcode.cxx  \
+        dsl_tensor_fold.cxx \
         dwarf_DST.cxx   \
         dwarf_DST_dump.cxx     \
         dwarf_DST_mem.cxx      \

--- a/osprey/wgen/Makefile.gbase
+++ b/osprey/wgen/Makefile.gbase
@@ -184,6 +184,7 @@ COMMON_COM_CXX_SRCS =   \
    dsl_region.cxx       \
    dsl_memory_behavior.cxx \
    dsl_opcode.cxx       \
+   dsl_tensor_fold.cxx  \
    dwarf_DST.cxx                \
    dwarf_DST_dump.cxx   \
    dwarf_DST_mem.cxx    \


### PR DESCRIPTION
## Summary

Completes the main Open64 integration for M2 tensor TCON storage after the storage foundation merged in #94.

- rebuilds the derived tensor TCON cache after the existing global TCON tables are mapped
- prints logical ZERO, ONE, SPLAT, INLINE_DENSE, and SIDE_FILE_DENSE constants in symbol and global TCON dumps while hiding the private string-TCON carrier
- links the shared tensor TCON service into Open64 phases that compile the common symbol-table and binary-reader code
- adds a mapped-image producer/reopen fixture with source positions and retained `ir_b2a -st -src` evidence
- updates the simplification and tensor constant-folding milestone dashboards

No WHIRL ELF section, `TCON` layout, or `.WHIRL.dsl` revision changes are introduced.

## Validation

- `dsl_tensor_fold_contract_test.sh`
- Linux Docker build of `dsl_builder_contract_test` and `ir_b2a`
- existing `OPEN64_DSL_SIMPLIFIER_ONLY` bridge contract
- Linux native syntax and physical operator compatibility matrix
- mapped `tensor_tcon.B` reopen with `ir_b2a -st -src`
- `git diff --check` and no-tab scan

Retained local evidence includes `tensor_tcon.B`, `tensor_tcon.T`, and `certification.txt` under `artifacts/m2-tensor-tcon`.