### PR TITLE
Add compact tensor constant folding

### DIFF
--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -1108,8 +1108,8 @@ capability per pull request. Do not use M7 as a miscellaneous cleanup batch.
 | --- | --- | --- | --- |
 | M0 | Merged through PR #89/#92 | None | Contract/API test report |
 | M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
-| M2 | Storage merged through PR #94; main integration under review | M1 merged | Tensor TCON `.B` and `.T` |
-| M3 | Blocked by M2 | M2 merged | Enabled/disabled fold artifacts |
+| M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
+| M3 | Compact integral slice implemented and validated on `codex/dsl-simplifier-m3` | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |
 | M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
@@ -1177,6 +1177,20 @@ of its private string-TCON carrier. The retained M2 fixture reopens
 `tensor_tcon.B` through `ir_b2a -st -src` and records compact ZERO and
 SIDE_FILE_DENSE constants in `tensor_tcon.T`.
 
+M3 begins with exact integral `common.add.v1` and `common.mul.v1` over compact
+ZERO, ONE, and SPLAT tensor TCONs. These forms already carry target-format
+scalar TCON values and therefore reuse traditional Open64 target constant
+operations without reinterpreting tensor bytes in host format. INLINE_DENSE
+and SIDE_FILE_DENSE operands without reviewed target-format element extraction
+must return a structured non-constant/materialization rejection and preserve
+the original logical operator.
+
+The compact M3 slice is now implemented. The builder hook is disabled by
+default, remains subordinate to `Enable_WN_Simp`, invokes the traditional
+three-step simplifier bridge before `Targ_DSL_WhirlOp`, publishes a
+`common.tensor_const` result, and permits the folded value to feed a parent
+fold. Dense payload evaluation remains deferred.
+
 ## Staged Action List
 
 ### S0: Baseline and contract review
@@ -1227,8 +1241,10 @@ SIDE_FILE_DENSE constants in `tensor_tcon.T`.
 - Add constant-to-`kid1`, ordered-relation, and deterministic structural
   normalization.
 - Preserve result symbol, source position, lineage, and metadata.
-- Queue, but do not evaluate, all-constant tensor payload candidates for the
-  tensor constant-folding service.
+- Send all-constant tensor payload candidates to the tensor constant-folding
+  service. The current compact M3 slice evaluates ZERO, ONE, and SPLAT
+  integral `common.add.v1` and `common.mul.v1`; unsupported dense forms retain
+  the original logical operator.
 - Allow a stage-specific option to disable the hook only as a further
   restriction; it must never re-enable work disabled by `Enable_WN_Simp`.
 

--- a/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
+++ b/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
@@ -566,8 +566,8 @@ range, and checksum.
 | --- | --- | --- | --- |
 | M0 | Merged through PR #89/#92 | None | Contract/API test report |
 | M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
-| M2 | Storage merged through PR #94; main integration under review | M1 merged | Tensor TCON `.B` and `.T` |
-| M3 | Blocked by M2 | M2 merged | Enabled/disabled fold artifacts |
+| M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
+| M3 | Compact integral slice implemented and validated on `codex/dsl-simplifier-m3` | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |
 | M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
@@ -579,26 +579,41 @@ Update both copies of the status table in the same documentation change.
 
 The milestone mapping above controls when each action may begin integration.
 
+M3 initially evaluates compact integral ZERO, ONE, and SPLAT carriers. Their
+scalar TCON is already in target format and is evaluated through the existing
+Open64 target constant operation. Dense inline and side-file payloads remain
+valid M2 constants, but M3 must reject them unless the evaluator can obtain
+each element through a reviewed target-format accessor. It must never cast
+their bytes to host integer pointers.
+
+The compact M3 slice is implemented through `Targ_WhirlOp` and
+`Targ_DSL_WhirlOp`. Construction-time publication is disabled by default and
+subordinate to `Enable_WN_Simp`. Its retained artifact proves enabled,
+stage-disabled, master-disabled, non-constant rejection, mapped-image reopen,
+and bottom-up parent-fold behavior. Items below that mention dense payloads,
+side-file publication, VHO, or WOPT remain future work.
+
 1. [x] Define a fixed-layout evaluator registry keyed by logical operator and
    version.
 2. [x] Define the simplifier candidate-input and folded-result handoff APIs.
-3. [ ] Add tensor TCON creation, query, target-format element access, hashing,
+3. [x] Add tensor TCON creation, query, target-format compact-scalar access, hashing,
    comparison, printing, and verification APIs.
 4. [x] Define result-size and evaluator-work budgets.
-5. [ ] Add the fixed-layout tensor envelope in a backward-compatible
+5. [x] Add the fixed-layout tensor envelope in a backward-compatible
    string-TCON carrier without changing `sizeof(TCON)`. Use `TCON_IDX` as the
    stable identity and the existing TCON character-array table as persistent
    byte ownership; any runtime lookup table is derived and rebuildable.
-6. [ ] Implement ZERO, ONE, and general SPLAT preservation.
+6. [x] Implement ZERO, ONE, and general SPLAT preservation.
 7. [ ] Implement INLINE_DENSE and SIDE_FILE_DENSE readers independent of
    Python and backend CG.
-8. [ ] Implement exact integer `common.add` and `common.mul` through
-   target-format element operations.
+8. [x] Implement exact integer `common.add` and `common.mul` for compact
+   ZERO, ONE, and SPLAT carriers through target-format scalar operations.
 9. [ ] After the projectable-operation contract is published, implement
    exact integer tensor DIVREM evaluation and quotient/remainder TCON
    projections.
 10. [ ] Publish folded constants atomically to the mapped image and side file.
-11. [ ] Requeue affected parent expressions after successful publication.
+11. [x] Revisit affected parent expressions after successful compact
+   publication.
 12. [ ] Preserve source position, result symbol, lineage, and descriptor
    identity.
 13. [ ] Add gatekeeper checks for carrier/record consistency, folded result
@@ -609,7 +624,8 @@ The milestone mapping above controls when each action may begin integration.
    reason.
 16. [ ] Add deterministic option A/B tests for construction, explicit VHO
    folding, and adapted WOPT.
-17. [ ] Preserve `.B`, side payload, and `ir_b2a -st -src` evidence.
+17. [x] Preserve compact-fold `.B` and `ir_b2a -st -src` evidence. Preserve
+   side payload evidence when dense side-file folding is implemented.
 
 ## Non-Goals
 

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -8,6 +8,7 @@
 #pragma hdrstop
 #include <algorithm>
 #include <ctype.h>
+#include <errno.h>
 #include <float.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -20,7 +21,10 @@
 
 #include "dsl_builder.h"
 #include "dsl_gatekeeper.h"
+#include "dsl_simp.h"
+#include "dsl_tensor_fold.h"
 #include "config.h"
+#include "const.h"
 #include "dwarf_DST.h"
 #include "dwarf_DST_mem.h"
 #include "dwarf_DST_producer.h"
@@ -49,6 +53,7 @@ typedef struct {
     TY_IDX result_ty;
     DSL_IR_VALUE_ID image_value_id;
     UINT32 value_kind;
+    TCON_IDX tensor_tcon;
     std::string canonical_key;
     BOOL materializing;
     BOOL materialized;
@@ -56,6 +61,7 @@ typedef struct {
 
 static std::vector<DSL_BUILDER_VALUE_RECORD> DSL_builder_value_registry;
 static BOOL DSL_builder_canonicalization_enabled = FALSE;
+static BOOL DSL_builder_tensor_folding_enabled = FALSE;
 
 struct dsl_builder_state {
     DSL_BUILDER_PROGRAM_UNIT pu;
@@ -591,6 +597,18 @@ BOOL
 DSL_Builder_Canonicalization_Enabled (void)
 {
     return Enable_WN_Simp && DSL_builder_canonicalization_enabled;
+}
+
+void
+DSL_Builder_Set_Tensor_Folding_Enabled (BOOL enabled)
+{
+    DSL_builder_tensor_folding_enabled = enabled;
+}
+
+BOOL
+DSL_Builder_Tensor_Folding_Enabled (void)
+{
+    return Enable_WN_Simp && DSL_builder_tensor_folding_enabled;
 }
 
 BOOL
@@ -1999,6 +2017,7 @@ DSL_Builder_Create_Native_Value
     record.result_ty = result_ty;
     record.image_value_id = image_value_id;
     record.value_kind = value_kind;
+    record.tensor_tcon = TCON_IDX_ZERO;
     record.canonical_key = canonical_key;
     record.materializing = FALSE;
     record.materialized = FALSE;
@@ -2212,15 +2231,108 @@ DSL_Builder_Tensor_Has_Unique_Ownership (ST_IDX st)
     return value != NULL && strcmp(value, "true") == 0;
 }
 
-DSL_BUILDER_VALUE
-DSL_Builder_Create_Tensor_Constant
+static BOOL
+DSL_Builder_Attach_Tensor_TCON
+        (DSL_BUILDER_VALUE value,
+         TCON_IDX tensor_tcon)
+{
+    DSL_BUILDER_VALUE_RECORD *record =
+        DSL_Builder_Find_Value_Record(value);
+    DSL_TENSOR_TCON_RECORD tensor_record;
+    char tcon_text[32];
+
+    if (record == NULL || tensor_tcon == TCON_IDX_ZERO ||
+        !DSL_Tensor_TCON_Get(tensor_tcon, &tensor_record) ||
+        tensor_record.descriptor_ty != record->result_ty)
+        return FALSE;
+
+    record->tensor_tcon = tensor_tcon;
+    snprintf(tcon_text, sizeof(tcon_text), "%u", (UINT32)tensor_tcon);
+    ST_tensor_bind_metadata(record->result_st, "tensor_tcon_idx", tcon_text);
+    return TRUE;
+}
+
+static BOOL
+DSL_Builder_Create_Compact_Tensor_TCON
+        (TY_IDX tensor_ty,
+         const char *value,
+         TCON_IDX *tensor_tcon)
+{
+    std::vector<UINT64> dimensions;
+    DSL_TENSOR_TCON_CREATE_INFO info;
+    TY_IDX element_ty;
+    TYPE_ID element_mtype;
+    TCON scalar;
+    TCON_IDX scalar_tcon;
+    UINT64 element_count = 1;
+    INT64 integer_value;
+    char *end;
+
+    if (tensor_tcon != NULL)
+        *tensor_tcon = TCON_IDX_ZERO;
+    if (tensor_tcon == NULL || value == NULL ||
+        !DSL_Builder_Tensor_Type_Is_Canonical(tensor_ty) ||
+        !DSL_Builder_Parse_Static_Shape
+             (TY_tensor_attribute(tensor_ty, TY_TENSOR_SCHEMA_SHAPE),
+              &dimensions))
+        return FALSE;
+
+    for (UINT32 i = 0; i < dimensions.size(); ++i) {
+        if (dimensions[i] == 0 ||
+            element_count > ~(UINT64)0 / dimensions[i])
+            return FALSE;
+        element_count *= dimensions[i];
+    }
+
+    element_ty = TY_tensor_element_ty(tensor_ty);
+    element_mtype = TY_mtype(element_ty);
+    if (!MTYPE_is_integral(element_mtype) || TY_size(element_ty) == 0)
+        return FALSE;
+
+    errno = 0;
+    integer_value = strtoll(value, &end, 0);
+    if (errno == ERANGE || end == value || *end != '\0')
+        return FALSE;
+    scalar = Host_To_Targ(element_mtype, integer_value);
+    if (Targ_To_Host(scalar) != integer_value)
+        return FALSE;
+    scalar_tcon = Enter_tcon(scalar);
+    if (scalar_tcon == TCON_IDX_ZERO)
+        return FALSE;
+
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = tensor_ty;
+    info.scalar_tcon = scalar_tcon;
+    info.element_mtype = element_mtype;
+    info.element_count = element_count;
+    info.element_size = TY_size(element_ty);
+    if (element_count > ~(UINT64)0 / info.element_size)
+        return FALSE;
+    info.logical_bytes = element_count * info.element_size;
+    info.required_alignment = TY_align(tensor_ty);
+    if (info.required_alignment < info.element_size)
+        info.required_alignment = info.element_size;
+    info.scalar_integer_value = integer_value;
+
+    if (integer_value == 0)
+        return DSL_Tensor_TCON_Create_Zero
+                   (&info, tensor_tcon, NULL);
+    if (integer_value == 1)
+        return DSL_Tensor_TCON_Create_One
+                   (&info, tensor_tcon, NULL);
+    return DSL_Tensor_TCON_Create_Splat(&info, tensor_tcon, NULL);
+}
+
+static DSL_BUILDER_VALUE
+DSL_Builder_Create_Tensor_Constant_Value
         (const char *name,
          TY_IDX tensor_ty,
          const char *dtype,
          UINT32 rank,
          const char *logical_shape,
          const char *value_kind,
-         const char *value)
+         const char *value,
+         TCON_IDX tensor_tcon)
 {
     char *payload;
     DSL_BUILDER_VALUE result;
@@ -2241,7 +2353,29 @@ DSL_Builder_Create_Tensor_Constant
                  (OPR_DSLTENSORCONST, 1, payload, NULL, 0, attrs, 2,
                   name, tensor_ty, DSL_IR_VALUE_CONSTANT);
     delete [] payload;
+    if (result != NULL && tensor_tcon != TCON_IDX_ZERO)
+        DSL_Builder_Attach_Tensor_TCON(result, tensor_tcon);
     return result;
+}
+
+DSL_BUILDER_VALUE
+DSL_Builder_Create_Tensor_Constant
+        (const char *name,
+         TY_IDX tensor_ty,
+         const char *dtype,
+         UINT32 rank,
+         const char *logical_shape,
+         const char *value_kind,
+         const char *value)
+{
+    TCON_IDX tensor_tcon = TCON_IDX_ZERO;
+
+    if (value_kind != NULL && strcmp(value_kind, "splat") == 0)
+        DSL_Builder_Create_Compact_Tensor_TCON
+            (tensor_ty, value, &tensor_tcon);
+    return DSL_Builder_Create_Tensor_Constant_Value
+               (name, tensor_ty, dtype, rank, logical_shape, value_kind,
+                value, tensor_tcon);
 }
 
 DSL_BUILDER_VALUE
@@ -2424,6 +2558,152 @@ DSL_Builder_Create_External_Tensor_Constant
     ST_tensor_bind_metadata(result_st, "storage_byte_length", byte_length);
     ST_tensor_bind_metadata(result_st, "storage_checksum", checksum);
     return result;
+}
+
+static WN *
+DSL_Builder_Project_Compact_Tensor_Constant
+        (const DSL_BUILDER_VALUE_RECORD *record)
+{
+    DSL_TENSOR_TCON_RECORD tensor_tcon;
+    TY_IDX element_ty;
+    TYPE_ID element_mtype;
+    ST *scalar_st;
+
+    if (record == NULL || record->tensor_tcon == TCON_IDX_ZERO ||
+        !DSL_Tensor_TCON_Get(record->tensor_tcon, &tensor_tcon) ||
+        (tensor_tcon.storage_kind != DSL_TENSOR_TCON_STORAGE_ZERO &&
+         tensor_tcon.storage_kind != DSL_TENSOR_TCON_STORAGE_ONE &&
+         tensor_tcon.storage_kind != DSL_TENSOR_TCON_STORAGE_SPLAT))
+        return NULL;
+
+    element_ty = TY_tensor_element_ty(record->result_ty);
+    element_mtype = TY_mtype(element_ty);
+    scalar_st = New_Const_Sym(tensor_tcon.scalar_tcon, element_ty);
+    return scalar_st == NULL ? NULL :
+        WN_CreateConst(OPR_CONST, element_mtype, MTYPE_V, scalar_st);
+}
+
+static DSL_BUILDER_VALUE
+DSL_Builder_Try_Fold_Tensor_Binary
+        (DSL_OPERATOR dsl_operator,
+         UINT16 version,
+         DSL_BUILDER_VALUE *kids,
+         UINT32 kid_count,
+         const DSL_BUILDER_OPERATOR_ATTRIBUTE *attrs,
+         UINT32 attr_count,
+         const char *result_name,
+         TY_IDX result_ty)
+{
+    DSL_BUILDER_VALUE_RECORD *kid_record[2];
+    DSL_SIMP_BINARY_CANDIDATE simp_candidate;
+    DSL_SIMP_BINARY_RESULT simp_result;
+    DSL_TENSOR_FOLD_CANDIDATE fold_candidate;
+    DSL_TENSOR_FOLD_OUTPUT fold_output;
+    DSL_TENSOR_FOLD_POLICY fold_policy;
+    DSL_TENSOR_TCON_RECORD folded_record;
+    DSL_IR_ATTRIBUTE_RECORD *fold_attrs = NULL;
+    TCON operands[2];
+    TY_IDX operand_ty[2];
+    TY_IDX result_types[1];
+    TCON_IDX folded_tcon;
+    DSL_BUILDER_VALUE folded_value;
+    DSL_SIMP_STATUS simp_status;
+    char folded_text[64];
+    const char *dtype;
+    const char *shape;
+    INT32 rank;
+
+    if (!DSL_Builder_Tensor_Folding_Enabled() || kids == NULL ||
+        kid_count != 2 ||
+        (dsl_operator != OPR_DSLADD && dsl_operator != OPR_DSLMUL))
+        return NULL;
+
+    for (UINT32 i = 0; i < 2; ++i) {
+        kid_record[i] = DSL_Builder_Find_Value_Record(kids[i]);
+        if (kid_record[i] == NULL ||
+            kid_record[i]->tensor_tcon == TCON_IDX_ZERO)
+            return NULL;
+        if (!DSL_Tensor_TCON_Get_Carrier
+                 (kid_record[i]->tensor_tcon, &operands[i]))
+            return NULL;
+        operand_ty[i] = kid_record[i]->result_ty;
+    }
+
+    memset(&simp_candidate, 0, sizeof(simp_candidate));
+    simp_candidate.dsl_operator = dsl_operator;
+    simp_candidate.version = version;
+    simp_candidate.result_ty = result_ty;
+    simp_candidate.operand_ty[0] = operand_ty[0];
+    simp_candidate.operand_ty[1] = operand_ty[1];
+    simp_candidate.projected_kid[0] =
+        DSL_Builder_Project_Compact_Tensor_Constant(kid_record[0]);
+    simp_candidate.projected_kid[1] =
+        DSL_Builder_Project_Compact_Tensor_Constant(kid_record[1]);
+    simp_candidate.projection_kind = DSL_SIMP_PROJECTION_TEST_SCALAR;
+    if (simp_candidate.projected_kid[0] == NULL ||
+        simp_candidate.projected_kid[1] == NULL)
+        return NULL;
+    simp_status = DSL_Simp_Binary(&simp_candidate, &simp_result);
+    if (simp_status != DSL_SIMP_ENGINE_REWRITE &&
+        simp_status != DSL_SIMP_UNCHANGED)
+        return NULL;
+
+    if (attr_count != 0) {
+        fold_attrs = new DSL_IR_ATTRIBUTE_RECORD[attr_count];
+        for (UINT32 i = 0; i < attr_count; ++i) {
+            DSL_IR_Attribute_Record_Init(&fold_attrs[i]);
+            fold_attrs[i].value_kind = DSL_IR_ATTRIBUTE_VALUE_STRING;
+            fold_attrs[i].name = Save_Str(attrs[i].name);
+            fold_attrs[i].value =
+                Save_Str(DSL_Builder_Safe_String(attrs[i].value));
+        }
+    }
+
+    DSL_Tensor_Fold_Default_Policy(&fold_policy);
+    result_types[0] = result_ty;
+    memset(&fold_candidate, 0, sizeof(fold_candidate));
+    fold_candidate.dsl_operator = dsl_operator;
+    fold_candidate.version = version;
+    fold_candidate.result_count = 1;
+    fold_candidate.operand_count = 2;
+    fold_candidate.operands = operands;
+    fold_candidate.operand_ty = operand_ty;
+    fold_candidate.result_ty = result_types;
+    fold_candidate.attributes = fold_attrs;
+    fold_candidate.attribute_count = attr_count;
+    fold_candidate.policy = &fold_policy;
+    DSL_TENSOR_FOLD_STATUS fold_status =
+        Targ_DSL_WhirlOp(&fold_candidate, &fold_output);
+    delete [] fold_attrs;
+    if (fold_status != DSL_TENSOR_FOLD_SUCCESS ||
+        fold_output.result_count != 1 ||
+        fold_output.results[0].kind != DSL_TENSOR_FOLD_RESULT_TCON ||
+        fold_output.results[0].result_ty != result_ty)
+        return NULL;
+
+    if (!DSL_Tensor_TCON_Find_Carrier
+             (&fold_output.results[0].result, &folded_tcon) ||
+        !DSL_Tensor_TCON_Get(folded_tcon, &folded_record))
+        return NULL;
+
+    dtype = TY_tensor_attribute(result_ty, TY_TENSOR_SCHEMA_DTYPE);
+    shape = TY_tensor_attribute(result_ty, TY_TENSOR_SCHEMA_SHAPE);
+    rank = TY_tensor_rank(result_ty);
+    if (dtype == NULL || shape == NULL || rank < 0)
+        return NULL;
+    snprintf(folded_text, sizeof(folded_text), "%lld",
+             (long long)folded_record.scalar_integer_value);
+    folded_value = DSL_Builder_Create_Tensor_Constant_Value
+                       (result_name, result_ty, dtype, rank, shape,
+                        "splat", folded_text, folded_tcon);
+    if (folded_value != NULL) {
+        DSL_BUILDER_VALUE_RECORD *folded_value_record =
+            DSL_Builder_Find_Value_Record(folded_value);
+        ST_tensor_bind_metadata
+            (folded_value_record->result_st, "tensor_fold.origin",
+             DSL_OPERATOR_name(dsl_operator));
+    }
+    return folded_value;
 }
 
 DSL_BUILDER_OPERATOR
@@ -2716,6 +2996,11 @@ DSL_Builder_Create_Operator_With_Result
             (dsl_operator, version, canonical_kids, kid_count);
         effective_kids = canonical_kids;
     }
+    result = DSL_Builder_Try_Fold_Tensor_Binary
+                 (dsl_operator, version, effective_kids, kid_count,
+                  attrs, attr_count, result_name, result_ty);
+    if (result != NULL)
+        return result;
     payload = DSL_Builder_Format_Operator_Payload
                   (effective_kids, kid_count, attrs, attr_count);
     result = DSL_Builder_Create_Native_Value
@@ -2956,6 +3241,7 @@ DSL_Builder_Declare_PU_Formal
     value_record.result_ty = ty;
     value_record.image_value_id = image_value_id;
     value_record.value_kind = DSL_IR_VALUE_SYMBOL;
+    value_record.tensor_tcon = TCON_IDX_ZERO;
     value_record.canonical_key = DSL_Builder_Value_Canonical_Key
                                      (OPR_DSLUNKNOWN, 0, ty, NULL, 0,
                                       NULL, 0, name);
@@ -3021,6 +3307,7 @@ DSL_Builder_Declare_PU_Result
     value_record.result_ty = ty;
     value_record.image_value_id = image_value_id;
     value_record.value_kind = DSL_IR_VALUE_SYMBOL;
+    value_record.tensor_tcon = TCON_IDX_ZERO;
     value_record.canonical_key = DSL_Builder_Value_Canonical_Key
                                      (OPR_DSLUNKNOWN, 0, ty, NULL, 0,
                                       NULL, 0, name);
@@ -3209,6 +3496,7 @@ DSL_Builder_Create_PU_Call
         value_record.result_ty = result_ty;
         value_record.image_value_id = image_value_id;
         value_record.value_kind = DSL_IR_VALUE_SYMBOL;
+        value_record.tensor_tcon = TCON_IDX_ZERO;
         value_record.canonical_key = DSL_Builder_Value_Canonical_Key
                                          (OPR_DSLUNKNOWN, 0, result_ty,
                                           NULL, 0, NULL, 0,

--- a/osprey/common/com/dsl_builder.h
+++ b/osprey/common/com/dsl_builder.h
@@ -149,6 +149,8 @@ typedef DSL_BUILDER_MARKER_INFO DSL_BUILDER_VALUE_INFO;
  */
 extern void DSL_Builder_Set_Canonicalization_Enabled (BOOL enabled);
 extern BOOL DSL_Builder_Canonicalization_Enabled (void);
+extern void DSL_Builder_Set_Tensor_Folding_Enabled (BOOL enabled);
+extern BOOL DSL_Builder_Tensor_Folding_Enabled (void);
 extern TY_IDX DSL_Builder_Create_Tensor_Type_Core
                                 (const char *name,
                                  TY_IDX element_ty,

--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "opcode.h"
 #include "dsl_tensor_fold.h"
 #include "strtab.h"
 #ifdef DSL_TENSOR_FOLD_TEST_STUB
@@ -933,6 +934,130 @@ DSL_Tensor_Fold_Apply_Mock
     return response->status;
 }
 
+static BOOL
+DSL_Tensor_Fold_Compact_Record
+        (const TCON *carrier,
+         DSL_TENSOR_TCON_RECORD *record)
+{
+    if (!DSL_Tensor_TCON_Decode_Carrier(carrier, record))
+        return FALSE;
+
+    return record->storage_kind == DSL_TENSOR_TCON_STORAGE_ZERO ||
+           record->storage_kind == DSL_TENSOR_TCON_STORAGE_ONE ||
+           record->storage_kind == DSL_TENSOR_TCON_STORAGE_SPLAT;
+}
+
+static DSL_TENSOR_FOLD_STATUS
+DSL_Tensor_Fold_Compact_Integer_Binary
+        (const DSL_TENSOR_FOLD_CANDIDATE *candidate,
+         DSL_TENSOR_FOLD_OUTPUT *output)
+{
+    DSL_TENSOR_TCON_RECORD left_record;
+    DSL_TENSOR_TCON_RECORD right_record;
+    DSL_TENSOR_TCON_CREATE_INFO result_info;
+    OPERATOR whirl_operator;
+    TYPE_ID element_mtype;
+    TCON left_scalar;
+    TCON right_scalar;
+    TCON result_scalar;
+    TCON result_carrier;
+    TCON_IDX result_scalar_idx;
+    TCON_IDX result_tcon_idx = TCON_IDX_ZERO;
+    INT64 result_value;
+    BOOL folded = FALSE;
+    BOOL created;
+
+    if (candidate->operand_count != 2 || candidate->result_count != 1)
+        return DSL_TENSOR_FOLD_REJECT_MALFORMED_CANDIDATE;
+    if (!DSL_Tensor_Fold_Compact_Record
+             (&candidate->operands[0], &left_record) ||
+        !DSL_Tensor_Fold_Compact_Record
+             (&candidate->operands[1], &right_record))
+        return DSL_TENSOR_FOLD_REJECT_NON_CONSTANT_OPERAND;
+    if (left_record.descriptor_ty != candidate->operand_ty[0] ||
+        right_record.descriptor_ty != candidate->operand_ty[1] ||
+        left_record.descriptor_ty != right_record.descriptor_ty ||
+        left_record.descriptor_ty != candidate->result_ty[0] ||
+        left_record.element_mtype != right_record.element_mtype ||
+        left_record.element_count != right_record.element_count ||
+        left_record.logical_bytes != right_record.logical_bytes)
+        return DSL_TENSOR_FOLD_REJECT_DESCRIPTOR_MISMATCH;
+
+    element_mtype = (TYPE_ID)left_record.element_mtype;
+    if (!MTYPE_is_integral(element_mtype))
+        return DSL_TENSOR_FOLD_REJECT_NUMERIC_POLICY;
+    if (candidate->policy != NULL &&
+        !candidate->policy->preserve_compact_splats)
+        return DSL_TENSOR_FOLD_REJECT_MATERIALIZATION_POLICY;
+    if (candidate->policy != NULL &&
+        ((candidate->policy->max_result_elements != 0 &&
+          left_record.element_count >
+              candidate->policy->max_result_elements) ||
+         (candidate->policy->max_evaluator_work != 0 &&
+          left_record.element_count >
+              candidate->policy->max_evaluator_work)))
+        return DSL_TENSOR_FOLD_REJECT_WORK_BUDGET;
+
+    switch (candidate->dsl_operator) {
+    case OPR_DSLADD:
+        whirl_operator = OPR_ADD;
+        break;
+    case OPR_DSLMUL:
+        whirl_operator = OPR_MPY;
+        break;
+    default:
+        return DSL_TENSOR_FOLD_REJECT_UNSUPPORTED_EVALUATOR;
+    }
+
+    left_scalar = TCON_from_IDX(left_record.scalar_tcon);
+    right_scalar = TCON_from_IDX(right_record.scalar_tcon);
+    result_scalar = Targ_WhirlOp
+                        (OPCODE_make_op(whirl_operator, element_mtype,
+                                        MTYPE_V),
+                         left_scalar, right_scalar, &folded);
+    if (!folded || TCON_ty(result_scalar) != element_mtype)
+        return DSL_TENSOR_FOLD_REJECT_TARGET_CAPABILITY;
+
+    result_scalar_idx = Enter_tcon(result_scalar);
+    if (result_scalar_idx == TCON_IDX_ZERO)
+        return DSL_TENSOR_FOLD_REJECT_MATERIALIZATION_POLICY;
+
+    memset(&result_info, 0, sizeof(result_info));
+    result_info.descriptor_ty = candidate->result_ty[0];
+    result_info.scalar_tcon = result_scalar_idx;
+    result_info.element_mtype = element_mtype;
+    result_info.element_count = left_record.element_count;
+    result_info.logical_bytes = left_record.logical_bytes;
+    result_info.required_alignment =
+        left_record.required_alignment > right_record.required_alignment ?
+            left_record.required_alignment : right_record.required_alignment;
+    result_info.element_size = left_record.element_size;
+    result_value = Targ_To_Host(result_scalar);
+    result_info.scalar_integer_value = result_value;
+
+    if (result_value == 0)
+        created = DSL_Tensor_TCON_Create_Zero
+                      (&result_info, &result_tcon_idx, &result_carrier);
+    else if (result_value == 1)
+        created = DSL_Tensor_TCON_Create_One
+                      (&result_info, &result_tcon_idx, &result_carrier);
+    else
+        created = DSL_Tensor_TCON_Create_Splat
+                      (&result_info, &result_tcon_idx, &result_carrier);
+    if (!created || result_tcon_idx == TCON_IDX_ZERO)
+        return DSL_TENSOR_FOLD_REJECT_MATERIALIZATION_POLICY;
+
+    if (output != NULL) {
+        output->status = DSL_TENSOR_FOLD_SUCCESS;
+        output->rejection = DSL_TENSOR_FOLD_NOT_APPLICABLE;
+        output->result_count = 1;
+        output->results[0].kind = DSL_TENSOR_FOLD_RESULT_TCON;
+        output->results[0].result_ty = candidate->result_ty[0];
+        output->results[0].result = result_carrier;
+    }
+    return DSL_TENSOR_FOLD_SUCCESS;
+}
+
 DSL_TENSOR_FOLD_STATUS
 Targ_DSL_WhirlOp
         (const DSL_TENSOR_FOLD_CANDIDATE *candidate,
@@ -950,9 +1075,10 @@ Targ_DSL_WhirlOp
     if (DSL_tensor_fold_mock_enabled)
         return DSL_Tensor_Fold_Apply_Mock(candidate, output);
 
-    DSL_Tensor_Fold_Set_Output_Status(output,
-                                      DSL_TENSOR_FOLD_NOT_APPLICABLE);
-    return DSL_TENSOR_FOLD_NOT_APPLICABLE;
+    reason = DSL_Tensor_Fold_Compact_Integer_Binary(candidate, output);
+    if (reason != DSL_TENSOR_FOLD_SUCCESS)
+        DSL_Tensor_Fold_Set_Output_Status(output, reason);
+    return reason;
 }
 
 void
@@ -1003,6 +1129,43 @@ DSL_Tensor_TCON_Get
 
     carrier = TCON_from_IDX(tcon_idx);
     return DSL_Tensor_TCON_Decode_Carrier(&carrier, record);
+}
+
+BOOL
+DSL_Tensor_TCON_Get_Carrier
+        (TCON_IDX tcon_idx,
+         TCON *carrier)
+{
+    DSL_TENSOR_TCON_RECORD record;
+
+    if (carrier != NULL)
+        TCON_clear(*carrier);
+    if (carrier == NULL || !DSL_Tensor_TCON_IDX_Valid(tcon_idx))
+        return FALSE;
+
+    *carrier = TCON_from_IDX(tcon_idx);
+    return DSL_Tensor_TCON_Decode_Carrier(carrier, &record);
+}
+
+BOOL
+DSL_Tensor_TCON_Find_Carrier
+        (const TCON *carrier,
+         TCON_IDX *tcon_idx)
+{
+    DSL_TENSOR_TCON_RECORD record;
+    TCON_IDX found;
+
+    if (tcon_idx != NULL)
+        *tcon_idx = TCON_IDX_ZERO;
+    if (carrier == NULL || tcon_idx == NULL ||
+        !DSL_Tensor_TCON_Decode_Carrier(carrier, &record))
+        return FALSE;
+
+    found = DSL_Tensor_TCON_Find_Cached_Equal(&record, carrier);
+    if (found == TCON_IDX_ZERO)
+        return FALSE;
+    *tcon_idx = found;
+    return TRUE;
 }
 
 BOOL

--- a/osprey/common/com/dsl_tensor_fold.h
+++ b/osprey/common/com/dsl_tensor_fold.h
@@ -200,6 +200,12 @@ extern void DSL_Tensor_TCON_Rebuild_Derived_Cache
 extern BOOL DSL_Tensor_TCON_Get
                                 (TCON_IDX tcon_idx,
                                  DSL_TENSOR_TCON_RECORD *record);
+extern BOOL DSL_Tensor_TCON_Get_Carrier
+                                (TCON_IDX tcon_idx,
+                                 TCON *carrier);
+extern BOOL DSL_Tensor_TCON_Find_Carrier
+                                (const TCON *carrier,
+                                 TCON_IDX *tcon_idx);
 extern BOOL DSL_Tensor_TCON_Is_Carrier
                                 (TCON_IDX tcon_idx,
                                  DSL_TENSOR_TCON_RECORD *record);

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -1748,6 +1748,241 @@ Check_Algebraic_Canonicalization(void)
     return failed;
 }
 
+static BOOL
+DSL_Test_Value_Has_Opcode
+        (DSL_BUILDER_VALUE value,
+         const char *opcode_name)
+{
+    DSL_BUILDER_VALUE_INFO info;
+
+    return value != NULL && opcode_name != NULL &&
+           DSL_Builder_Get_Value_Info(value, &info) &&
+           info.opcode_name_len == strlen(opcode_name) &&
+           strncmp(info.opcode_name, opcode_name,
+                   info.opcode_name_len) == 0;
+}
+
+static int
+Check_Construction_Tensor_Folding(void)
+{
+    const char *artifact =
+        getenv("OPEN64_DSL_TENSOR_FOLD_M3_ARTIFACT");
+    DSL_BUILDER_TENSOR_DESCRIPTOR descriptor;
+    DSL_BUILDER_OPERATOR_ATTRIBUTE attribute;
+    DSL_BUILDER_COMPILER_METADATA metadata;
+    DSL_BUILDER_SOURCE_POSITION source_position;
+    DSL_BUILDER_MAPPED_IMAGE_REQUEST request;
+    DSL_BUILDER_VERIFY_RESULT verify;
+    DSL_BUILDER_VALUE kids[2];
+    DSL_BUILDER_VALUE constants[4];
+    DSL_BUILDER_VALUE disabled_add;
+    DSL_BUILDER_VALUE folded_add;
+    DSL_BUILDER_VALUE folded_mul;
+    DSL_BUILDER_VALUE folded_parent;
+    DSL_BUILDER_VALUE runtime_input;
+    DSL_BUILDER_VALUE rejected_add;
+    DSL_BUILDER_VALUE master_disabled;
+    DSL_BUILDER_PROGRAM_UNIT pu;
+    DSL_DOMAIN_ID common_id;
+    DSL_OPCODE_ID add_id;
+    DSL_OPCODE_ID mul_id;
+    TY_IDX tensor_ty;
+    BOOL saved_wn_simp = Enable_WN_Simp;
+    BOOL saved_canonicalization = DSL_Builder_Canonicalization_Enabled();
+    BOOL saved_tensor_folding = DSL_Builder_Tensor_Folding_Enabled();
+    UINT32 file_id;
+    char diagnostic[1024];
+    int failed = 0;
+
+    if (artifact == NULL || artifact[0] == '\0')
+        artifact = "dsl_tensor_fold_m3.B";
+
+    DSL_Builder_Begin_Program();
+    DSL_Opcode_Register_Common_Substrate();
+    memset(&descriptor, 0, sizeof(descriptor));
+    descriptor.type_core.kind = "tensor";
+    descriptor.type_core.dtype = "int32";
+    descriptor.type_core.rank = 2;
+    descriptor.type_core.logical_shape = "[2,2]";
+    tensor_ty = DSL_Builder_Intern_Tensor_Type
+                    ("tensor_fold_m3_i32_2x2", MTYPE_To_TY(MTYPE_I4),
+                     &descriptor);
+    common_id = DSL_Domain_Find("common");
+    add_id = DSL_Opcode_Find(common_id, DSL_OPCODE_COMMON_ADD, 1);
+    mul_id = DSL_Opcode_Find(common_id, DSL_OPCODE_COMMON_MUL, 1);
+    pu = DSL_Builder_Create_Minimal_PU("tensor_fold_m3_contract");
+    file_id = DSL_Builder_Register_Source_File(pu, __FILE__);
+    if (tensor_ty == TY_IDX_ZERO || add_id == DSL_OPCODE_INVALID_ID ||
+        mul_id == DSL_OPCODE_INVALID_ID || pu == NULL || file_id == 0) {
+        fprintf(stderr, "M3 tensor folding setup failed\n");
+        return 1;
+    }
+
+    constants[0] = DSL_Builder_Create_Tensor_Constant
+                       ("zero", tensor_ty, "int32", 2, "[2,2]",
+                        "splat", "0");
+    constants[1] = DSL_Builder_Create_Tensor_Constant
+                       ("one", tensor_ty, "int32", 2, "[2,2]",
+                        "splat", "1");
+    constants[2] = DSL_Builder_Create_Tensor_Constant
+                       ("three", tensor_ty, "int32", 2, "[2,2]",
+                        "splat", "3");
+    constants[3] = DSL_Builder_Create_Tensor_Constant
+                       ("four", tensor_ty, "int32", 2, "[2,2]",
+                        "splat", "4");
+    for (UINT32 i = 0; i < 4; ++i) {
+        if (constants[i] == NULL) {
+            fprintf(stderr, "M3 compact tensor constant creation failed\n");
+            return 1;
+        }
+    }
+
+    attribute.name = "attr.broadcast_rule";
+    attribute.value = "none";
+    Enable_WN_Simp = TRUE;
+    DSL_Builder_Set_Canonicalization_Enabled(TRUE);
+    DSL_Builder_Set_Tensor_Folding_Enabled(FALSE);
+    kids[0] = constants[0];
+    kids[1] = constants[1];
+    disabled_add = DSL_Builder_Create_Operator_With_Result
+                       (add_id, 1, kids, 2, &attribute, 1,
+                        "disabled_add", tensor_ty);
+
+    DSL_Builder_Set_Tensor_Folding_Enabled(TRUE);
+    folded_add = DSL_Builder_Create_Operator_With_Result
+                     (add_id, 1, kids, 2, &attribute, 1,
+                      "folded_add", tensor_ty);
+    kids[0] = constants[2];
+    kids[1] = constants[3];
+    folded_mul = DSL_Builder_Create_Operator_With_Result
+                     (mul_id, 1, kids, 2, &attribute, 1,
+                      "folded_mul", tensor_ty);
+    kids[0] = folded_add;
+    kids[1] = folded_mul;
+    folded_parent = DSL_Builder_Create_Operator_With_Result
+                        (add_id, 1, kids, 2, &attribute, 1,
+                         "folded_parent", tensor_ty);
+
+    runtime_input = DSL_Builder_Create_Model_Input
+                        ("runtime_input", tensor_ty, 0);
+    kids[0] = runtime_input;
+    kids[1] = constants[1];
+    rejected_add = DSL_Builder_Create_Operator_With_Result
+                       (add_id, 1, kids, 2, &attribute, 1,
+                        "rejected_add", tensor_ty);
+
+    Enable_WN_Simp = FALSE;
+    kids[0] = constants[2];
+    kids[1] = constants[3];
+    master_disabled = DSL_Builder_Create_Operator_With_Result
+                          (add_id, 1, kids, 2, &attribute, 1,
+                           "master_disabled_add", tensor_ty);
+    Enable_WN_Simp = TRUE;
+
+    if (!DSL_Test_Value_Has_Opcode(disabled_add,
+                                   DSL_OPCODE_COMMON_ADD) ||
+        !DSL_Test_Value_Has_Opcode(folded_add,
+                                   DSL_OPCODE_COMMON_TENSOR_CONST) ||
+        !DSL_Test_Value_Has_Opcode(folded_mul,
+                                   DSL_OPCODE_COMMON_TENSOR_CONST) ||
+        !DSL_Test_Value_Has_Opcode(folded_parent,
+                                   DSL_OPCODE_COMMON_TENSOR_CONST) ||
+        !DSL_Test_Value_Has_Opcode(rejected_add,
+                                   DSL_OPCODE_COMMON_ADD) ||
+        !DSL_Test_Value_Has_Opcode(master_disabled,
+                                   DSL_OPCODE_COMMON_ADD)) {
+        fprintf(stderr, "M3 enabled/disabled operator evidence changed\n");
+        failed = 1;
+    }
+
+    ST_IDX folded_add_st = DSL_Builder_Get_Value_Result_Symbol(folded_add);
+    ST_IDX folded_mul_st = DSL_Builder_Get_Value_Result_Symbol(folded_mul);
+    const char *add_tcon =
+        ST_tensor_metadata(folded_add_st, "tensor_tcon_idx");
+    const char *mul_tcon =
+        ST_tensor_metadata(folded_mul_st, "tensor_tcon_idx");
+    const char *add_origin =
+        ST_tensor_metadata(folded_add_st, "tensor_fold.origin");
+    const char *mul_origin =
+        ST_tensor_metadata(folded_mul_st, "tensor_fold.origin");
+    if (ST_IDX_index(folded_add_st) == 0 ||
+        ST_IDX_index(folded_mul_st) == 0 ||
+        strcmp(ST_name(St_Table[folded_add_st]), "folded_add") != 0 ||
+        strcmp(ST_name(St_Table[folded_mul_st]), "folded_mul") != 0 ||
+        add_tcon == NULL || mul_tcon == NULL ||
+        add_origin == NULL || strcmp(add_origin, "OPR_DSLADD") != 0 ||
+        mul_origin == NULL || strcmp(mul_origin, "OPR_DSLMUL") != 0) {
+        fprintf(stderr, "M3 folded result identity was not preserved\n");
+        failed = 1;
+    }
+    DSL_BUILDER_VALUE_INFO folded_parent_info;
+    if (!DSL_Builder_Get_Value_Info(folded_parent, &folded_parent_info) ||
+        folded_parent_info.payload == NULL ||
+        strstr(folded_parent_info.payload, "value=13") == NULL) {
+        fprintf(stderr, "M3 folded parent was not revisited bottom-up\n");
+        failed = 1;
+    }
+
+    memset(&source_position, 0, sizeof(source_position));
+    source_position.file_id = file_id;
+    source_position.line = __LINE__ + 1;
+    source_position.column = 1;
+    source_position.statement_begin = 1;
+    if (!DSL_Builder_Set_Value_Source_Position
+             (folded_add, &source_position)) {
+        fprintf(stderr, "M3 folded source position was not preserved\n");
+        failed = 1;
+    }
+    metadata.name = "source.expression";
+    metadata.value = "zero + one";
+    const char *source_expression;
+    if (!DSL_Builder_Attach_Value_Metadata(folded_add, &metadata, 1))
+        source_expression = NULL;
+    else
+        source_expression =
+            ST_tensor_metadata(folded_add_st, "source.expression");
+    if (source_expression == NULL ||
+        strcmp(source_expression, "zero + one") != 0) {
+        fprintf(stderr, "M3 folded compiler metadata was not preserved\n");
+        failed = 1;
+    }
+
+    DSL_BUILDER_VALUE values[] = {
+        disabled_add, folded_add, folded_mul, folded_parent,
+        rejected_add, master_disabled
+    };
+    for (UINT32 i = 0; i < sizeof(values) / sizeof(values[0]); ++i) {
+        if (values[i] == NULL ||
+            !DSL_Builder_Append_PU_Value(pu, values[i])) {
+            fprintf(stderr, "M3 folded value materialization failed\n");
+            failed = 1;
+        }
+    }
+
+    request.path = artifact;
+    request.flags = 0;
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    if (!failed && !DSL_Builder_Verify_Program(&verify)) {
+        fprintf(stderr, "M3 tensor fold gatekeeper failed: %s\n",
+                diagnostic);
+        failed = 1;
+    }
+    if (!failed && !DSL_Builder_Finalize_Mapped_Image(&request)) {
+        fprintf(stderr, "M3 tensor fold mapped-image finalization failed\n");
+        failed = 1;
+    }
+
+    DSL_Builder_Set_Tensor_Folding_Enabled(saved_tensor_folding);
+    DSL_Builder_Set_Canonicalization_Enabled(saved_canonicalization);
+    Enable_WN_Simp = saved_wn_simp;
+    if (!failed)
+        printf("DSL construction tensor folding contract passed\n");
+    return failed;
+}
+
 static int
 Check_Native_DSL_Node_Layout(void)
 {
@@ -4108,6 +4343,8 @@ main(void)
         return Check_Multiple_Program_Units();
     if (getenv("OPEN64_DSL_CANONICALIZATION_ONLY") != NULL)
         return Check_Algebraic_Canonicalization();
+    if (getenv("OPEN64_DSL_TENSOR_FOLD_M3_ONLY") != NULL)
+        return Check_Construction_Tensor_Folding();
     if (getenv("OPEN64_DSL_SIMPLIFIER_ONLY") != NULL)
         return Check_DSL_Simplifier_Bridge();
     if (getenv("OPEN64_DSL_TENSOR_TCON_ONLY") != NULL)

--- a/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
@@ -106,10 +106,10 @@ Check_Candidate_Contract(void)
     }
 
     if (Targ_DSL_WhirlOp(&candidate, &output) !=
-            DSL_TENSOR_FOLD_NOT_APPLICABLE ||
-        output.status != DSL_TENSOR_FOLD_NOT_APPLICABLE ||
+            DSL_TENSOR_FOLD_REJECT_NON_CONSTANT_OPERAND ||
+        output.status != DSL_TENSOR_FOLD_REJECT_NON_CONSTANT_OPERAND ||
         output.result_count != 0) {
-        fprintf(stderr, "production tensor fold fallback changed\n");
+        fprintf(stderr, "non-constant tensor fold rejection changed\n");
         return 1;
     }
 
@@ -619,6 +619,130 @@ Check_Tensor_TCON_Storage(void)
     return 0;
 }
 
+static TCON_IDX
+Test_Integer_TCON (INT64 value)
+{
+    TCON scalar;
+
+    TCON_clear(scalar);
+    Set_TCON_ty(scalar, MTYPE_I4);
+    scalar.vals.i0 = value;
+    return Enter_tcon(scalar);
+}
+
+static int
+Check_Compact_Integer_Evaluator(void)
+{
+    DSL_TENSOR_TCON_CREATE_INFO info;
+    DSL_TENSOR_TCON_RECORD result_record;
+    DSL_TENSOR_FOLD_POLICY policy;
+    DSL_TENSOR_FOLD_CANDIDATE candidate;
+    DSL_TENSOR_FOLD_OUTPUT output;
+    TCON operands[2];
+    TY_IDX operand_ty[2];
+    TY_IDX result_ty[1];
+    TCON_IDX one_idx;
+    TCON_IDX three_idx;
+    TCON_IDX dense_idx;
+    unsigned char dense_bytes[16];
+
+    Initialize_Strtab(1024);
+    DSL_Tensor_TCON_Reset();
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = Test_Tensor_Type(101);
+    info.element_mtype = MTYPE_I4;
+    info.element_size = 4;
+    info.element_count = 4;
+    info.logical_bytes = 16;
+    info.required_alignment = 4;
+
+    info.scalar_tcon = Test_Integer_TCON(1);
+    info.scalar_integer_value = 1;
+    if (!DSL_Tensor_TCON_Create_One(&info, &one_idx, NULL))
+        return 1;
+    info.scalar_tcon = Test_Integer_TCON(3);
+    info.scalar_integer_value = 3;
+    if (!DSL_Tensor_TCON_Create_Splat(&info, &three_idx, NULL) ||
+        !DSL_Tensor_TCON_Get_Carrier(one_idx, &operands[0]) ||
+        !DSL_Tensor_TCON_Get_Carrier(three_idx, &operands[1]))
+        return 1;
+
+    operand_ty[0] = info.descriptor_ty;
+    operand_ty[1] = info.descriptor_ty;
+    result_ty[0] = info.descriptor_ty;
+    DSL_Tensor_Fold_Default_Policy(&policy);
+    memset(&candidate, 0, sizeof(candidate));
+    candidate.dsl_operator = OPR_DSLADD;
+    candidate.version = 1;
+    candidate.result_count = 1;
+    candidate.operand_count = 2;
+    candidate.operands = operands;
+    candidate.operand_ty = operand_ty;
+    candidate.result_ty = result_ty;
+    candidate.policy = &policy;
+    DSL_TENSOR_FOLD_STATUS status =
+        Targ_DSL_WhirlOp(&candidate, &output);
+    if (status != DSL_TENSOR_FOLD_SUCCESS ||
+        output.result_count != 1 ||
+        !DSL_Tensor_TCON_Decode_Carrier
+             (&output.results[0].result, &result_record) ||
+        result_record.storage_kind != DSL_TENSOR_TCON_STORAGE_SPLAT ||
+        result_record.scalar_integer_value != 4) {
+        fprintf(stderr,
+                "compact integer tensor add evaluation changed: %s\n",
+                DSL_Tensor_Fold_Status_Name(status));
+        return 1;
+    }
+
+    policy.preserve_compact_splats = FALSE;
+    if (Targ_DSL_WhirlOp(&candidate, &output) !=
+            DSL_TENSOR_FOLD_REJECT_MATERIALIZATION_POLICY) {
+        fprintf(stderr, "compact tensor materialization policy changed\n");
+        return 1;
+    }
+    policy.preserve_compact_splats = TRUE;
+
+    candidate.dsl_operator = OPR_DSLMUL;
+    operands[0] = operands[1];
+    if (Targ_DSL_WhirlOp(&candidate, &output) !=
+            DSL_TENSOR_FOLD_SUCCESS ||
+        !DSL_Tensor_TCON_Decode_Carrier
+             (&output.results[0].result, &result_record) ||
+        result_record.scalar_integer_value != 9) {
+        fprintf(stderr, "compact integer tensor multiply evaluation changed\n");
+        return 1;
+    }
+
+    memset(dense_bytes, 1, sizeof(dense_bytes));
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = result_ty[0];
+    info.element_mtype = MTYPE_I4;
+    info.element_size = 4;
+    info.element_count = 4;
+    info.logical_bytes = 16;
+    info.required_alignment = 4;
+    info.dense_bytes = dense_bytes;
+    info.dense_bytes_length = sizeof(dense_bytes);
+    info.checksum_hi = 1;
+    if (!DSL_Tensor_TCON_Create_Inline_Dense
+             (&info, &dense_idx, &operands[0]) ||
+        Targ_DSL_WhirlOp(&candidate, &output) !=
+            DSL_TENSOR_FOLD_REJECT_NON_CONSTANT_OPERAND ||
+        output.result_count != 0) {
+        fprintf(stderr, "dense tensor fold rejection changed\n");
+        return 1;
+    }
+
+    DSL_Tensor_TCON_Get_Carrier(three_idx, &operands[0]);
+    policy.max_evaluator_work = 2;
+    if (Targ_DSL_WhirlOp(&candidate, &output) !=
+            DSL_TENSOR_FOLD_REJECT_WORK_BUDGET) {
+        fprintf(stderr, "tensor evaluator work budget changed\n");
+        return 1;
+    }
+    return 0;
+}
+
 int
 main(void)
 {
@@ -631,9 +755,10 @@ main(void)
         Check_Evaluator_Identity() ||
         Check_Candidate_Contract() ||
         Check_Mock_Evaluator() ||
-        Check_Tensor_TCON_Storage())
+        Check_Tensor_TCON_Storage() ||
+        Check_Compact_Integer_Evaluator())
         return 1;
 
-    printf("DSL tensor fold M2 storage contract passed\n");
+    printf("DSL tensor fold M3 compact evaluator contract passed\n");
     return 0;
 }

--- a/osprey/common/com/tests/dsl_tensor_fold_m3_image_test.sh
+++ b/osprey/common/com/tests/dsl_tensor_fold_m3_image_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Preserve construction-time tensor folding evidence for human review.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+build_dir="${OPEN64_BUILD_DIR:-$repo_root/build}"
+producer_default="$build_dir/osprey/targdir/ir_tools/dsl_builder_contract_test"
+producer="${OPEN64_DSL_CONTRACT_TEST:-$producer_default}"
+ir_b2a="${OPEN64_IR_B2A:-$build_dir/osprey/targdir/ir_tools/ir_b2a}"
+artifact_default="$repo_root/artifacts/m3-tensor-fold"
+artifact_dir="${OPEN64_DSL_TENSOR_FOLD_M3_ARTIFACT_DIR:-$artifact_default}"
+image="$artifact_dir/tensor_fold_m3.B"
+trace="$artifact_dir/tensor_fold_m3.T"
+
+for executable in "$producer" "$ir_b2a"; do
+  if [[ ! -x "$executable" ]]; then
+    echo "missing executable: $executable" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$artifact_dir"
+find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -delete
+
+OPEN64_DSL_TENSOR_FOLD_M3_ONLY=1 \
+OPEN64_DSL_TENSOR_FOLD_M3_ARTIFACT="$image" \
+  "$producer" > "$artifact_dir/producer.log" 2>&1
+
+"$ir_b2a" -st -src "$image" "$trace"
+
+for evidence in \
+  "operator=OPR_DSLADD version=1 operands=[value1,value2]" \
+  "name=folded_add;dtype=int32;rank=2;shape=[2,2];value_kind=splat;value=1" \
+  "name=folded_mul;dtype=int32;rank=2;shape=[2,2];value_kind=splat;value=12" \
+  "name=folded_parent;dtype=int32;rank=2;shape=[2,2];"\
+"value_kind=splat;value=13" \
+  "name=rejected_add" \
+  "name=master_disabled_add" \
+  "tensor_fold.origin = OPR_DSLADD" \
+  "tensor_fold.origin = OPR_DSLMUL" \
+  "source.expression = zero + one" \
+  "tensor_tcon storage=splat"; do
+  if ! grep -Fq "$evidence" "$trace"; then
+    echo "missing M3 tensor-fold evidence '$evidence' in $trace" >&2
+    exit 1
+  fi
+done
+
+if grep -Fq "operator=OPR_DSLMUL version=1 operands=[" "$trace"; then
+  echo "folded common.mul remained in the DSL node table" >&2
+  exit 1
+fi
+
+cat > "$artifact_dir/certification.txt" <<EOF
+compact_add_fold=passed
+compact_mul_fold=passed
+bottom_up_parent_fold=passed
+stage_disabled_preserves_operator=passed
+master_disabled_preserves_operator=passed
+non_constant_rejection_preserves_operator=passed
+result_symbol_source_metadata=passed
+mapped_image_reopen=passed
+ir_b2a_st_src=passed
+EOF
+
+echo "DSL tensor fold M3 mapped-image fixture passed"
+echo "review artifacts: $artifact_dir"

--- a/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_strtab_stub.cxx
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "opcode.h"
 #include "strtab.h"
 #include "symtab_idx.h"
 #include "targ_const.h"
@@ -28,7 +29,9 @@ Initialize_Strtab (UINT32)
     TCON zero;
     TCON_clear(zero);
     DSL_tensor_fold_test_tcon_table.push_back(zero);
+    Machine_Types[MTYPE_I4].id = MTYPE_I4;
     Machine_Types[MTYPE_I4].name = "I4";
+    Machine_Types[MTYPE_I4].type_class_bits = MTYPE_CLASS_INTEGER;
 }
 
 void
@@ -132,6 +135,38 @@ Host_To_Targ_String (TYPE_ID ctype, const char *bytes, UINT32 length)
         result.vals.sval.cp = Save_StrN(bytes, saved_length);
     }
     result.vals.sval.len = length;
+    return result;
+}
+
+INT64
+Targ_To_Host (TCON value)
+{
+    return TCON_i0(value);
+}
+
+TCON
+Targ_WhirlOp (OPCODE opcode, TCON left, TCON right, BOOL *folded)
+{
+    TCON result;
+    INT64 value;
+
+    TCON_clear(result);
+    Set_TCON_ty(result, OPCODE_rtype(opcode));
+    switch (OPCODE_operator(opcode)) {
+    case OPR_ADD:
+        value = TCON_i0(left) + TCON_i0(right);
+        break;
+    case OPR_MPY:
+        value = TCON_i0(left) * TCON_i0(right);
+        break;
+    default:
+        if (folded != NULL)
+            *folded = FALSE;
+        return result;
+    }
+    result.vals.i0 = value;
+    if (folded != NULL)
+        *folded = TRUE;
     return result;
 }
 


### PR DESCRIPTION
## Summary

- add the first production `Targ_DSL_WhirlOp` evaluator for exact integral
  `common.add.v1` and `common.mul.v1` over compact ZERO, ONE, and SPLAT tensor
  TCON carriers
- route construction-time candidates through the traditional Open64
  prepare/apply/postprocess simplifier bridge before tensor evaluation
- publish successful folds as `common.tensor_const` values while preserving
  result identity and permitting bottom-up parent folding
- keep the new builder stage disabled by default and subordinate to
  `Enable_WN_Simp`
- retain unsupported dense and non-constant expressions as their original
  logical operators with structured rejection
- update both simplification plans and add mapped-image review evidence

This is the compact M3 vertical slice following the M2 tensor-TCON integration
merged through PR #95. It does not change the binary WHIRL or ELF layout.
INLINE_DENSE and SIDE_FILE_DENSE evaluation remain deferred until a reviewed
target-format element accessor exists.

## Validation

- Linux/amd64 Open64 build:
  `make -j4 dsl_builder_contract_test ir_b2a`
- `osprey/common/com/tests/dsl_native_syntax_test.sh`
- focused traditional simplifier and canonicalization producer lanes
- `osprey/common/com/tests/dsl_tensor_tcon_image_test.sh`
- `osprey/common/com/tests/dsl_tensor_fold_m3_image_test.sh`
- `git diff --check`, no-tab scan, and shell syntax check

The retained M3 trace proves compact add/multiply folding, a bottom-up parent
fold, stage-disabled and master-disabled behavior, non-constant rejection,
source/metadata preservation, mapped-image reopen, and `ir_b2a -st -src`
inspection.
