### PR TITLE
Add explicit VHO DSL simplification

### DIFF
--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -1042,9 +1042,10 @@ descriptor and constant propagation; revisit parents without recursively
 entering the folder.
 
 **Exit criteria:** construction-time and VHO-time folding share one legality,
-evaluator, publication, and trace contract. `-OPT:wn_simp` and `-DSL:canon`
-A/B artifacts distinguish the two simplification points without changing
-program results.
+evaluator, publication, and trace contract. `-OPT:wn_simp`, `-DSL:canon`, and
+`-DSL:algebraic` A/B artifacts distinguish construction simplification, VHO
+canonicalization/coefficient collection, and VHO tensor evaluation without
+changing program results.
 
 **Pull request:** VHO pipeline integration and canonicalization only.
 
@@ -1109,8 +1110,8 @@ capability per pull request. Do not use M7 as a miscellaneous cleanup batch.
 | M0 | Merged through PR #89/#92 | None | Contract/API test report |
 | M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
 | M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
-| M3 | Compact integral slice implemented and validated on `codex/dsl-simplifier-m3` | M2 merged | Enabled/disabled fold artifacts |
-| M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |
+| M3 | Merged through PR #96 | M2 merged | Enabled/disabled fold artifacts |
+| M4 | Implemented and validated on `codex/dsl-simplifier-m4` | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
 | M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
 | M7 | Blocked by M6 | M6 merged | Full certification matrix |
@@ -1190,6 +1191,17 @@ default, remains subordinate to `Enable_WN_Simp`, invokes the traditional
 three-step simplifier bridge before `Targ_DSL_WhirlOp`, publishes a
 `common.tensor_const` result, and permits the folded value to feed a parent
 fold. Dense payload evaluation remains deferred.
+
+The M4 VHO slice is implemented after the released descriptor- and
+constant-propagation stage positions. `-DSL:canon` controls deterministic
+operand order and the reviewed integer tensor coefficient rewrite
+`x+x -> 2*x`; the coefficient is a real compact tensor TCON and logical
+`common.tensor_const`. `-DSL:algebraic` independently controls all-constant
+tensor evaluation through the same `Targ_DSL_WhirlOp` service used by M3.
+Both rewrites update the physical WN and logical DSL image together while
+retaining the original result node/value identity, ST, TY, metadata, lineage,
+and statement SRCPOS. The retained M4 artifact reopens through
+`ir_b2a -st -src` without changing the `.WHIRL.dsl` row layout or version.
 
 ## Staged Action List
 

--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -1111,7 +1111,7 @@ capability per pull request. Do not use M7 as a miscellaneous cleanup batch.
 | M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
 | M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Merged through PR #96 | M2 merged | Enabled/disabled fold artifacts |
-| M4 | Implemented and validated on `codex/dsl-simplifier-m4` | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
+| M4 | PR #97 open; implemented and validated on `codex/dsl-simplifier-m4` | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
 | M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
 | M7 | Blocked by M6 | M6 merged | Full certification matrix |
@@ -1273,6 +1273,9 @@ and statement SRCPOS. The retained M4 artifact reopens through
 - Invoke tensor constant folding after descriptor and constant propagation
   have completed, publish the resulting `common.tensor_const`, and revisit
   affected parent expressions under their existing simplifier controls.
+- Treat publication atomicity as semantic mapped-image visibility: compact
+  relationship tables before exposing the replacement node, while permitting
+  ordinary unreferenced entries in Open64's global deduplicated TCON table.
 - Re-run the gatekeeper after the pass in validation builds and tests.
 
 ### S5: Reassociation and factorization

--- a/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
+++ b/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
@@ -568,7 +568,7 @@ range, and checksum.
 | M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
 | M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Merged through PR #96 | M2 merged | Enabled/disabled fold artifacts |
-| M4 | Implemented and validated on `codex/dsl-simplifier-m4` | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
+| M4 | PR #97 open; implemented and validated on `codex/dsl-simplifier-m4` | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
 | M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
 | M7 | Blocked by M6 | M6 merged | Full certification matrix |
@@ -596,6 +596,16 @@ node/value identity, publishes `common.tensor_const`, and revisits parent
 definitions without recursively entering the evaluator. Items below that
 mention dense payloads, side-file evaluation, WOPT, or DIVREM remain future
 work.
+
+M4 atomic publication means that a node's logical opcode, active operands,
+active attributes, payload, and result kind become visible as one coherent
+mapped-image relationship set. Rewriting compacts and renumbers the
+relationship tables so stale rows cannot survive in table-wide consumers or
+`ir_b2a -st -src`. This does not promise rollback of Open64's global,
+deduplicated TCON table: evaluator-created but ultimately unused TCON entries
+are legal in the same way as other unreferenced constants. Only a successfully
+published node and result-symbol binding makes a folded tensor constant
+semantically reachable.
 
 1. [x] Define a fixed-layout evaluator registry keyed by logical operator and
    version.

--- a/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
+++ b/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
@@ -567,8 +567,8 @@ range, and checksum.
 | M0 | Merged through PR #89/#92 | None | Contract/API test report |
 | M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
 | M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
-| M3 | Compact integral slice implemented and validated on `codex/dsl-simplifier-m3` | M2 merged | Enabled/disabled fold artifacts |
-| M4 | Blocked by M3 | M3 merged | Construction/VHO A/B artifacts |
+| M3 | Merged through PR #96 | M2 merged | Enabled/disabled fold artifacts |
+| M4 | Implemented and validated on `codex/dsl-simplifier-m4` | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
 | M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
 | M7 | Blocked by M6 | M6 merged | Full certification matrix |
@@ -588,10 +588,14 @@ their bytes to host integer pointers.
 
 The compact M3 slice is implemented through `Targ_WhirlOp` and
 `Targ_DSL_WhirlOp`. Construction-time publication is disabled by default and
-subordinate to `Enable_WN_Simp`. Its retained artifact proves enabled,
-stage-disabled, master-disabled, non-constant rejection, mapped-image reopen,
-and bottom-up parent-fold behavior. Items below that mention dense payloads,
-side-file publication, VHO, or WOPT remain future work.
+subordinate to `Enable_WN_Simp`. M4 adds a fixed-layout VHO replacement
+description, compact operand identification, integer-splat creation from a
+canonical TensorDescriptorIR, and the explicit VHO consumer under
+`-DSL:algebraic`. The consumer retains result ST/TY/SRCPOS and mapped-image
+node/value identity, publishes `common.tensor_const`, and revisits parent
+definitions without recursively entering the evaluator. Items below that
+mention dense payloads, side-file evaluation, WOPT, or DIVREM remain future
+work.
 
 1. [x] Define a fixed-layout evaluator registry keyed by logical operator and
    version.
@@ -611,10 +615,11 @@ side-file publication, VHO, or WOPT remain future work.
 9. [ ] After the projectable-operation contract is published, implement
    exact integer tensor DIVREM evaluation and quotient/remainder TCON
    projections.
-10. [ ] Publish folded constants atomically to the mapped image and side file.
+10. [x] Publish compact folded constants atomically to the mapped image.
+    Dense side-file evaluation and publication remain deferred.
 11. [x] Revisit affected parent expressions after successful compact
    publication.
-12. [ ] Preserve source position, result symbol, lineage, and descriptor
+12. [x] Preserve source position, result symbol, lineage, and descriptor
    identity.
 13. [ ] Add gatekeeper checks for carrier/record consistency, folded result
    descriptor, alignment, checksum, and payload size.

--- a/osprey/be/vho/dsl_lower.cxx
+++ b/osprey/be/vho/dsl_lower.cxx
@@ -1737,7 +1737,8 @@ VHO_DSL_Lower_Driver
               ("DSL gatekeeper rejected Very High Level WHIRL"));
 
     VHO_DSL_OPT_RESULT opt_result;
-    BOOL opt_valid = VHO_DSL_Optimize_Program_Unit
+    BOOL opt_valid = VHO_DSL_Opt_Register_Default_Passes() &&
+                     VHO_DSL_Optimize_Program_Unit
                          (pu_info, &tree, stderr, &opt_result);
     FmtAssert(opt_valid,
               ("DSL VHO optimization pipeline failed"));

--- a/osprey/be/vho/dsl_opt.cxx
+++ b/osprey/be/vho/dsl_opt.cxx
@@ -2,11 +2,26 @@
  * Copyright (C) 2026 Open64 Project
  */
 
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
 #include <string.h>
+#include <string>
+#include <vector>
 
 #include "dsl_opt.h"
 #include "config.h"
 #include "config_dsl.h"
+#include "dsl_builder.h"
+#include "dsl_ir_image.h"
+#include "dsl_opcode.h"
+#include "dsl_tensor_fold.h"
+#include "pu_info.h"
+#include "stab.h"
+#include "strtab.h"
+#include "symtab.h"
+#include "wn.h"
+#include "wn_util.h"
 
 static VHO_DSL_OPT_PASS VHO_DSL_opt_pass[VHO_DSL_OPT_STAGE_COUNT];
 
@@ -23,6 +38,625 @@ static const char *VHO_DSL_opt_stage_name[VHO_DSL_OPT_STAGE_COUNT] = {
     "parallelization",
     "implementation_selection"
 };
+
+static BOOL
+VHO_DSL_Is_Integer_Tensor (TY_IDX ty)
+{
+    return TY_is_tensor_extension(ty) &&
+           MTYPE_is_integral(TY_mtype(TY_tensor_element_ty(ty)));
+}
+
+static BOOL
+VHO_DSL_Image_Node_For_Result
+        (ST_IDX result_st,
+         const char *owner_pu,
+         DSL_IR_VALUE_RECORD *value,
+         DSL_IR_NODE_RECORD *node)
+{
+    const char *name = ST_name(St_Table[result_st]);
+
+    return DSL_IR_Image_Find_PU_Value
+               (result_st, name, owner_pu, value) &&
+           value->producer_node_id != DSL_IR_NODE_INVALID_ID &&
+           DSL_IR_Image_Get_Node(value->producer_node_id, node);
+}
+
+static BOOL
+VHO_DSL_Image_Value_For_Operand
+        (WN *operand,
+         const char *owner_pu,
+         DSL_IR_VALUE_RECORD *value)
+{
+    return operand != NULL && WN_operator(operand) == OPR_LDID &&
+           DSL_IR_Image_Find_PU_Value
+               (WN_st_idx(operand), ST_name(WN_st(operand)),
+                owner_pu, value);
+}
+
+static BOOL
+VHO_DSL_Copy_Node_Attributes
+        (const DSL_IR_NODE_RECORD *node,
+         std::vector<DSL_IR_ATTRIBUTE_RECORD> *attributes)
+{
+    attributes->clear();
+    for (UINT32 i = 0; i < node->attribute_count; ++i) {
+        DSL_IR_ATTRIBUTE_RECORD attribute;
+        if (!DSL_IR_Image_Get_Attribute
+                 (node->first_attribute_id + i, &attribute))
+            return FALSE;
+        attribute.id = DSL_IR_ATTRIBUTE_INVALID_ID;
+        attribute.owner_node_id = DSL_IR_NODE_INVALID_ID;
+        attributes->push_back(attribute);
+    }
+    return TRUE;
+}
+
+static std::string
+VHO_DSL_Binary_Payload
+        (WN *kid0,
+         WN *kid1,
+         const std::vector<DSL_IR_ATTRIBUTE_RECORD> &attributes)
+{
+    std::string payload = "kid0=";
+    payload += ST_name(WN_st(kid0));
+    payload += ";kid1=";
+    payload += ST_name(WN_st(kid1));
+    for (UINT32 i = 0; i < attributes.size(); ++i) {
+        payload += ";";
+        payload += Index_To_Str(attributes[i].name);
+        payload += "=";
+        if (attributes[i].value != STR_IDX_ZERO)
+            payload += Index_To_Str(attributes[i].value);
+    }
+    return payload;
+}
+
+static void
+VHO_DSL_Operand_Key (WN *operand, char *key, UINT32 key_size)
+{
+    ST_IDX st = WN_st_idx(operand);
+    snprintf(key, key_size, "%s:%u:%u", ST_name(WN_st(operand)),
+             ST_IDX_level(st), ST_IDX_index(st));
+}
+
+static std::string VHO_DSL_Tensor_Constant_Payload
+        (const char *name, TY_IDX ty, const char *value);
+
+static BOOL
+VHO_DSL_Publish_Coefficient_Two
+        (WN *block,
+         WN *statement,
+         const DSL_IR_VALUE_RECORD *owner_value,
+         TY_IDX ty,
+         DSL_IR_VALUE_RECORD *coefficient_value)
+{
+    TCON_IDX tcon_idx;
+    char name[128];
+    char tcon_text[32];
+    snprintf(name, sizeof(name), "__dsl_coeff2_%u_%u",
+             ST_IDX_level(WN_st_idx(statement)),
+             ST_IDX_index(WN_st_idx(statement)));
+
+    if (!DSL_Tensor_TCON_Create_Integer_Splat
+             (ty, 2, &tcon_idx, NULL))
+        return FALSE;
+
+    ST_IDX st = DSL_Builder_Create_Tensor_Result_Symbol
+                    (name, ty, SCLASS_AUTO, EXPORT_LOCAL);
+    if (ST_IDX_index(st) == 0)
+        return FALSE;
+    Set_ST_Srcpos(St_Table[st], WN_Get_Linenum(statement));
+    snprintf(tcon_text, sizeof(tcon_text), "%u", (UINT32)tcon_idx);
+    ST_tensor_bind_metadata(st, "tensor_tcon_idx", tcon_text);
+    ST_tensor_bind_metadata(st, "tensor_fold.origin",
+                            "vho.coefficient_collection");
+
+    std::string payload =
+        VHO_DSL_Tensor_Constant_Payload(name, ty, "2");
+    WN *constant = DSL_WN_Create_Native
+                       (OPR_DSLTENSORCONST, 1, payload.c_str(), NULL, 0);
+    if (constant == NULL)
+        return FALSE;
+    WN *definition =
+        WN_CreateStid(OPR_STID, MTYPE_V, MTYPE_M, 0, st, ty, constant);
+    WN_Set_Linenum(definition, WN_Get_Linenum(statement));
+
+    DSL_IR_OPCODE_DESCRIPTOR_ID descriptor_id =
+        DSL_IR_Image_Ensure_Opcode_Descriptor(OPR_DSLTENSORCONST, 1);
+    DSL_IR_NODE_RECORD node;
+    DSL_IR_Node_Record_Init(&node);
+    node.opcode_descriptor_id = descriptor_id;
+    node.payload = Save_Str(payload.c_str());
+    DSL_IR_NODE_ID node_id = DSL_IR_Image_Add_Node(&node);
+    if (node_id == DSL_IR_NODE_INVALID_ID)
+        return FALSE;
+
+    DSL_IR_ATTRIBUTE_RECORD attrs[2];
+    DSL_IR_Attribute_Record_Init(&attrs[0]);
+    attrs[0].owner_node_id = node_id;
+    attrs[0].value_kind = DSL_IR_ATTRIBUTE_VALUE_STRING;
+    attrs[0].name = Save_Str("value_kind");
+    attrs[0].value = Save_Str("splat");
+    DSL_IR_ATTRIBUTE_ID first_attr = DSL_IR_Image_Add_Attribute(&attrs[0]);
+    DSL_IR_Attribute_Record_Init(&attrs[1]);
+    attrs[1].owner_node_id = node_id;
+    attrs[1].value_kind = DSL_IR_ATTRIBUTE_VALUE_STRING;
+    attrs[1].name = Save_Str("value");
+    attrs[1].value = Save_Str("2");
+    if (first_attr == DSL_IR_ATTRIBUTE_INVALID_ID ||
+        DSL_IR_Image_Add_Attribute(&attrs[1]) ==
+            DSL_IR_ATTRIBUTE_INVALID_ID)
+        return FALSE;
+
+    DSL_IR_Value_Record_Init(coefficient_value);
+    coefficient_value->value_kind = DSL_IR_VALUE_CONSTANT;
+    coefficient_value->producer_node_id = node_id;
+    coefficient_value->ty = ty;
+    coefficient_value->st = st;
+    coefficient_value->name = Save_Str(name);
+    coefficient_value->metadata = owner_value->metadata;
+    coefficient_value->id = DSL_IR_Image_Add_Value(coefficient_value);
+    if (coefficient_value->id == DSL_IR_VALUE_INVALID_ID ||
+        !DSL_IR_Image_Set_Node_Links
+             (node_id, DSL_IR_VALUE_REFERENCE_INVALID_ID, 0,
+              first_attr, 2, coefficient_value->id))
+        return FALSE;
+
+    WN_INSERT_BlockBefore(block, statement, definition);
+    return TRUE;
+}
+
+static BOOL
+VHO_DSL_Collect_Duplicate_Term
+        (WN *block,
+         WN *statement,
+         const DSL_LOGICAL_OPCODE *logical_opcode,
+         const DSL_IR_NODE_RECORD *image_node,
+         const DSL_IR_VALUE_RECORD *result_value,
+         const DSL_IR_VALUE_RECORD operand_value[2],
+         const std::vector<DSL_IR_ATTRIBUTE_RECORD> &attributes)
+{
+    WN *expression = WN_kid0(statement);
+    DSL_ALGEBRAIC_INFO algebraic;
+    if (logical_opcode->dsl_operator != OPR_DSLADD ||
+        WN_st_idx(WN_kid0(expression)) != WN_st_idx(WN_kid1(expression)) ||
+        !DSL_Operator_Get_Algebraic_Info
+             (logical_opcode->dsl_operator,
+              logical_opcode->effective_version, &algebraic) ||
+        (algebraic.flags & DSL_ALGEBRAIC_ALLOW_REASSOCIATION) == 0 ||
+        (algebraic.reassociation_safety != DSL_ALGEBRAIC_SAFETY_INTEGER &&
+         algebraic.reassociation_safety !=
+             DSL_ALGEBRAIC_SAFETY_INTEGER_OR_FP_REASSOCIATE))
+        return FALSE;
+
+    DSL_IR_VALUE_RECORD coefficient_value;
+    if (!VHO_DSL_Publish_Coefficient_Two
+             (block, statement, result_value, WN_ty(statement),
+              &coefficient_value))
+        return FALSE;
+
+    WN *operands[2] = {
+        WN_COPY_Tree(WN_kid0(expression)),
+        WN_CreateLdid(OPR_LDID, MTYPE_M, MTYPE_M, 0,
+                      coefficient_value.st, coefficient_value.ty)
+    };
+    std::string payload =
+        VHO_DSL_Binary_Payload(operands[0], operands[1], attributes);
+    WN *replacement = DSL_WN_Create_Native
+                          (OPR_DSLMUL, 1, payload.c_str(), operands, 2);
+    if (replacement == NULL)
+        return FALSE;
+
+    DSL_IR_VALUE_ID operand_ids[2] = {
+        operand_value[0].id, coefficient_value.id
+    };
+    DSL_IR_NODE_REWRITE_REQUEST request;
+    memset(&request, 0, sizeof(request));
+    request.node_id = image_node->id;
+    request.opcode_descriptor_id =
+        DSL_IR_Image_Ensure_Opcode_Descriptor(OPR_DSLMUL, 1);
+    request.payload = Save_Str(payload.c_str());
+    request.operand_value_ids = operand_ids;
+    request.operand_count = 2;
+    request.attributes = attributes.empty() ? NULL : &attributes[0];
+    request.attribute_count = (UINT32)attributes.size();
+    request.result_value_kind = result_value->value_kind;
+    if (request.opcode_descriptor_id ==
+            DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID ||
+        !DSL_IR_Image_Rewrite_Node(&request)) {
+        WN_DELETE_Tree(replacement);
+        return FALSE;
+    }
+
+    WN_kid0(statement) = replacement;
+    WN_DELETE_Tree(expression);
+    return TRUE;
+}
+
+static BOOL
+VHO_DSL_Canonicalize_Definition
+        (WN *block,
+         WN *statement,
+         const char *owner_pu,
+         FILE *diagnostic)
+{
+    WN *expression = WN_kid0(statement);
+    DSL_LOGICAL_OPCODE logical_opcode;
+    DSL_IR_VALUE_RECORD result_value;
+    DSL_IR_VALUE_RECORD operand_value[2];
+    DSL_IR_NODE_RECORD image_node;
+    std::vector<DSL_IR_ATTRIBUTE_RECORD> attributes;
+    char kid_key[2][256];
+    BOOL kid_is_constant[2];
+
+    if (!DSL_WN_Get_Logical_Opcode
+             (expression, &logical_opcode, diagnostic) ||
+        WN_kid_count(expression) != 2 ||
+        !VHO_DSL_Is_Integer_Tensor(WN_ty(statement)) ||
+        !VHO_DSL_Image_Node_For_Result
+             (WN_st_idx(statement), owner_pu,
+              &result_value, &image_node) ||
+        !VHO_DSL_Image_Value_For_Operand
+             (WN_kid0(expression), owner_pu, &operand_value[0]) ||
+        !VHO_DSL_Image_Value_For_Operand
+             (WN_kid1(expression), owner_pu, &operand_value[1]) ||
+        operand_value[0].ty != operand_value[1].ty ||
+        operand_value[0].ty != WN_ty(statement) ||
+        !VHO_DSL_Copy_Node_Attributes(&image_node, &attributes))
+        return TRUE;
+
+    if (logical_opcode.dsl_operator == OPR_DSLADD &&
+        WN_st_idx(WN_kid0(expression)) == WN_st_idx(WN_kid1(expression)))
+        return VHO_DSL_Collect_Duplicate_Term
+                   (block, statement, &logical_opcode, &image_node,
+                    &result_value, operand_value, attributes);
+
+    kid_is_constant[0] =
+        operand_value[0].value_kind == DSL_IR_VALUE_CONSTANT;
+    kid_is_constant[1] =
+        operand_value[1].value_kind == DSL_IR_VALUE_CONSTANT;
+    VHO_DSL_Operand_Key(WN_kid0(expression), kid_key[0],
+                        sizeof(kid_key[0]));
+    VHO_DSL_Operand_Key(WN_kid1(expression), kid_key[1],
+                        sizeof(kid_key[1]));
+    if (!DSL_Algebraic_Should_Swap_Binary_Operands
+             (logical_opcode.dsl_operator,
+              logical_opcode.effective_version, TRUE, TRUE,
+              kid_is_constant[0], kid_is_constant[1],
+              kid_key[0], kid_key[1]))
+        return TRUE;
+
+    WN *operands[2] = {
+        WN_COPY_Tree(WN_kid1(expression)),
+        WN_COPY_Tree(WN_kid0(expression))
+    };
+    std::string payload =
+        VHO_DSL_Binary_Payload(operands[0], operands[1], attributes);
+    WN *replacement = DSL_WN_Create_Native
+                          (logical_opcode.dsl_operator,
+                           logical_opcode.effective_version,
+                           payload.c_str(), operands, 2);
+    if (replacement == NULL) {
+        WN_DELETE_Tree(operands[0]);
+        WN_DELETE_Tree(operands[1]);
+        return FALSE;
+    }
+
+    DSL_IR_VALUE_ID operand_value_id[2] = {
+        operand_value[1].id, operand_value[0].id
+    };
+    DSL_IR_NODE_REWRITE_REQUEST request;
+    memset(&request, 0, sizeof(request));
+    request.node_id = image_node.id;
+    request.opcode_descriptor_id = image_node.opcode_descriptor_id;
+    request.payload = Save_Str(payload.c_str());
+    request.operand_value_ids = operand_value_id;
+    request.operand_count = 2;
+    request.attributes = attributes.empty() ? NULL : &attributes[0];
+    request.attribute_count = (UINT32)attributes.size();
+    request.result_value_kind = result_value.value_kind;
+    if (!DSL_IR_Image_Rewrite_Node(&request)) {
+        WN_DELETE_Tree(replacement);
+        return FALSE;
+    }
+
+    WN_kid0(statement) = replacement;
+    WN_DELETE_Tree(expression);
+    return TRUE;
+}
+
+static BOOL
+VHO_DSL_Canonicalize_Tree
+        (WN *tree,
+         const char *owner_pu,
+         FILE *diagnostic)
+{
+    if (tree == NULL)
+        return TRUE;
+    if (WN_operator(tree) == OPR_BLOCK) {
+        for (WN *statement = WN_first(tree); statement != NULL;
+             statement = WN_next(statement)) {
+            if (WN_operator(statement) == OPR_STID &&
+                WN_kid_count(statement) == 1 &&
+                DSL_WN_Is_Native(WN_kid0(statement))) {
+                if (!VHO_DSL_Canonicalize_Definition
+                         (tree, statement, owner_pu, diagnostic))
+                    return FALSE;
+            } else if (!VHO_DSL_Canonicalize_Tree
+                            (statement, owner_pu, diagnostic)) {
+                return FALSE;
+            }
+        }
+        return TRUE;
+    }
+    for (INT kid = 0; kid < WN_kid_count(tree); ++kid) {
+        if (!VHO_DSL_Canonicalize_Tree
+                 (WN_kid(tree, kid), owner_pu, diagnostic))
+            return FALSE;
+    }
+    return TRUE;
+}
+
+static BOOL
+VHO_DSL_Canonicalization_Pass
+        (struct pu_info *pu_info,
+         WN **tree,
+         FILE *diagnostic)
+{
+    const char *owner_pu =
+        ST_name(St_Table[PU_Info_proc_sym(pu_info)]);
+    return tree != NULL &&
+           VHO_DSL_Canonicalize_Tree(*tree, owner_pu, diagnostic);
+}
+
+static BOOL
+VHO_DSL_Tensor_TCON_Index (ST_IDX st, TCON_IDX *tcon_idx)
+{
+    const char *text = ST_tensor_metadata(st, "tensor_tcon_idx");
+    char *end;
+
+    if (tcon_idx != NULL)
+        *tcon_idx = TCON_IDX_ZERO;
+    if (text == NULL || tcon_idx == NULL)
+        return FALSE;
+    errno = 0;
+    unsigned long value = strtoul(text, &end, 10);
+    if (errno == ERANGE || end == text || *end != '\0' ||
+        value == 0 || value > UINT_MAX)
+        return FALSE;
+    *tcon_idx = (TCON_IDX)value;
+    return TRUE;
+}
+
+static BOOL
+VHO_DSL_Compact_Operand
+        (WN *operand,
+         const char *owner_pu,
+         DSL_IR_VALUE_RECORD *image_value,
+         DSL_TENSOR_FOLD_VALUE *fold_value)
+{
+    TCON_IDX tcon_idx;
+    DSL_TENSOR_FOLD_STATUS reason;
+
+    return VHO_DSL_Image_Value_For_Operand
+               (operand, owner_pu, image_value) &&
+           VHO_DSL_Tensor_TCON_Index(WN_st_idx(operand), &tcon_idx) &&
+           DSL_Tensor_Fold_Identify_Compact_TCON
+               (tcon_idx, image_value->ty, image_value->st,
+                image_value->id, fold_value, &reason);
+}
+
+static std::string
+VHO_DSL_Tensor_Constant_Payload
+        (const char *name,
+         TY_IDX ty,
+         const char *value)
+{
+    char rank[32];
+    const char *dtype =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_DTYPE);
+    const char *shape =
+        TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_SHAPE);
+    snprintf(rank, sizeof(rank), "%d", TY_tensor_rank(ty));
+
+    std::string payload = "name=";
+    payload += name;
+    payload += ";dtype=";
+    payload += dtype == NULL ? "" : dtype;
+    payload += ";rank=";
+    payload += rank;
+    payload += ";shape=";
+    payload += shape == NULL ? "" : shape;
+    payload += ";value_kind=splat;value=";
+    payload += value;
+    return payload;
+}
+
+static BOOL
+VHO_DSL_Fold_Definition
+        (WN *statement,
+         const char *owner_pu,
+         FILE *diagnostic,
+         BOOL *changed)
+{
+    WN *expression = WN_kid0(statement);
+    DSL_LOGICAL_OPCODE logical_opcode;
+    DSL_IR_VALUE_RECORD result_value;
+    DSL_IR_VALUE_RECORD operand_value[2];
+    DSL_IR_NODE_RECORD image_node;
+    DSL_TENSOR_FOLD_VALUE fold_value[2];
+    std::vector<DSL_IR_ATTRIBUTE_RECORD> attributes;
+
+    if (!DSL_WN_Get_Logical_Opcode
+             (expression, &logical_opcode, diagnostic) ||
+        WN_kid_count(expression) != 2 ||
+        !VHO_DSL_Is_Integer_Tensor(WN_ty(statement)) ||
+        !VHO_DSL_Image_Node_For_Result
+             (WN_st_idx(statement), owner_pu,
+              &result_value, &image_node) ||
+        !VHO_DSL_Compact_Operand
+             (WN_kid0(expression), owner_pu,
+              &operand_value[0], &fold_value[0]) ||
+        !VHO_DSL_Compact_Operand
+             (WN_kid1(expression), owner_pu,
+              &operand_value[1], &fold_value[1]) ||
+        !VHO_DSL_Copy_Node_Attributes(&image_node, &attributes))
+        return TRUE;
+
+    TCON operands[2] = {
+        fold_value[0].carrier, fold_value[1].carrier
+    };
+    TY_IDX operand_ty[2] = {
+        fold_value[0].ty, fold_value[1].ty
+    };
+    TY_IDX result_ty[1] = { WN_ty(statement) };
+    DSL_TENSOR_FOLD_POLICY policy;
+    DSL_Tensor_Fold_Default_Policy(&policy);
+
+    DSL_TENSOR_FOLD_CANDIDATE candidate;
+    memset(&candidate, 0, sizeof(candidate));
+    candidate.dsl_operator = logical_opcode.dsl_operator;
+    candidate.version = logical_opcode.effective_version;
+    candidate.result_count = 1;
+    candidate.operand_count = 2;
+    candidate.operands = operands;
+    candidate.operand_ty = operand_ty;
+    candidate.result_ty = result_ty;
+    candidate.attributes =
+        attributes.empty() ? NULL : &attributes[0];
+    candidate.attribute_count = (UINT32)attributes.size();
+    candidate.policy = &policy;
+
+    const char *lineage =
+        TY_tensor_attribute(WN_ty(statement), TY_TENSOR_SCHEMA_LINEAGE);
+    DSL_TENSOR_FOLD_REPLACEMENT_CONTEXT context;
+    memset(&context, 0, sizeof(context));
+    context.result_ty = WN_ty(statement);
+    context.result_st = WN_st_idx(statement);
+    context.source_position = WN_Get_Linenum(statement);
+    context.origin_node_id = image_node.id;
+    context.origin_result_value_id = result_value.id;
+    context.result_name = result_value.name;
+    context.metadata = result_value.metadata;
+    context.lineage = lineage == NULL ? STR_IDX_ZERO : Save_Str(lineage);
+
+    DSL_TENSOR_FOLD_REPLACEMENT fold;
+    DSL_TENSOR_FOLD_STATUS status =
+        DSL_Tensor_Fold_Describe_Replacement(&candidate, &context, &fold);
+    if (status != DSL_TENSOR_FOLD_SUCCESS)
+        return TRUE;
+
+    const char *result_name = result_value.name == STR_IDX_ZERO ?
+                                  ST_name(WN_st(statement)) :
+                                  Index_To_Str(result_value.name);
+    std::string payload =
+        VHO_DSL_Tensor_Constant_Payload
+            (result_name, fold.result_ty, fold.compact_scalar_text);
+    WN *replacement = DSL_WN_Create_Native
+                          (fold.logical_operator, fold.version,
+                           payload.c_str(), NULL, 0);
+    if (replacement == NULL)
+        return FALSE;
+
+    DSL_IR_ATTRIBUTE_RECORD tensor_const_attributes[2];
+    DSL_IR_Attribute_Record_Init(&tensor_const_attributes[0]);
+    tensor_const_attributes[0].value_kind =
+        DSL_IR_ATTRIBUTE_VALUE_STRING;
+    tensor_const_attributes[0].name = Save_Str("value_kind");
+    tensor_const_attributes[0].value = Save_Str("splat");
+    DSL_IR_Attribute_Record_Init(&tensor_const_attributes[1]);
+    tensor_const_attributes[1].value_kind =
+        DSL_IR_ATTRIBUTE_VALUE_STRING;
+    tensor_const_attributes[1].name = Save_Str("value");
+    tensor_const_attributes[1].value =
+        Save_Str(fold.compact_scalar_text);
+
+    DSL_IR_OPCODE_DESCRIPTOR_ID descriptor_id =
+        DSL_IR_Image_Ensure_Opcode_Descriptor
+            (fold.logical_operator, fold.version);
+    DSL_IR_NODE_REWRITE_REQUEST request;
+    memset(&request, 0, sizeof(request));
+    request.node_id = fold.origin_node_id;
+    request.opcode_descriptor_id = descriptor_id;
+    request.payload = Save_Str(payload.c_str());
+    request.attributes = tensor_const_attributes;
+    request.attribute_count = 2;
+    request.result_value_kind = DSL_IR_VALUE_CONSTANT;
+    if (descriptor_id == DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID ||
+        !DSL_IR_Image_Rewrite_Node(&request)) {
+        WN_DELETE_Tree(replacement);
+        return FALSE;
+    }
+
+    char tcon_text[32];
+    snprintf(tcon_text, sizeof(tcon_text), "%u",
+             (UINT32)fold.result_tcon_idx);
+    ST_tensor_bind_metadata
+        (fold.result_st, "tensor_tcon_idx", tcon_text);
+    ST_tensor_bind_metadata
+        (fold.result_st, "tensor_fold.origin",
+         DSL_OPERATOR_name(logical_opcode.dsl_operator));
+    WN_kid0(statement) = replacement;
+    WN_DELETE_Tree(expression);
+    *changed = TRUE;
+    return TRUE;
+}
+
+static BOOL
+VHO_DSL_Fold_Tree
+        (WN *tree,
+         const char *owner_pu,
+         FILE *diagnostic,
+         BOOL *changed)
+{
+    if (tree == NULL)
+        return TRUE;
+    if (WN_operator(tree) == OPR_BLOCK) {
+        for (WN *statement = WN_first(tree); statement != NULL;
+             statement = WN_next(statement)) {
+            if (WN_operator(statement) == OPR_STID &&
+                WN_kid_count(statement) == 1 &&
+                DSL_WN_Is_Native(WN_kid0(statement))) {
+                if (!VHO_DSL_Fold_Definition
+                         (statement, owner_pu, diagnostic, changed))
+                    return FALSE;
+            } else if (!VHO_DSL_Fold_Tree
+                            (statement, owner_pu,
+                             diagnostic, changed)) {
+                return FALSE;
+            }
+        }
+        return TRUE;
+    }
+    for (INT kid = 0; kid < WN_kid_count(tree); ++kid) {
+        if (!VHO_DSL_Fold_Tree
+                 (WN_kid(tree, kid), owner_pu, diagnostic, changed))
+            return FALSE;
+    }
+    return TRUE;
+}
+
+static BOOL
+VHO_DSL_Algebraic_Simplification_Pass
+        (struct pu_info *pu_info,
+         WN **tree,
+         FILE *diagnostic)
+{
+    if (tree == NULL)
+        return FALSE;
+
+    UINT32 remaining_sweeps = DSL_IR_Image_Node_Count() + 1;
+    const char *owner_pu =
+        ST_name(St_Table[PU_Info_proc_sym(pu_info)]);
+    BOOL changed = TRUE;
+    while (changed && remaining_sweeps-- != 0) {
+        changed = FALSE;
+        if (!VHO_DSL_Fold_Tree
+                 (*tree, owner_pu, diagnostic, &changed))
+            return FALSE;
+    }
+    return !changed;
+}
 
 const char *
 VHO_DSL_Opt_Stage_Name (VHO_DSL_OPT_STAGE stage)
@@ -73,6 +707,18 @@ VHO_DSL_Opt_Register_Pass
         pass == NULL || VHO_DSL_opt_pass[stage] != NULL)
         return FALSE;
     VHO_DSL_opt_pass[stage] = pass;
+    return TRUE;
+}
+
+BOOL
+VHO_DSL_Opt_Register_Default_Passes (void)
+{
+    if (VHO_DSL_opt_pass[VHO_DSL_OPT_CANONICALIZATION] == NULL)
+        VHO_DSL_opt_pass[VHO_DSL_OPT_CANONICALIZATION] =
+            VHO_DSL_Canonicalization_Pass;
+    if (VHO_DSL_opt_pass[VHO_DSL_OPT_ALGEBRAIC_SIMPLIFICATION] == NULL)
+        VHO_DSL_opt_pass[VHO_DSL_OPT_ALGEBRAIC_SIMPLIFICATION] =
+            VHO_DSL_Algebraic_Simplification_Pass;
     return TRUE;
 }
 

--- a/osprey/be/vho/dsl_opt.h
+++ b/osprey/be/vho/dsl_opt.h
@@ -45,6 +45,7 @@ extern BOOL VHO_DSL_Opt_Stage_Enabled (VHO_DSL_OPT_STAGE stage);
 extern BOOL VHO_DSL_Opt_Register_Pass
                                 (VHO_DSL_OPT_STAGE stage,
                                  VHO_DSL_OPT_PASS pass);
+extern BOOL VHO_DSL_Opt_Register_Default_Passes (void);
 extern void VHO_DSL_Opt_Reset_Passes (void);
 extern BOOL VHO_DSL_Optimize_Program_Unit
                                 (struct pu_info *pu_info,

--- a/osprey/be/vho/tests/dsl_lower_contract_test.cxx
+++ b/osprey/be/vho/tests/dsl_lower_contract_test.cxx
@@ -1830,8 +1830,8 @@ Check_VHO_DSL_M4_Canonicalization(void)
         !DSL_Builder_Append_PU_Value(pu, three) ||
         !DSL_Builder_Append_PU_Value(pu, add) ||
         !DSL_Builder_Append_PU_Value(pu, duplicate_add) ||
-        !DSL_Builder_Append_PU_Value(pu, folded_add) ||
-        !DSL_Builder_Append_PU_Value(pu, folded_parent))
+        !DSL_Builder_Append_PU_Value(pu, folded_parent) ||
+        !DSL_Builder_Append_PU_Value(pu, folded_add))
         return FALSE;
 
     WN *tree = PU_Info_tree_ptr(pu);

--- a/osprey/be/vho/tests/dsl_lower_contract_test.cxx
+++ b/osprey/be/vho/tests/dsl_lower_contract_test.cxx
@@ -18,12 +18,14 @@
 #include "errors.h"
 #include "err_host.tab"
 #include "config.h"
+#include "config_dsl.h"
 #include "controls.h"
 #include "config_targ_opt.h"
 #include "dwarf_DST_mem.h"
 #include "dsl_builder.h"
 #include "dsl_gatekeeper.h"
 #include "dsl_lower.h"
+#include "dsl_opt.h"
 #include "dsl_region.h"
 #include "open64_dsl_runtime_abi.h"
 
@@ -1754,6 +1756,205 @@ Check_Llama2_Decode_Lowering(void)
     return TRUE;
 }
 
+static BOOL
+Check_VHO_DSL_M4_Canonicalization(void)
+{
+    BOOL saved_canonicalization = VHO_DSL_Enable_Canonicalization;
+    BOOL saved_algebraic = VHO_DSL_Enable_Algebraic_Simplification;
+    DSL_BUILDER_TENSOR_DESCRIPTOR descriptor;
+    DSL_BUILDER_OPERATOR_ATTRIBUTE attribute;
+    DSL_BUILDER_SOURCE_POSITION source_position;
+    DSL_BUILDER_VALUE kids[2];
+    VHO_DSL_OPT_RESULT result;
+
+    DSL_Builder_Begin_Program();
+    DSL_Opcode_Register_Common_Substrate();
+    DSL_Builder_Set_Canonicalization_Enabled(FALSE);
+    DSL_Builder_Set_Tensor_Folding_Enabled(FALSE);
+    memset(&descriptor, 0, sizeof(descriptor));
+    descriptor.type_core.kind = "tensor";
+    descriptor.type_core.dtype = "int32";
+    descriptor.type_core.rank = 2;
+    descriptor.type_core.logical_shape = "[2,2]";
+    TY_IDX tensor_ty = DSL_Builder_Intern_Tensor_Type
+                           ("vho_m4_i32_2x2", MTYPE_To_TY(MTYPE_I4),
+                            &descriptor);
+    DSL_BUILDER_PROGRAM_UNIT pu =
+        DSL_Builder_Create_Minimal_PU("vho_dsl_m4_canonicalization");
+    UINT32 file_id = DSL_Builder_Register_Source_File(pu, __FILE__);
+    DSL_BUILDER_VALUE input =
+        DSL_Builder_Create_Model_Input("canonical_input", tensor_ty, 0);
+    DSL_BUILDER_VALUE one = DSL_Builder_Create_Tensor_Constant
+                                ("canonical_one", tensor_ty, "int32", 2,
+                                 "[2,2]", "splat", "1");
+    DSL_BUILDER_VALUE two = DSL_Builder_Create_Tensor_Constant
+                                ("fold_two", tensor_ty, "int32", 2,
+                                 "[2,2]", "splat", "2");
+    DSL_BUILDER_VALUE three = DSL_Builder_Create_Tensor_Constant
+                                  ("fold_three", tensor_ty, "int32", 2,
+                                   "[2,2]", "splat", "3");
+    DSL_DOMAIN_ID common = DSL_Domain_Find("common");
+    DSL_OPCODE_ID add_id =
+        DSL_Opcode_Find(common, DSL_OPCODE_COMMON_ADD, 1);
+    attribute.name = "attr.broadcast_rule";
+    attribute.value = "none";
+    kids[0] = one;
+    kids[1] = input;
+    DSL_BUILDER_VALUE add = DSL_Builder_Create_Operator_With_Result
+                                (add_id, 1, kids, 2, &attribute, 1,
+                                 "canonical_add", tensor_ty);
+    kids[0] = input;
+    kids[1] = input;
+    DSL_BUILDER_VALUE duplicate_add =
+        DSL_Builder_Create_Operator_With_Result
+            (add_id, 1, kids, 2, &attribute, 1,
+             "duplicate_add", tensor_ty);
+    kids[0] = two;
+    kids[1] = three;
+    DSL_BUILDER_VALUE folded_add =
+        DSL_Builder_Create_Operator_With_Result
+            (add_id, 1, kids, 2, &attribute, 1, "folded_add", tensor_ty);
+    kids[0] = folded_add;
+    kids[1] = one;
+    DSL_BUILDER_VALUE folded_parent =
+        DSL_Builder_Create_Operator_With_Result
+            (add_id, 1, kids, 2, &attribute, 1, "folded_parent", tensor_ty);
+    if (tensor_ty == TY_IDX_ZERO || pu == NULL || input == NULL ||
+        file_id == 0 ||
+        one == NULL || two == NULL || three == NULL || add == NULL ||
+        duplicate_add == NULL || folded_add == NULL ||
+        folded_parent == NULL ||
+        !DSL_Builder_Append_PU_Value(pu, input) ||
+        !DSL_Builder_Append_PU_Value(pu, one) ||
+        !DSL_Builder_Append_PU_Value(pu, two) ||
+        !DSL_Builder_Append_PU_Value(pu, three) ||
+        !DSL_Builder_Append_PU_Value(pu, add) ||
+        !DSL_Builder_Append_PU_Value(pu, duplicate_add) ||
+        !DSL_Builder_Append_PU_Value(pu, folded_add) ||
+        !DSL_Builder_Append_PU_Value(pu, folded_parent))
+        return FALSE;
+
+    WN *tree = PU_Info_tree_ptr(pu);
+    WN *expression = WN_kid0(add);
+    ST_IDX folded_result_st = WN_st_idx(folded_add);
+    TY_IDX folded_result_ty = WN_ty(folded_add);
+    memset(&source_position, 0, sizeof(source_position));
+    source_position.file_id = file_id;
+    source_position.line = __LINE__ + 1;
+    source_position.column = 1;
+    source_position.statement_begin = 1;
+    if (!DSL_Builder_Set_Value_Source_Position
+             (folded_add, &source_position))
+        return FALSE;
+    SRCPOS folded_source_position = WN_Get_Linenum(folded_add);
+    ST_IDX duplicate_result_st = WN_st_idx(duplicate_add);
+    TY_IDX duplicate_result_ty = WN_ty(duplicate_add);
+    ++source_position.line;
+    if (!DSL_Builder_Set_Value_Source_Position
+             (duplicate_add, &source_position))
+        return FALSE;
+    SRCPOS duplicate_source_position = WN_Get_Linenum(duplicate_add);
+    if (WN_st_idx(WN_kid0(expression)) != WN_st_idx(one) ||
+        WN_st_idx(WN_kid1(expression)) != WN_st_idx(input) ||
+        !DSL_WN_Is_Native(WN_kid0(folded_add)) ||
+        WN_kid_count(WN_kid0(folded_add)) != 2)
+        return FALSE;
+
+    VHO_DSL_Opt_Reset_Passes();
+    if (!VHO_DSL_Opt_Register_Default_Passes())
+        return FALSE;
+    VHO_DSL_Enable_Canonicalization = FALSE;
+    VHO_DSL_Enable_Algebraic_Simplification = FALSE;
+    if (!VHO_DSL_Optimize_Program_Unit
+             (pu, &tree, stderr, &result) ||
+        result.executed_stage_count != 0 ||
+        WN_st_idx(WN_kid0(WN_kid0(add))) != WN_st_idx(one))
+        return FALSE;
+
+    VHO_DSL_Enable_Canonicalization = TRUE;
+    if (!VHO_DSL_Optimize_Program_Unit
+             (pu, &tree, stderr, &result) ||
+        result.executed_stage_count != 1)
+        return FALSE;
+    expression = WN_kid0(add);
+    DSL_OPCODE_ANNOTATION annotation;
+    DSL_LOGICAL_OPCODE duplicate_logical_opcode;
+    const char *coefficient_origin =
+        ST_tensor_metadata
+            (WN_st_idx(WN_kid1(WN_kid0(duplicate_add))),
+             "tensor_fold.origin");
+    if (WN_st_idx(WN_kid0(expression)) != WN_st_idx(input) ||
+        WN_st_idx(WN_kid1(expression)) != WN_st_idx(one) ||
+        !DSL_WN_Get_Opcode_Annotation(expression, &annotation) ||
+        strstr(annotation.payload, "kid0=canonical_input") == NULL ||
+        strstr(annotation.payload, "kid1=canonical_one") == NULL ||
+        WN_st_idx(duplicate_add) != duplicate_result_st ||
+        WN_ty(duplicate_add) != duplicate_result_ty ||
+        WN_Get_Linenum(duplicate_add) != duplicate_source_position ||
+        !DSL_WN_Get_Logical_Opcode
+             (WN_kid0(duplicate_add), &duplicate_logical_opcode, stderr) ||
+        duplicate_logical_opcode.dsl_operator != OPR_DSLMUL ||
+        WN_kid_count(WN_kid0(duplicate_add)) != 2 ||
+        WN_st_idx(WN_kid0(WN_kid0(duplicate_add))) != WN_st_idx(input) ||
+        coefficient_origin == NULL ||
+        strcmp(coefficient_origin, "vho.coefficient_collection") != 0 ||
+        !DSL_IR_Image_Validate(stderr))
+        return FALSE;
+
+    VHO_DSL_Enable_Canonicalization = FALSE;
+    VHO_DSL_Enable_Algebraic_Simplification = TRUE;
+    DSL_LOGICAL_OPCODE folded_logical_opcode;
+    DSL_LOGICAL_OPCODE parent_logical_opcode;
+    if (!VHO_DSL_Optimize_Program_Unit
+             (pu, &tree, stderr, &result) ||
+        result.executed_stage_count != 1 ||
+        WN_st_idx(folded_add) != folded_result_st ||
+        WN_ty(folded_add) != folded_result_ty ||
+        WN_Get_Linenum(folded_add) != folded_source_position ||
+        !DSL_WN_Is_Native(WN_kid0(folded_add)) ||
+        WN_kid_count(WN_kid0(folded_add)) != 0 ||
+        !DSL_WN_Get_Logical_Opcode
+             (WN_kid0(folded_add), &folded_logical_opcode, stderr) ||
+        folded_logical_opcode.dsl_operator != OPR_DSLTENSORCONST ||
+        !DSL_WN_Get_Opcode_Annotation
+             (WN_kid0(folded_add), &annotation) ||
+        strstr(annotation.payload, "value_kind=splat") == NULL ||
+        strstr(annotation.payload, "value=5") == NULL ||
+        ST_tensor_metadata(folded_result_st, "tensor_tcon_idx") == NULL ||
+        strcmp(ST_tensor_metadata
+                   (folded_result_st, "tensor_fold.origin"),
+               "OPR_DSLADD") != 0 ||
+        !DSL_WN_Get_Logical_Opcode
+             (WN_kid0(folded_parent), &parent_logical_opcode, stderr) ||
+        parent_logical_opcode.dsl_operator != OPR_DSLTENSORCONST ||
+        !DSL_WN_Get_Opcode_Annotation
+             (WN_kid0(folded_parent), &annotation) ||
+        strstr(annotation.payload, "value=6") == NULL ||
+        !DSL_IR_Image_Validate(stderr))
+        return FALSE;
+
+    DSL_GATEKEEPER_RESULT gatekeeper_result;
+    BOOL valid = DSL_Gatekeeper_Verify_Program
+                     (pu, stderr, &gatekeeper_result) &&
+                 gatekeeper_result.error_count == 0;
+    const char *artifact =
+        getenv("OPEN64_DSL_VHO_M4_ARTIFACT");
+    if (valid && artifact != NULL && artifact[0] != '\0') {
+        DSL_BUILDER_MAPPED_IMAGE_REQUEST request;
+        request.path = artifact;
+        request.flags = 0;
+        (void)unlink(request.path);
+        valid = DSL_Builder_Finalize_Mapped_Image(&request) &&
+                access(request.path, F_OK) == 0;
+    }
+    VHO_DSL_Enable_Canonicalization = saved_canonicalization;
+    VHO_DSL_Enable_Algebraic_Simplification = saved_algebraic;
+    VHO_DSL_Opt_Reset_Passes();
+    if (valid)
+        printf("DSL VHO M4 canonicalization contract passed\n");
+    return valid;
+}
+
 int
 main(void)
 {
@@ -1762,6 +1963,8 @@ main(void)
     memset(&empty_pu, 0, sizeof(empty_pu));
 
     Initialize_Test_Context();
+    if (getenv("OPEN64_DSL_VHO_M4_ONLY") != NULL)
+        return Check_VHO_DSL_M4_Canonicalization() ? 0 : 1;
     if (getenv("OPEN64_DSL_LLAMA2_DECODE_LOWER_ONLY") != NULL)
         return Check_Llama2_Decode_Lowering() ? 0 : 1;
     if (getenv("OPEN64_DSL_STATE_LOWER_ONLY") != NULL)

--- a/osprey/common/com/dsl_ir_image.cxx
+++ b/osprey/common/com/dsl_ir_image.cxx
@@ -3,6 +3,7 @@
  */
 
 #include <string.h>
+#include <string>
 #include <vector>
 
 #include "dsl_ir_image.h"
@@ -764,6 +765,42 @@ DSL_IR_Image_Find_Opcode_Descriptor
     return DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID;
 }
 
+DSL_IR_OPCODE_DESCRIPTOR_ID
+DSL_IR_Image_Ensure_Opcode_Descriptor
+        (UINT32 logical_operator,
+         UINT32 version)
+{
+    DSL_IR_OPCODE_DESCRIPTOR_ID id =
+        DSL_IR_Image_Find_Opcode_Descriptor(logical_operator, version);
+    if (id != DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID)
+        return id;
+
+    DSL_OPERATOR_INFO info;
+    if (!DSL_Operator_Get_Info_Version
+             ((DSL_OPERATOR)logical_operator, version, &info))
+        return DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID;
+
+    DSL_IR_OPCODE_DESCRIPTOR_RECORD record;
+    DSL_IR_Opcode_Descriptor_Record_Init(&record);
+    record.logical_operator = logical_operator;
+    record.version = info.version;
+    record.operand_count = info.nkids;
+    record.category = info.category;
+    record.level = info.level;
+    record.shape_rule = info.shape_rule;
+    record.effect_model = info.effect_model;
+    record.lowering_model = info.lowering_model;
+    record.flags = info.flags;
+    record.logical_name = Save_Str(info.logical_name);
+    record.stable_name = Save_Str(info.stable_name);
+    record.attribute_schema =
+        Save_Str(info.attribute_schema == NULL ? "" : info.attribute_schema);
+    record.diagnostic_prefix =
+        Save_Str(info.diagnostic_prefix == NULL ? "" :
+                 info.diagnostic_prefix);
+    return DSL_IR_Image_Add_Opcode_Descriptor(&record);
+}
+
 DSL_IR_NODE_ID
 DSL_IR_Image_Add_Node (const DSL_IR_NODE_RECORD *record)
 {
@@ -889,6 +926,140 @@ DSL_IR_Image_Set_Node_Links
     node.attribute_count = attribute_count;
     node.result_value_id = result_value_id;
     return TRUE;
+}
+
+BOOL
+DSL_IR_Image_Rewrite_Node
+        (const DSL_IR_NODE_REWRITE_REQUEST *request)
+{
+    if (request == NULL ||
+        request->node_id == DSL_IR_NODE_INVALID_ID ||
+        request->node_id > DSL_ir_node_table.Size() ||
+        request->opcode_descriptor_id ==
+            DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID ||
+        request->opcode_descriptor_id >
+            DSL_ir_opcode_descriptor_table.Size() ||
+        (request->operand_count != 0 &&
+         request->operand_value_ids == NULL) ||
+        (request->attribute_count != 0 &&
+         request->attributes == NULL) ||
+        request->result_value_kind == DSL_IR_VALUE_UNKNOWN)
+        return FALSE;
+
+    const DSL_IR_OPCODE_DESCRIPTOR_RECORD &descriptor =
+        DSL_ir_opcode_descriptor_table[request->opcode_descriptor_id - 1];
+    if (descriptor.operand_count >= 0 &&
+        (UINT32)descriptor.operand_count != request->operand_count)
+        return FALSE;
+
+    DSL_IR_NODE_RECORD &node =
+        DSL_ir_node_table[request->node_id - 1];
+    if (node.result_value_id == DSL_IR_VALUE_INVALID_ID ||
+        node.result_value_id > DSL_ir_value_table.Size())
+        return FALSE;
+    DSL_IR_VALUE_RECORD &result =
+        DSL_ir_value_table[node.result_value_id - 1];
+    if (result.producer_node_id != request->node_id)
+        return FALSE;
+
+    for (UINT32 i = 0; i < request->operand_count; ++i) {
+        if (request->operand_value_ids[i] == DSL_IR_VALUE_INVALID_ID ||
+            request->operand_value_ids[i] > DSL_ir_value_table.Size())
+            return FALSE;
+    }
+    for (UINT32 i = 0; i < request->attribute_count; ++i) {
+        const DSL_IR_ATTRIBUTE_RECORD &attribute = request->attributes[i];
+        if (attribute.name == STR_IDX_ZERO ||
+            attribute.value_kind == DSL_IR_ATTRIBUTE_VALUE_UNKNOWN)
+            return FALSE;
+    }
+
+    UINT32 reference_checkpoint = DSL_ir_value_reference_table.Size();
+    UINT32 attribute_checkpoint = DSL_ir_attribute_table.Size();
+    DSL_IR_VALUE_REFERENCE_ID first_operand_id =
+        DSL_IR_VALUE_REFERENCE_INVALID_ID;
+    DSL_IR_ATTRIBUTE_ID first_attribute_id = DSL_IR_ATTRIBUTE_INVALID_ID;
+
+    for (UINT32 i = 0; i < request->operand_count; ++i) {
+        DSL_IR_VALUE_REFERENCE_RECORD reference;
+        DSL_IR_Value_Reference_Record_Init(&reference);
+        reference.owner_node_id = request->node_id;
+        reference.ordinal = i;
+        reference.value_id = request->operand_value_ids[i];
+        DSL_IR_VALUE_REFERENCE_ID id =
+            DSL_IR_Image_Add_Value_Reference(&reference);
+        if (id == DSL_IR_VALUE_REFERENCE_INVALID_ID) {
+            DSL_ir_value_reference_table.Delete_down_to(reference_checkpoint);
+            return FALSE;
+        }
+        if (i == 0)
+            first_operand_id = id;
+    }
+
+    for (UINT32 i = 0; i < request->attribute_count; ++i) {
+        DSL_IR_ATTRIBUTE_RECORD attribute = request->attributes[i];
+        attribute.id = DSL_IR_ATTRIBUTE_INVALID_ID;
+        attribute.owner_node_id = request->node_id;
+        DSL_IR_ATTRIBUTE_ID id = DSL_IR_Image_Add_Attribute(&attribute);
+        if (id == DSL_IR_ATTRIBUTE_INVALID_ID) {
+            DSL_ir_value_reference_table.Delete_down_to(reference_checkpoint);
+            DSL_ir_attribute_table.Delete_down_to(attribute_checkpoint);
+            return FALSE;
+        }
+        if (i == 0)
+            first_attribute_id = id;
+    }
+
+    node.opcode_descriptor_id = request->opcode_descriptor_id;
+    node.first_operand_reference_id = first_operand_id;
+    node.operand_count = request->operand_count;
+    node.first_attribute_id = first_attribute_id;
+    node.attribute_count = request->attribute_count;
+    node.payload = request->payload;
+    result.value_kind = request->result_value_kind;
+    return TRUE;
+}
+
+BOOL
+DSL_IR_Image_Find_PU_Value
+        (ST_IDX st,
+         const char *name,
+         const char *owner_pu,
+         DSL_IR_VALUE_RECORD *record)
+{
+    DSL_IR_VALUE_ID found = DSL_IR_VALUE_INVALID_ID;
+    std::string owner_metadata;
+
+    if (ST_IDX_index(st) == 0 || name == NULL)
+        return FALSE;
+    if (owner_pu != NULL) {
+        owner_metadata = "owner_pu=";
+        owner_metadata += owner_pu;
+    }
+    for (UINT32 i = 0; i < DSL_ir_value_table.Size(); ++i) {
+        const DSL_IR_VALUE_RECORD &value = DSL_ir_value_table[i];
+        if (value.st != st || value.name == STR_IDX_ZERO ||
+            strcmp(Index_To_Str(value.name), name) != 0)
+            continue;
+        if (owner_pu != NULL &&
+            (value.metadata == STR_IDX_ZERO ||
+             owner_metadata != Index_To_Str(value.metadata)))
+            continue;
+        if (found != DSL_IR_VALUE_INVALID_ID)
+            return FALSE;
+        found = i + 1;
+    }
+    return found != DSL_IR_VALUE_INVALID_ID &&
+           DSL_IR_Image_Get_Value(found, record);
+}
+
+BOOL
+DSL_IR_Image_Find_Value
+        (ST_IDX st,
+         const char *name,
+         DSL_IR_VALUE_RECORD *record)
+{
+    return DSL_IR_Image_Find_PU_Value(st, name, NULL, record);
 }
 
 UINT32

--- a/osprey/common/com/dsl_ir_image.cxx
+++ b/osprey/common/com/dsl_ir_image.cxx
@@ -451,6 +451,8 @@ static BOOL
 DSL_IR_Image_View_Validate (const DSL_IR_IMAGE_VIEW *view, FILE *diagnostic)
 {
     const DSL_IR_IMAGE_HEADER &header = *view->header;
+    UINT32 active_attribute_count = 0;
+    UINT32 active_value_reference_count = 0;
     const UINT32 required_capabilities =
         DSL_IR_IMAGE_CAP_OPCODE_DESCRIPTOR |
         DSL_IR_IMAGE_CAP_NODE |
@@ -515,6 +517,8 @@ DSL_IR_Image_View_Validate (const DSL_IR_IMAGE_VIEW *view, FILE *diagnostic)
 
     for (UINT32 i = 0; i < header.node_count; ++i) {
         const DSL_IR_NODE_RECORD &record = view->nodes[i];
+        active_attribute_count += record.attribute_count;
+        active_value_reference_count += record.operand_count;
         if (record.id != i + 1 || record.opcode_descriptor_id == 0 ||
             record.opcode_descriptor_id > header.opcode_descriptor_count ||
             record.result_value_id == 0 ||
@@ -571,6 +575,11 @@ DSL_IR_Image_View_Validate (const DSL_IR_IMAGE_VIEW *view, FILE *diagnostic)
             return DSL_IR_Image_Report
                        (diagnostic, "node result provenance mismatch", i + 1);
     }
+
+    if (active_attribute_count != header.attribute_count ||
+        active_value_reference_count != header.value_reference_count)
+        return DSL_IR_Image_Report
+                   (diagnostic, "unowned relationship record", 0);
 
     return TRUE;
 }
@@ -974,46 +983,79 @@ DSL_IR_Image_Rewrite_Node
             return FALSE;
     }
 
-    UINT32 reference_checkpoint = DSL_ir_value_reference_table.Size();
-    UINT32 attribute_checkpoint = DSL_ir_attribute_table.Size();
-    DSL_IR_VALUE_REFERENCE_ID first_operand_id =
-        DSL_IR_VALUE_REFERENCE_INVALID_ID;
-    DSL_IR_ATTRIBUTE_ID first_attribute_id = DSL_IR_ATTRIBUTE_INVALID_ID;
+    std::vector<DSL_IR_VALUE_REFERENCE_RECORD> references;
+    std::vector<DSL_IR_ATTRIBUTE_RECORD> attributes;
+    std::vector<DSL_IR_VALUE_REFERENCE_ID> first_operand_ids;
+    std::vector<DSL_IR_ATTRIBUTE_ID> first_attribute_ids;
+    UINT32 node_count = DSL_ir_node_table.Size();
 
-    for (UINT32 i = 0; i < request->operand_count; ++i) {
-        DSL_IR_VALUE_REFERENCE_RECORD reference;
-        DSL_IR_Value_Reference_Record_Init(&reference);
-        reference.owner_node_id = request->node_id;
-        reference.ordinal = i;
-        reference.value_id = request->operand_value_ids[i];
-        DSL_IR_VALUE_REFERENCE_ID id =
-            DSL_IR_Image_Add_Value_Reference(&reference);
-        if (id == DSL_IR_VALUE_REFERENCE_INVALID_ID) {
-            DSL_ir_value_reference_table.Delete_down_to(reference_checkpoint);
-            return FALSE;
+    references.reserve(DSL_ir_value_reference_table.Size() +
+                       request->operand_count);
+    attributes.reserve(DSL_ir_attribute_table.Size() +
+                       request->attribute_count);
+    first_operand_ids.resize(node_count,
+                             DSL_IR_VALUE_REFERENCE_INVALID_ID);
+    first_attribute_ids.resize(node_count, DSL_IR_ATTRIBUTE_INVALID_ID);
+
+    for (UINT32 node_index = 0; node_index < node_count; ++node_index) {
+        const DSL_IR_NODE_RECORD &current = DSL_ir_node_table[node_index];
+        UINT32 operand_count = current.operand_count;
+        UINT32 attribute_count = current.attribute_count;
+
+        if (current.id == request->node_id) {
+            operand_count = request->operand_count;
+            attribute_count = request->attribute_count;
         }
-        if (i == 0)
-            first_operand_id = id;
+
+        if (operand_count != 0)
+            first_operand_ids[node_index] = references.size() + 1;
+        for (UINT32 i = 0; i < operand_count; ++i) {
+            DSL_IR_VALUE_REFERENCE_RECORD reference;
+            if (current.id == request->node_id) {
+                DSL_IR_Value_Reference_Record_Init(&reference);
+                reference.owner_node_id = request->node_id;
+                reference.ordinal = i;
+                reference.value_id = request->operand_value_ids[i];
+            } else {
+                reference = DSL_ir_value_reference_table
+                    [current.first_operand_reference_id - 1 + i];
+            }
+            reference.id = references.size() + 1;
+            references.push_back(reference);
+        }
+
+        if (attribute_count != 0)
+            first_attribute_ids[node_index] = attributes.size() + 1;
+        for (UINT32 i = 0; i < attribute_count; ++i) {
+            DSL_IR_ATTRIBUTE_RECORD attribute;
+            if (current.id == request->node_id) {
+                attribute = request->attributes[i];
+                attribute.owner_node_id = request->node_id;
+            } else {
+                attribute = DSL_ir_attribute_table
+                    [current.first_attribute_id - 1 + i];
+            }
+            attribute.id = attributes.size() + 1;
+            attributes.push_back(attribute);
+        }
     }
 
-    for (UINT32 i = 0; i < request->attribute_count; ++i) {
-        DSL_IR_ATTRIBUTE_RECORD attribute = request->attributes[i];
-        attribute.id = DSL_IR_ATTRIBUTE_INVALID_ID;
-        attribute.owner_node_id = request->node_id;
-        DSL_IR_ATTRIBUTE_ID id = DSL_IR_Image_Add_Attribute(&attribute);
-        if (id == DSL_IR_ATTRIBUTE_INVALID_ID) {
-            DSL_ir_value_reference_table.Delete_down_to(reference_checkpoint);
-            DSL_ir_attribute_table.Delete_down_to(attribute_checkpoint);
-            return FALSE;
-        }
-        if (i == 0)
-            first_attribute_id = id;
+    DSL_ir_value_reference_table.Delete_down_to(0);
+    if (!references.empty())
+        DSL_ir_value_reference_table.Insert(&references[0],
+                                            references.size());
+    DSL_ir_attribute_table.Delete_down_to(0);
+    if (!attributes.empty())
+        DSL_ir_attribute_table.Insert(&attributes[0], attributes.size());
+
+    for (UINT32 node_index = 0; node_index < node_count; ++node_index) {
+        DSL_IR_NODE_RECORD &current = DSL_ir_node_table[node_index];
+        current.first_operand_reference_id = first_operand_ids[node_index];
+        current.first_attribute_id = first_attribute_ids[node_index];
     }
 
     node.opcode_descriptor_id = request->opcode_descriptor_id;
-    node.first_operand_reference_id = first_operand_id;
     node.operand_count = request->operand_count;
-    node.first_attribute_id = first_attribute_id;
     node.attribute_count = request->attribute_count;
     node.payload = request->payload;
     result.value_kind = request->result_value_kind;

--- a/osprey/common/com/dsl_ir_image.h
+++ b/osprey/common/com/dsl_ir_image.h
@@ -218,6 +218,22 @@ typedef struct {
     UINT32 reserved;
 } DSL_IR_VALUE_REFERENCE_RECORD;
 
+/*
+ * Runtime-only request for replacing one logical operation while retaining
+ * its node and result identities.  Referenced arrays are borrowed for the
+ * duration of the call and are copied into the existing WHIRL image tables.
+ */
+typedef struct {
+    DSL_IR_NODE_ID node_id;
+    DSL_IR_OPCODE_DESCRIPTOR_ID opcode_descriptor_id;
+    STR_IDX payload;
+    const DSL_IR_VALUE_ID *operand_value_ids;
+    UINT32 operand_count;
+    const DSL_IR_ATTRIBUTE_RECORD *attributes;
+    UINT32 attribute_count;
+    UINT32 result_value_kind;
+} DSL_IR_NODE_REWRITE_REQUEST;
+
 typedef enum {
     DSL_STATE_KIND_UNKNOWN = 0,
     DSL_STATE_KIND_RUNTIME_STATUS = 1,
@@ -346,6 +362,9 @@ extern DSL_IR_OPCODE_DESCRIPTOR_ID DSL_IR_Image_Add_Opcode_Descriptor
 extern DSL_IR_OPCODE_DESCRIPTOR_ID DSL_IR_Image_Find_Opcode_Descriptor
                                 (UINT32 logical_operator,
                                  UINT32 version);
+extern DSL_IR_OPCODE_DESCRIPTOR_ID DSL_IR_Image_Ensure_Opcode_Descriptor
+                                (UINT32 logical_operator,
+                                 UINT32 version);
 extern DSL_IR_NODE_ID DSL_IR_Image_Add_Node
                                 (const DSL_IR_NODE_RECORD *record);
 extern DSL_IR_ATTRIBUTE_ID DSL_IR_Image_Add_Attribute
@@ -361,6 +380,17 @@ extern BOOL DSL_IR_Image_Set_Node_Links
                                  DSL_IR_ATTRIBUTE_ID first_attribute_id,
                                  UINT32 attribute_count,
                                  DSL_IR_VALUE_ID result_value_id);
+extern BOOL DSL_IR_Image_Rewrite_Node
+                                (const DSL_IR_NODE_REWRITE_REQUEST *request);
+extern BOOL DSL_IR_Image_Find_Value
+                                (ST_IDX st,
+                                 const char *name,
+                                 DSL_IR_VALUE_RECORD *record);
+extern BOOL DSL_IR_Image_Find_PU_Value
+                                (ST_IDX st,
+                                 const char *name,
+                                 const char *owner_pu,
+                                 DSL_IR_VALUE_RECORD *record);
 
 extern UINT32 DSL_IR_Image_Opcode_Descriptor_Count (void);
 extern UINT32 DSL_IR_Image_Node_Count (void);

--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -1238,7 +1238,7 @@ DSL_Tensor_Fold_Describe_Replacement
     DSL_Tensor_Fold_Replacement_Init(replacement);
 
     if (candidate == NULL || context == NULL ||
-        candidate->result_count != 1)
+        candidate->result_count != 1 || candidate->result_ty == NULL)
         return DSL_Tensor_Fold_Describe_Failure
                    (replacement, DSL_TENSOR_FOLD_REJECT_MALFORMED_CANDIDATE);
     if (context->result_ty != TY_IDX_ZERO &&
@@ -1388,6 +1388,21 @@ DSL_Tensor_TCON_Find_Carrier
         return FALSE;
 
     found = DSL_Tensor_TCON_Find_Cached_Equal(&record, carrier);
+    if (found == TCON_IDX_ZERO) {
+        UINT32 table_size = TCON_Table_Size();
+        for (TCON_IDX idx = 1; idx < table_size; ++idx) {
+            TCON candidate = TCON_from_IDX(idx);
+            DSL_TENSOR_TCON_RECORD candidate_record;
+            if (DSL_Tensor_TCON_Decode_Carrier
+                    (&candidate, &candidate_record) &&
+                DSL_Tensor_TCON_Record_Semantic_Equal
+                    (&candidate_record, &candidate, &record, carrier)) {
+                found = idx;
+                DSL_Tensor_TCON_Cache(found);
+                break;
+            }
+        }
+    }
     if (found == TCON_IDX_ZERO)
         return FALSE;
     *tcon_idx = found;
@@ -1606,12 +1621,12 @@ DSL_Tensor_TCON_Create_Integer_Splat
 
     memset(&info, 0, sizeof(info));
     info.descriptor_ty = descriptor_ty;
-    info.scalar_tcon = Enter_tcon(scalar);
     info.element_mtype = element_mtype;
     info.element_count = element_count;
     info.element_size = TY_size(element_ty);
     if (element_count > ~0ULL / info.element_size)
         return FALSE;
+    info.scalar_tcon = Enter_tcon(scalar);
     info.logical_bytes = element_count * info.element_size;
     info.required_alignment = TY_align(descriptor_ty);
     if (info.required_alignment < info.element_size)

--- a/osprey/common/com/dsl_tensor_fold.cxx
+++ b/osprey/common/com/dsl_tensor_fold.cxx
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
+#include <errno.h>
 
 #include "opcode.h"
 #include "dsl_tensor_fold.h"
@@ -116,6 +118,62 @@ DSL_Tensor_TCON_Mul_Exact (UINT64 left, UINT32 right, UINT64 *result)
         *result = left * right;
     return TRUE;
 }
+
+#ifndef DSL_TENSOR_FOLD_TEST_STUB
+static BOOL
+DSL_Tensor_TCON_Static_Element_Count
+        (TY_IDX descriptor_ty,
+         UINT64 *element_count)
+{
+    const char *shape =
+        TY_tensor_attribute(descriptor_ty, TY_TENSOR_SCHEMA_SHAPE);
+    INT32 rank = TY_tensor_rank(descriptor_ty);
+    const char *cursor;
+    UINT32 dimensions = 0;
+    UINT64 count = 1;
+
+    if (element_count != NULL)
+        *element_count = 0;
+    if (shape == NULL || rank < 0 || element_count == NULL)
+        return FALSE;
+    cursor = shape;
+    while (isspace((unsigned char)*cursor))
+        ++cursor;
+    if (*cursor++ != '[')
+        return FALSE;
+    while (TRUE) {
+        while (isspace((unsigned char)*cursor))
+            ++cursor;
+        if (*cursor == ']') {
+            ++cursor;
+            break;
+        }
+        errno = 0;
+        char *end;
+        unsigned long long dimension = strtoull(cursor, &end, 10);
+        if (errno == ERANGE || end == cursor || dimension == 0 ||
+            count > ~0ULL / dimension)
+            return FALSE;
+        count *= dimension;
+        ++dimensions;
+        cursor = end;
+        while (isspace((unsigned char)*cursor))
+            ++cursor;
+        if (*cursor == ',') {
+            ++cursor;
+            continue;
+        }
+        if (*cursor != ']')
+            return FALSE;
+    }
+    while (isspace((unsigned char)*cursor))
+        ++cursor;
+    if (*cursor != '\0' || dimensions != (UINT32)rank)
+        return FALSE;
+    *element_count = count;
+    return TRUE;
+}
+#endif
 
 static BOOL
 DSL_Tensor_TCON_Relative_Path_Valid (const char *text, UINT32 length)
@@ -1082,6 +1140,174 @@ Targ_DSL_WhirlOp
 }
 
 void
+DSL_Tensor_Fold_Value_Init (DSL_TENSOR_FOLD_VALUE *value)
+{
+    if (value != NULL)
+        memset(value, 0, sizeof(*value));
+}
+
+BOOL
+DSL_Tensor_Fold_Identify_Compact_TCON
+        (TCON_IDX tcon_idx,
+         TY_IDX expected_ty,
+         ST_IDX st,
+         DSL_IR_VALUE_ID dsl_value_id,
+         DSL_TENSOR_FOLD_VALUE *value,
+         DSL_TENSOR_FOLD_STATUS *reason)
+{
+    DSL_TENSOR_TCON_RECORD record;
+    TCON carrier;
+
+    if (reason != NULL)
+        *reason = DSL_TENSOR_FOLD_SUCCESS;
+    DSL_Tensor_Fold_Value_Init(value);
+
+    if (value == NULL) {
+        if (reason != NULL)
+            *reason = DSL_TENSOR_FOLD_REJECT_MALFORMED_CANDIDATE;
+        return FALSE;
+    }
+
+    if (!DSL_Tensor_TCON_Get_Carrier(tcon_idx, &carrier) ||
+        !DSL_Tensor_TCON_Decode_Carrier(&carrier, &record)) {
+        if (reason != NULL)
+            *reason = DSL_TENSOR_FOLD_REJECT_NON_CONSTANT_OPERAND;
+        return FALSE;
+    }
+
+    if (record.storage_kind != DSL_TENSOR_TCON_STORAGE_ZERO &&
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_ONE &&
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_SPLAT) {
+        if (reason != NULL)
+            *reason = DSL_TENSOR_FOLD_REJECT_NON_CONSTANT_OPERAND;
+        return FALSE;
+    }
+
+    if (expected_ty != TY_IDX_ZERO && record.descriptor_ty != expected_ty) {
+        if (reason != NULL)
+            *reason = DSL_TENSOR_FOLD_REJECT_DESCRIPTOR_MISMATCH;
+        return FALSE;
+    }
+
+    value->kind = DSL_TENSOR_FOLD_VALUE_COMPACT_TCON;
+    value->tcon_idx = tcon_idx;
+    value->carrier = carrier;
+    value->tensor_record = record;
+    value->ty = record.descriptor_ty;
+    value->st = st;
+    value->dsl_value_id = dsl_value_id;
+    value->flags = DSL_TENSOR_FOLD_VALUE_FLAG_COMPACT;
+    return TRUE;
+}
+
+void
+DSL_Tensor_Fold_Replacement_Init
+        (DSL_TENSOR_FOLD_REPLACEMENT *replacement)
+{
+    if (replacement != NULL) {
+        memset(replacement, 0, sizeof(*replacement));
+        replacement->status = DSL_TENSOR_FOLD_NOT_APPLICABLE;
+    }
+}
+
+static DSL_TENSOR_FOLD_STATUS
+DSL_Tensor_Fold_Describe_Failure
+        (DSL_TENSOR_FOLD_REPLACEMENT *replacement,
+         DSL_TENSOR_FOLD_STATUS status)
+{
+    DSL_Tensor_Fold_Replacement_Init(replacement);
+    if (replacement != NULL)
+        replacement->status = status;
+    return status;
+}
+
+DSL_TENSOR_FOLD_STATUS
+DSL_Tensor_Fold_Describe_Replacement
+        (const DSL_TENSOR_FOLD_CANDIDATE *candidate,
+         const DSL_TENSOR_FOLD_REPLACEMENT_CONTEXT *context,
+         DSL_TENSOR_FOLD_REPLACEMENT *replacement)
+{
+    DSL_TENSOR_FOLD_OUTPUT output;
+    DSL_TENSOR_FOLD_STATUS status;
+    DSL_TENSOR_TCON_RECORD record;
+    TCON_IDX result_tcon_idx;
+    TY_IDX result_ty;
+
+    if (replacement == NULL)
+        return DSL_TENSOR_FOLD_REJECT_MALFORMED_CANDIDATE;
+    DSL_Tensor_Fold_Replacement_Init(replacement);
+
+    if (candidate == NULL || context == NULL ||
+        candidate->result_count != 1)
+        return DSL_Tensor_Fold_Describe_Failure
+                   (replacement, DSL_TENSOR_FOLD_REJECT_MALFORMED_CANDIDATE);
+    if (context->result_ty != TY_IDX_ZERO &&
+        context->result_ty != candidate->result_ty[0])
+        return DSL_Tensor_Fold_Describe_Failure
+                   (replacement,
+                    DSL_TENSOR_FOLD_REJECT_DESCRIPTOR_MISMATCH);
+
+    status = Targ_DSL_WhirlOp(candidate, &output);
+    if (status != DSL_TENSOR_FOLD_SUCCESS)
+        return DSL_Tensor_Fold_Describe_Failure(replacement, status);
+
+    if (output.result_count != 1 ||
+        output.results[0].kind != DSL_TENSOR_FOLD_RESULT_TCON ||
+        output.results[0].result_ty != candidate->result_ty[0])
+        return DSL_Tensor_Fold_Describe_Failure
+                   (replacement,
+                    DSL_TENSOR_FOLD_REJECT_MATERIALIZATION_POLICY);
+
+    if (!DSL_Tensor_TCON_Find_Carrier(&output.results[0].result,
+                                      &result_tcon_idx) ||
+        result_tcon_idx == TCON_IDX_ZERO ||
+        !DSL_Tensor_TCON_Get(result_tcon_idx, &record))
+        return DSL_Tensor_Fold_Describe_Failure
+                   (replacement,
+                    DSL_TENSOR_FOLD_REJECT_MATERIALIZATION_POLICY);
+
+    if (record.storage_kind != DSL_TENSOR_TCON_STORAGE_ZERO &&
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_ONE &&
+        record.storage_kind != DSL_TENSOR_TCON_STORAGE_SPLAT)
+        return DSL_Tensor_Fold_Describe_Failure
+                   (replacement,
+                    DSL_TENSOR_FOLD_REJECT_MATERIALIZATION_POLICY);
+
+    result_ty = context->result_ty != TY_IDX_ZERO ?
+                    context->result_ty : candidate->result_ty[0];
+    if (result_ty != record.descriptor_ty ||
+        candidate->result_ty[0] != record.descriptor_ty)
+        return DSL_Tensor_Fold_Describe_Failure
+                   (replacement,
+                    DSL_TENSOR_FOLD_REJECT_DESCRIPTOR_MISMATCH);
+
+    replacement->status = DSL_TENSOR_FOLD_SUCCESS;
+    replacement->logical_operator = OPR_DSLTENSORCONST;
+    replacement->version = 1;
+    replacement->result_count = 1;
+    replacement->result_tcon_idx = result_tcon_idx;
+    replacement->result_tcon = output.results[0].result;
+    replacement->result_ty = result_ty;
+    replacement->result_st = context->result_st;
+    replacement->descriptor_ty = record.descriptor_ty;
+    replacement->result_storage_kind = record.storage_kind;
+    replacement->scalar_tcon = record.scalar_tcon;
+    replacement->scalar_integer_value = record.scalar_integer_value;
+    snprintf(replacement->compact_scalar_text,
+             sizeof(replacement->compact_scalar_text), "%lld",
+             (long long)record.scalar_integer_value);
+    replacement->source_position = context->source_position;
+    replacement->origin_node_id = context->origin_node_id;
+    replacement->origin_result_value_id = context->origin_result_value_id;
+    replacement->result_name = context->result_name;
+    replacement->metadata = context->metadata;
+    replacement->lineage = context->lineage;
+    replacement->flags = context->flags |
+                         DSL_TENSOR_FOLD_REPLACEMENT_REVISIT_PARENTS;
+    return DSL_TENSOR_FOLD_SUCCESS;
+}
+
+void
 DSL_Tensor_TCON_Reset (void)
 {
     /*
@@ -1340,6 +1566,65 @@ DSL_Tensor_TCON_Create_Splat
 {
     return DSL_Tensor_TCON_Create_Record
                (DSL_TENSOR_TCON_STORAGE_SPLAT, info, tcon_idx, carrier);
+}
+
+BOOL
+DSL_Tensor_TCON_Create_Integer_Splat
+        (TY_IDX descriptor_ty,
+         INT64 scalar_value,
+         TCON_IDX *tcon_idx,
+         TCON *carrier)
+{
+#ifdef DSL_TENSOR_FOLD_TEST_STUB
+    if (tcon_idx != NULL)
+        *tcon_idx = TCON_IDX_ZERO;
+    if (carrier != NULL)
+        memset(carrier, 0, sizeof(*carrier));
+    return FALSE;
+#else
+    DSL_TENSOR_TCON_CREATE_INFO info;
+    TY_IDX element_ty;
+    TYPE_ID element_mtype;
+    UINT64 element_count;
+    TCON scalar;
+
+    if (tcon_idx != NULL)
+        *tcon_idx = TCON_IDX_ZERO;
+    if (descriptor_ty == TY_IDX_ZERO || tcon_idx == NULL ||
+        !TY_tensor_is_canonical(descriptor_ty) ||
+        !DSL_Tensor_TCON_Static_Element_Count
+             (descriptor_ty, &element_count))
+        return FALSE;
+
+    element_ty = TY_tensor_element_ty(descriptor_ty);
+    element_mtype = TY_mtype(element_ty);
+    if (!MTYPE_is_integral(element_mtype) || TY_size(element_ty) == 0)
+        return FALSE;
+    scalar = Host_To_Targ(element_mtype, scalar_value);
+    if (Targ_To_Host(scalar) != scalar_value)
+        return FALSE;
+
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = descriptor_ty;
+    info.scalar_tcon = Enter_tcon(scalar);
+    info.element_mtype = element_mtype;
+    info.element_count = element_count;
+    info.element_size = TY_size(element_ty);
+    if (element_count > ~0ULL / info.element_size)
+        return FALSE;
+    info.logical_bytes = element_count * info.element_size;
+    info.required_alignment = TY_align(descriptor_ty);
+    if (info.required_alignment < info.element_size)
+        info.required_alignment = info.element_size;
+    info.scalar_integer_value = scalar_value;
+    if (scalar_value == 0)
+        return DSL_Tensor_TCON_Create_Zero
+                   (&info, tcon_idx, carrier);
+    if (scalar_value == 1)
+        return DSL_Tensor_TCON_Create_One
+                   (&info, tcon_idx, carrier);
+    return DSL_Tensor_TCON_Create_Splat(&info, tcon_idx, carrier);
+#endif
 }
 
 BOOL

--- a/osprey/common/com/dsl_tensor_fold.h
+++ b/osprey/common/com/dsl_tensor_fold.h
@@ -10,6 +10,7 @@
 #include "defs.h"
 #include "dsl_ir_image.h"
 #include "dsl_opcode.h"
+#include "srcpos.h"
 #include "symtab_idx.h"
 #include "targ_const.h"
 
@@ -24,6 +25,7 @@
  */
 
 #define DSL_TENSOR_FOLD_MAX_RESULTS 2
+#define DSL_TENSOR_FOLD_SCALAR_TEXT_SIZE 32
 #define DSL_TENSOR_TCON_MAGIC 0x44535443U
 #define DSL_TENSOR_TCON_VERSION 1
 #define DSL_TENSOR_TCON_ENVELOPE_SIZE 128
@@ -170,6 +172,66 @@ typedef struct {
     UINT32 flags;
 } DSL_TENSOR_FOLD_MOCK_RESPONSE;
 
+typedef enum {
+    DSL_TENSOR_FOLD_VALUE_NONE = 0,
+    DSL_TENSOR_FOLD_VALUE_COMPACT_TCON = 1
+} DSL_TENSOR_FOLD_VALUE_KIND;
+
+enum {
+    DSL_TENSOR_FOLD_VALUE_FLAG_COMPACT = 0x00000001,
+    DSL_TENSOR_FOLD_REPLACEMENT_REVISIT_PARENTS = 0x00000001
+};
+
+typedef struct {
+    DSL_TENSOR_FOLD_VALUE_KIND kind;
+    TCON_IDX tcon_idx;
+    TCON carrier;
+    DSL_TENSOR_TCON_RECORD tensor_record;
+    TY_IDX ty;
+    ST_IDX st;
+    DSL_IR_VALUE_ID dsl_value_id;
+    UINT32 flags;
+} DSL_TENSOR_FOLD_VALUE;
+
+/*
+ * STR_IDX and SRCPOS members are borrowed pass-through identities.  This
+ * service does not own or mutate their source tables.
+ */
+typedef struct {
+    TY_IDX result_ty;
+    ST_IDX result_st;
+    SRCPOS source_position;
+    DSL_IR_NODE_ID origin_node_id;
+    DSL_IR_VALUE_ID origin_result_value_id;
+    STR_IDX result_name;
+    STR_IDX metadata;
+    STR_IDX lineage;
+    UINT32 flags;
+} DSL_TENSOR_FOLD_REPLACEMENT_CONTEXT;
+
+typedef struct {
+    DSL_TENSOR_FOLD_STATUS status;
+    DSL_OPERATOR logical_operator;
+    UINT16 version;
+    UINT16 result_count;
+    TCON_IDX result_tcon_idx;
+    TCON result_tcon;
+    TY_IDX result_ty;
+    ST_IDX result_st;
+    TY_IDX descriptor_ty;
+    DSL_TENSOR_TCON_STORAGE_KIND result_storage_kind;
+    TCON_IDX scalar_tcon;
+    INT64 scalar_integer_value;
+    char compact_scalar_text[DSL_TENSOR_FOLD_SCALAR_TEXT_SIZE];
+    SRCPOS source_position;
+    DSL_IR_NODE_ID origin_node_id;
+    DSL_IR_VALUE_ID origin_result_value_id;
+    STR_IDX result_name;
+    STR_IDX metadata;
+    STR_IDX lineage;
+    UINT32 flags;
+} DSL_TENSOR_FOLD_REPLACEMENT;
+
 extern void DSL_Tensor_Fold_Default_Policy
                                 (DSL_TENSOR_FOLD_POLICY *policy);
 extern void DSL_Tensor_Fold_Reset_Mock_Evaluator (void);
@@ -193,6 +255,22 @@ extern BOOL DSL_Tensor_Fold_Candidate_Valid
 extern DSL_TENSOR_FOLD_STATUS Targ_DSL_WhirlOp
                                 (const DSL_TENSOR_FOLD_CANDIDATE *candidate,
                                  DSL_TENSOR_FOLD_OUTPUT *output);
+extern void DSL_Tensor_Fold_Value_Init
+                                (DSL_TENSOR_FOLD_VALUE *value);
+extern BOOL DSL_Tensor_Fold_Identify_Compact_TCON
+                                (TCON_IDX tcon_idx,
+                                 TY_IDX expected_ty,
+                                 ST_IDX st,
+                                 DSL_IR_VALUE_ID dsl_value_id,
+                                 DSL_TENSOR_FOLD_VALUE *value,
+                                 DSL_TENSOR_FOLD_STATUS *reason);
+extern void DSL_Tensor_Fold_Replacement_Init
+                                (DSL_TENSOR_FOLD_REPLACEMENT *replacement);
+extern DSL_TENSOR_FOLD_STATUS DSL_Tensor_Fold_Describe_Replacement
+                                (const DSL_TENSOR_FOLD_CANDIDATE *candidate,
+                                 const DSL_TENSOR_FOLD_REPLACEMENT_CONTEXT
+                                     *context,
+                                 DSL_TENSOR_FOLD_REPLACEMENT *replacement);
 extern void DSL_Tensor_TCON_Reset (void);
 extern void DSL_Tensor_TCON_Rebuild_Derived_Cache
                                 (TCON_IDX first_tcon_idx,
@@ -233,6 +311,11 @@ extern BOOL DSL_Tensor_TCON_Create_One
                                  TCON *carrier);
 extern BOOL DSL_Tensor_TCON_Create_Splat
                                 (const DSL_TENSOR_TCON_CREATE_INFO *info,
+                                 TCON_IDX *tcon_idx,
+                                 TCON *carrier);
+extern BOOL DSL_Tensor_TCON_Create_Integer_Splat
+                                (TY_IDX descriptor_ty,
+                                 INT64 scalar_value,
                                  TCON_IDX *tcon_idx,
                                  TCON *carrier);
 extern BOOL DSL_Tensor_TCON_Create_Inline_Dense

--- a/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
@@ -815,6 +815,22 @@ Check_VHO_Service_Boundary(void)
     context.flags = 0x20;
 
     UINT32 tcon_count = TCON_Table_Size();
+    const TY_IDX *saved_result_ty = candidate.result_ty;
+    candidate.result_ty = NULL;
+    memset(&replacement, 0xff, sizeof(replacement));
+    if (DSL_Tensor_Fold_Describe_Replacement
+            (&candidate, &context, &replacement) !=
+            DSL_TENSOR_FOLD_REJECT_MALFORMED_CANDIDATE ||
+        replacement.status !=
+            DSL_TENSOR_FOLD_REJECT_MALFORMED_CANDIDATE ||
+        replacement.result_count != 0 ||
+        replacement.result_tcon_idx != TCON_IDX_ZERO ||
+        TCON_Table_Size() != tcon_count) {
+        fprintf(stderr, "M4 malformed replacement created a TCON\n");
+        return 1;
+    }
+    candidate.result_ty = saved_result_ty;
+
     memset(&replacement, 0xff, sizeof(replacement));
     if (DSL_Tensor_Fold_Describe_Replacement
             (&candidate, &context, &replacement) !=

--- a/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_tensor_fold_contract_test.cxx
@@ -743,6 +743,123 @@ Check_Compact_Integer_Evaluator(void)
     return 0;
 }
 
+static int
+Check_VHO_Service_Boundary(void)
+{
+    DSL_TENSOR_TCON_CREATE_INFO info;
+    DSL_TENSOR_FOLD_VALUE left_value;
+    DSL_TENSOR_FOLD_VALUE right_value;
+    DSL_TENSOR_FOLD_POLICY policy;
+    DSL_TENSOR_FOLD_CANDIDATE candidate;
+    DSL_TENSOR_FOLD_REPLACEMENT_CONTEXT context;
+    DSL_TENSOR_FOLD_REPLACEMENT replacement;
+    DSL_TENSOR_TCON_RECORD replacement_record;
+    DSL_TENSOR_FOLD_STATUS reason;
+    TCON operands[2];
+    TY_IDX operand_ty[2];
+    TY_IDX result_ty[1];
+    TCON_IDX two_idx;
+    TCON_IDX three_idx;
+    TY_IDX descriptor_ty = Test_Tensor_Type(101);
+    TY_IDX wrong_ty = Test_Tensor_Type(201);
+
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = descriptor_ty;
+    info.element_mtype = MTYPE_I4;
+    info.element_size = 4;
+    info.element_count = 4;
+    info.logical_bytes = 16;
+    info.required_alignment = 4;
+    info.scalar_tcon = Test_Integer_TCON(2);
+    info.scalar_integer_value = 2;
+    if (!DSL_Tensor_TCON_Create_Splat(&info, &two_idx, NULL))
+        return 1;
+    info.scalar_tcon = Test_Integer_TCON(3);
+    info.scalar_integer_value = 3;
+    if (!DSL_Tensor_TCON_Create_Splat(&info, &three_idx, NULL))
+        return 1;
+
+    if (!DSL_Tensor_Fold_Identify_Compact_TCON
+             (two_idx, descriptor_ty, 11, 21, &left_value, &reason) ||
+        !DSL_Tensor_Fold_Identify_Compact_TCON
+             (three_idx, descriptor_ty, 12, 22, &right_value, &reason)) {
+        fprintf(stderr, "M4 compact tensor identification failed\n");
+        return 1;
+    }
+
+    operands[0] = left_value.carrier;
+    operands[1] = right_value.carrier;
+    operand_ty[0] = left_value.ty;
+    operand_ty[1] = right_value.ty;
+    result_ty[0] = descriptor_ty;
+    DSL_Tensor_Fold_Default_Policy(&policy);
+    memset(&candidate, 0, sizeof(candidate));
+    candidate.dsl_operator = OPR_DSLADD;
+    candidate.version = 1;
+    candidate.result_count = 1;
+    candidate.operand_count = 2;
+    candidate.operands = operands;
+    candidate.operand_ty = operand_ty;
+    candidate.result_ty = result_ty;
+    candidate.policy = &policy;
+
+    memset(&context, 0, sizeof(context));
+    context.result_ty = wrong_ty;
+    context.result_st = 77;
+    context.source_position = 0x1234;
+    context.origin_node_id = 31;
+    context.origin_result_value_id = 32;
+    context.result_name = Save_Str("folded_splat");
+    context.metadata = Save_Str("tensor_fold.origin=OPR_DSLADD");
+    context.lineage = Save_Str("lineage:add-after-propagation");
+    context.flags = 0x20;
+
+    UINT32 tcon_count = TCON_Table_Size();
+    memset(&replacement, 0xff, sizeof(replacement));
+    if (DSL_Tensor_Fold_Describe_Replacement
+            (&candidate, &context, &replacement) !=
+            DSL_TENSOR_FOLD_REJECT_DESCRIPTOR_MISMATCH ||
+        replacement.status !=
+            DSL_TENSOR_FOLD_REJECT_DESCRIPTOR_MISMATCH ||
+        replacement.result_count != 0 ||
+        replacement.result_tcon_idx != TCON_IDX_ZERO ||
+        TCON_Table_Size() != tcon_count) {
+        fprintf(stderr, "M4 descriptor rejection created a TCON\n");
+        return 1;
+    }
+
+    context.result_ty = descriptor_ty;
+    if (DSL_Tensor_Fold_Describe_Replacement
+            (&candidate, &context, &replacement) !=
+            DSL_TENSOR_FOLD_SUCCESS ||
+        replacement.status != DSL_TENSOR_FOLD_SUCCESS ||
+        replacement.logical_operator != OPR_DSLTENSORCONST ||
+        replacement.version != 1 ||
+        replacement.result_count != 1 ||
+        replacement.result_tcon_idx == TCON_IDX_ZERO ||
+        !DSL_Tensor_TCON_Get(replacement.result_tcon_idx,
+                             &replacement_record) ||
+        replacement_record.scalar_integer_value != 5 ||
+        replacement.result_ty != descriptor_ty ||
+        replacement.result_st != context.result_st ||
+        replacement.source_position != context.source_position ||
+        replacement.origin_node_id != context.origin_node_id ||
+        replacement.origin_result_value_id !=
+            context.origin_result_value_id ||
+        replacement.result_name != context.result_name ||
+        replacement.metadata != context.metadata ||
+        replacement.lineage != context.lineage ||
+        strcmp(replacement.compact_scalar_text, "5") != 0 ||
+        (replacement.flags &
+             DSL_TENSOR_FOLD_REPLACEMENT_REVISIT_PARENTS) == 0 ||
+        (replacement.flags & context.flags) == 0) {
+        fprintf(stderr, "M4 tensor replacement descriptor changed\n");
+        return 1;
+    }
+
+    return 0;
+}
+
 int
 main(void)
 {
@@ -756,9 +873,10 @@ main(void)
         Check_Candidate_Contract() ||
         Check_Mock_Evaluator() ||
         Check_Tensor_TCON_Storage() ||
-        Check_Compact_Integer_Evaluator())
+        Check_Compact_Integer_Evaluator() ||
+        Check_VHO_Service_Boundary())
         return 1;
 
-    printf("DSL tensor fold M3 compact evaluator contract passed\n");
+    printf("DSL tensor fold M4 VHO service contract passed\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

- register fixed-position VHO DSL canonicalization and algebraic simplification passes
- canonicalize compact integer tensor operands and collect `x + x` as `2 * x`
- reuse `Targ_DSL_WhirlOp` for VHO-time compact tensor constant folding and parent revisiting
- rewrite logical DSL image nodes while preserving node/value IDs, result ST/TY, metadata, lineage, and SRCPOS
- keep `.WHIRL.dsl` version 1 and all fixed binary row layouts unchanged
- update the synchronized simplification and tensor-folding M4 plans

## Compatibility

The new image mutation APIs operate only on in-memory tables. They preserve existing node/result identities and use the existing ELF mapped-image path. No WHIRL opcode encoding, ELF section contract, TCON size, or DSL image record layout changes.

## Validation

- `OPEN64_DSL_TENSOR_FOLD_M3_ONLY=1 dsl_builder_contract_test`
- `OPEN64_DSL_VHO_M4_ONLY=1 dsl_lower_contract_test`
- `dsl_tensor_fold_contract_test.sh`
- `dsl_native_syntax_test.sh`, including all physical operator compatibility targets
- mapped `.B` reopen with `ir_b2a -st -src`
- `git diff --check` and no-tab scan

The retained local review trace demonstrates canonical operand order, `common.mul(input, tensor_const(2))`, folded `tensor_const(5)`, parent revisit to `tensor_const(6)`, source positions, tensor TCON rows, and logical image records.

The broad `dsl_lower_contract_test` still reports `native DSL value-source lowering contract changed`; the same failure was reproduced on untouched `develop` and is not introduced by this PR.