### PR TITLE
Complete M5 DSL WOPT admission and factorization

### DIFF
--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -75,12 +75,14 @@ in all four operand positions using `FACTOR_11`, `FACTOR_12`, `FACTOR_21`, and
 z*x + z*y  -> z*(x+y)
 x*z + y*z  -> (x+y)*z
 z*x - z*y  -> z*(x-y)
-z*x + z    -> z*(x+1)
+z*c + z    -> z*(c+1)
 ```
 
 The same framework is also used for selected bitwise and logical identities.
 Arithmetic factorization requires aggressive simplification. Floating-point
-factorization is rejected unless reassociation is enabled.
+factorization is rejected unless reassociation is enabled. The arithmetic
+`simp_factor_idty()` call uses `const_only=TRUE`, so the final identity form
+above requires the non-common product operand to be constant.
 
 Factorization is a relationship between an outer operator and an inner
 operator. It is not adequately represented by a single `factorable` bit on
@@ -99,10 +101,71 @@ reassociation followed by tree comparison and cancellation. It is enabled for
 integer types and requires `Enable_Cfold_Reassociate` for floating-point
 types. The cancellation search also requires `Enable_Cfold_Aggressive`.
 
+WOPT exposes this rule through a deliberately limited copy-propagation
+classification:
+
+```text
+Is_exp_cancellable(producer_rhs, consumer_rhs)
+```
+
+`Is_exp_cancellable()` classifies the producer and consumer RHS operator
+relationship. Its first supported family is `ADD/SUB`. `MPY/DIV` is a
+potential mathematical family but is not admitted merely from operator names:
+integer division is not an inverse under truncation, floating-point
+multiplication and division are sensitive to zero, NaN, infinity, and
+rounding, and tensor division may define additional elementwise behavior.
+The traditional simplifier currently implements `x/x -> 1` under its existing
+aggressive and numeric controls, but it does not provide a general
+`(x*y)/x -> y` or `x*(y/x) -> y` rule.
+
+A separate structural predicate controls whether the classified producer can
+actually be propagated:
+
+```text
+Is_simplification_propagatable(use, producer_stmt, consumer_stmt, relation)
+```
+
+The first cancellation implementation accepts only an adjacent same-BB
+producer and consumer, a direct single use of the producer result in the
+consumer RHS, pure/projectable DSL semantics, compatible TensorDescriptorIR
+identities, no effects, and numeric safety that permits reassociation.
+Operator compatibility identifies an opportunity; it does not prove
+cancellation. The traditional `simp_add_sub()` implementation still compares
+operands and is the sole authority that performs or rejects the rewrite.
+
+This predicate authorizes only the exact producer CODEREP. It does not enable
+general DSL copy propagation, propagation across another statement, or
+recursive propagation of nested DSL definitions. CODEREP-to-WN emission must
+re-materialize the retained unique no-alias result STIDs and mapped-image
+relationships after simplification.
+
 `simp_factor()` and `simp_factor_idty()` handle the second family across all
 four common-factor operand positions. They require
 `Enable_Cfold_Aggressive`, and floating-point factorization additionally
 requires `Enable_Cfold_Reassociate`.
+
+Factorization also depends on opportunity-forming copy propagation. Given:
+
+```text
+t0 = x * y
+t1 = x * z
+t2 = t0 + t1
+```
+
+both producer expressions must become visible to `simp_factor()` as
+`(x*y) + (x*z)`. An adjacency-only predicate cannot expose this form because
+`t0` is not immediately adjacent to `t2`. Therefore factorization uses a
+separate `Is_exp_factorable()` operator-relation classifier and permits a
+bounded same-BB walk over pure statements. Each propagated value must still be
+single-use, dominate the consumer, have no prohibited boundary between its
+definition and use, and satisfy the registered factorization operand mask.
+The traditional factorization engine remains responsible for finding the
+actual common operand.
+
+For commutative elementwise `common.mul`, all four factor positions may be
+eligible. Noncommutative operations such as matrix multiplication require a
+different relation contract and operand mask; they must never inherit the
+elementwise `FACTOR_ALL` behavior.
 
 `Enable_Cfold_Aggressive` is normally enabled by Open64 configuration unless
 the user overrides `-OPT:fold_aggressive`. Consequently, the DSL
@@ -1082,14 +1145,20 @@ second tensor-folding implementation. `-WOPT:cr_simp` and
 **Pull request:** WOPT admission and existing-rule reuse only. DIVREM remains
 disabled until M6.
 
-**Current status:** W3-W6 are implemented as a guarded pure integer tensor
-vertical slice for `common.tensor_const`, `common.add`, and `common.mul`.
-Logical CODEREP import/printing/emission is complete for this slice, and WOPT
-calls the same `DSL_Tensor_Fold_Describe_Replacement` service used by WN/VHO.
-The native bridge test proves import, evaluation, mapped-image rewrite,
-emission, and gatekeeper acceptance. Full backend option A/B artifacts remain
-blocked on W7's conservative audit because the established driver currently
-lowers DSL WHIRL before WOPT.
+**Current status:** W3-W6 and the first controlled W7 transform are
+implemented as a guarded pure integer tensor vertical slice for
+`common.tensor_const`, `common.add`, and `common.mul`. Logical CODEREP
+import/printing/emission is complete for this slice, and WOPT calls the same
+`DSL_Tensor_Fold_Describe_Replacement` service used by WN/VHO. Bounded
+single-use same-BB factorization projects tensor-element-typed stack CODEREPs
+through the traditional `wn_simp_code.h` engine, then rematerializes unique
+DSL result STIDs and mapped-image records. Retained tests cover the positive
+integer rewrite, `-WOPT:cr_simp=off`, and no-common-factor rejection.
+The non-asserting algebraic-safety test covers strict FP and explicitly
+enabled reassociation before WOPT enters the traditional simplifier.
+Cancellation remains inactive until a native subtraction contract exists;
+general DSL copy propagation, MPY/DIV cancellation, CSE, PRE, and broad
+enablement remain deferred.
 
 ### M6: Add projectable tensor DIVREM
 
@@ -1136,7 +1205,7 @@ capability per pull request. Do not use M7 as a miscellaneous cleanup batch.
 | M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Merged through PR #96 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Merged through PR #97 | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
-| M5 | W3-W6 vertical slice implemented; W7 service/driver audit remains | M4 merged | Native bridge passed; WOPT A/B pending W7 |
+| M5 | Complete; PR pending | M4 merged | Fold A/B, factor/no-factor traces, strict-FP policy test |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
 | M7 | Blocked by M6 | M6 merged | Full certification matrix |
 

--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -1067,6 +1067,15 @@ second tensor-folding implementation. `-WOPT:cr_simp` and
 **Pull request:** WOPT admission and existing-rule reuse only. DIVREM remains
 disabled until M6.
 
+**Current status:** W3-W6 are implemented as a guarded pure integer tensor
+vertical slice for `common.tensor_const`, `common.add`, and `common.mul`.
+Logical CODEREP import/printing/emission is complete for this slice, and WOPT
+calls the same `DSL_Tensor_Fold_Describe_Replacement` service used by WN/VHO.
+The native bridge test proves import, evaluation, mapped-image rewrite,
+emission, and gatekeeper acceptance. Full backend option A/B artifacts remain
+blocked on W7's conservative audit because the established driver currently
+lowers DSL WHIRL before WOPT.
+
 ### M6: Add projectable tensor DIVREM
 
 **Simplifier work:** complete the projectable-operation portion of S2 and S8:
@@ -1112,7 +1121,7 @@ capability per pull request. Do not use M7 as a miscellaneous cleanup batch.
 | M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Merged through PR #96 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Merged through PR #97 | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
-| M5 | Active on `codex/dsl-wopt-m5`; W0/W1 foundation in progress | M4 merged | WOPT A/B artifacts |
+| M5 | W3-W6 vertical slice implemented; W7 service/driver audit remains | M4 merged | Native bridge passed; WOPT A/B pending W7 |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
 | M7 | Blocked by M6 | M6 merged | Full certification matrix |
 

--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -1111,8 +1111,8 @@ capability per pull request. Do not use M7 as a miscellaneous cleanup batch.
 | M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
 | M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Merged through PR #96 | M2 merged | Enabled/disabled fold artifacts |
-| M4 | PR #97 open; implemented and validated on `codex/dsl-simplifier-m4` | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
-| M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |
+| M4 | Merged through PR #97 | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
+| M5 | Active on `codex/dsl-wopt-m5`; W0/W1 foundation in progress | M4 merged | WOPT A/B artifacts |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
 | M7 | Blocked by M6 | M6 merged | Full certification matrix |
 

--- a/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
+++ b/doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md
@@ -111,6 +111,21 @@ eligible DSL integer expression, investigate the logical-DSL preparation,
 traditional opcode projection, option state, tree comparison, or
 TensorDescriptorIR legality checks.
 
+The first cancellation family also demonstrates why the owner of a rule is
+not necessarily the phase that exposes it. Given:
+
+```text
+t0 = y - x
+t1 = x + t0
+```
+
+WOPT copy propagation must first form `x + (y - x)`. The resulting expression
+is then simplified by the traditional `simp_add_sub()` rule. Therefore,
+controlled DSL copy propagation is part of the immediate DSL WOPT expression
+milestone even though cancellation itself remains a `wn_simp` responsibility.
+Emission must restore unique no-alias result STIDs instead of publishing
+propagated DSL producer nodes as duplicate nested definitions.
+
 The TVM div/mod reconstruction family requires a more precise Open64
 comparison. The traditional WN simplifier handles individual `DIV`, `MOD`,
 and `REM` identities and power-of-two cases, but it does not directly
@@ -1324,6 +1339,10 @@ and statement SRCPOS. The retained M4 artifact reopens through
   CODEREP-to-WN emission.
 - Include DSL operator, version, attributes, and TensorDescriptorIR identity
   in hash and equality.
+- Allow controlled copy propagation to form eligible multi-level expressions
+  before invoking the traditional simplifier.
+- Re-materialize every retained logical DSL operator result into its unique
+  no-alias STID during CODEREP-to-WN emission.
 - Add logical CODEREP printing and effect-aware optimization queries.
 - Route eligible DSL algebra through the existing CODEREP instantiation of
   `wn_simp_code.h`.

--- a/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
+++ b/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
@@ -569,7 +569,7 @@ range, and checksum.
 | M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Merged through PR #96 | M2 merged | Enabled/disabled fold artifacts |
 | M4 | Merged through PR #97 | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
-| M5 | Active on `codex/dsl-wopt-m5`; W0/W1 foundation in progress | M4 merged | WOPT A/B artifacts |
+| M5 | WOPT compact add/mul bridge implemented; W7 admission remains | M4 merged | Shared-evaluator bridge passed; WOPT A/B pending W7 |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
 | M7 | Blocked by M6 | M6 merged | Full certification matrix |
 

--- a/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
+++ b/doc/WHIRL-DSL-TENSOR-CONSTANT-FOLDING-PLAN.md
@@ -568,8 +568,8 @@ range, and checksum.
 | M1 | Merged through PR #93 | M0 merged | Simplifier bridge traces |
 | M2 | Merged through PR #94/#95 | M1 merged | Tensor TCON `.B` and `.T` |
 | M3 | Merged through PR #96 | M2 merged | Enabled/disabled fold artifacts |
-| M4 | PR #97 open; implemented and validated on `codex/dsl-simplifier-m4` | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
-| M5 | Blocked by M4 | M4 merged | WOPT A/B artifacts |
+| M4 | Merged through PR #97 | M3 merged | `artifacts/m4-vho-simplification/vho_simplification.{B,T}` |
+| M5 | Active on `codex/dsl-wopt-m5`; W0/W1 foundation in progress | M4 merged | WOPT A/B artifacts |
 | M6 | Blocked by M5 | M5 merged | DIVREM gate/projection artifacts |
 | M7 | Blocked by M6 | M6 merged | Full certification matrix |
 

--- a/doc/WOPT-DSL-ADAPTATION-PLAN.md
+++ b/doc/WOPT-DSL-ADAPTATION-PLAN.md
@@ -68,8 +68,14 @@ WOPT-local operator field may fit without increasing the 88-byte CODEREP on
 this ABI. This is an observation, not a portable guarantee. Any layout change
 must be compiled and measured for every supported target.
 
-The old disabled size assertion in `opt_main.cxx` expects a historical
-48-byte CODEREP and does not describe the current x86-64 layout.
+The historical disabled 48-byte assertion in `opt_main.cxx` has been
+corrected for the measured x86-64 LP64 layout. The active runtime assertion
+and the compile-time guard in `opt_htable.cxx` both require
+`sizeof(CODEREP) == 88`. An intentional CODEREP expansion must update these
+guards in the same reviewed change after documenting the new field, measured
+target layouts, memory-cost impact, stack/pool allocation behavior, and
+required regression results. Other target layouts remain measurements to add,
+not assumptions copied from x86-64.
 
 ### Existing stack and pool protocol
 

--- a/doc/WOPT-DSL-ADAPTATION-PLAN.md
+++ b/doc/WOPT-DSL-ADAPTATION-PLAN.md
@@ -58,6 +58,7 @@ DWARF information in the current Linux x86-64 WOPT build reports:
 | Entity | Observed size |
 | --- | ---: |
 | `CODEREP` | 88 bytes |
+| `STMTREP` | 112 bytes |
 | `CK_OP` subrecord | 48 bytes |
 | `CK_IVAR` subrecord | 40 bytes |
 | `CK_OP::_opr` | 8 bits |
@@ -68,14 +69,18 @@ WOPT-local operator field may fit without increasing the 88-byte CODEREP on
 this ABI. This is an observation, not a portable guarantee. Any layout change
 must be compiled and measured for every supported target.
 
-The historical disabled 48-byte assertion in `opt_main.cxx` has been
-corrected for the measured x86-64 LP64 layout. The active runtime assertion
-and the compile-time guard in `opt_htable.cxx` both require
-`sizeof(CODEREP) == 88`. An intentional CODEREP expansion must update these
-guards in the same reviewed change after documenting the new field, measured
-target layouts, memory-cost impact, stack/pool allocation behavior, and
-required regression results. Other target layouts remain measurements to add,
-not assumptions copied from x86-64.
+The historical disabled 48-byte `CODEREP` and 60/64-byte `STMTREP` assertions
+in `opt_main.cxx` have been corrected for the measured x86-64 LP64 layout.
+Active runtime assertions and compile-time guards in `opt_htable.cxx` require
+`sizeof(CODEREP) == 88` and `sizeof(STMTREP) == 112`. The two records must be
+reviewed together because DSL value expressions enter WOPT as CODEREPs while
+DSL assignments, including `STID`, enter as STMTREPs.
+
+An intentional expansion of either record must update its guards in the same
+reviewed change after documenting the new field, measured target layouts,
+memory-cost impact, stack/pool allocation behavior, and required regression
+results. Other target layouts remain measurements to add, not assumptions
+copied from x86-64.
 
 ### Existing stack and pool protocol
 

--- a/doc/WOPT-DSL-ADAPTATION-PLAN.md
+++ b/doc/WOPT-DSL-ADAPTATION-PLAN.md
@@ -1,0 +1,534 @@
+# WOPT Adaptation Plan for DSL WHIRL
+
+## Purpose
+
+This plan defines how WOPT will admit, represent, optimize, simplify, and emit
+unlowered Very High Level DSL WHIRL expressions.
+
+The objective is to make logical DSL operators first-class WOPT expressions
+without exposing the physical `OPR_DSL` escape representation to WOPT
+developers. Binary WHIRL compatibility remains unchanged: WN and binary WHIRL
+continue using the existing escape and mapped-image records until an explicit
+versioned binary-format change is approved.
+
+This is main Open64 middle-end infrastructure work. Python frontends continue
+to produce binary WHIRL through opaque native builder APIs and do not inspect
+CODEREP, WN layout, or private DSL encoding.
+
+## Architectural Boundary
+
+The intended pipeline is:
+
+```text
+binary WHIRL / physical OPR_DSL
+  -> mapped-image reader
+  -> DSL gatekeeper
+  -> WN-to-CODEREP DSL import
+  -> first-class logical DSL CODEREP
+  -> WOPT analyses, transformations, and simplification
+  -> CODEREP-to-WN DSL emission
+  -> physical OPR_DSL plus mapped-image relationships
+```
+
+`OPR_DSL` remains a private compatibility mechanism at the WN and binary file
+boundaries. WOPT diagnostics, traces, hashing, matching, and optimization
+logic operate on logical names such as `OPR_DSLADD`.
+
+## Current WOPT Findings
+
+### CODEREP operator capacity
+
+`CODEREP` is defined in `osprey/be/opt/opt_htable.h`.
+
+- `CK_OP` stores `_opr` as `OPERATOR _opr:8`.
+- `CK_IVAR` also stores `_opr` as `OPERATOR _opr:8`.
+- The field therefore represents at most 256 values.
+- Native `OPERATOR_LAST` is currently 148.
+- Only 107 numeric values remain between 149 and 255.
+- `OPCODE` also reserves eight bits for its operator component.
+
+Allocating the remaining native values directly to DSL operators is not a
+scalable first-class WOPT design. It would also entangle runtime WOPT identity
+with the binary WHIRL operator namespace.
+
+### Observed x86-64 layout
+
+DWARF information in the current Linux x86-64 WOPT build reports:
+
+| Entity | Observed size |
+| --- | ---: |
+| `CODEREP` | 88 bytes |
+| `CK_OP` subrecord | 48 bytes |
+| `CK_IVAR` subrecord | 40 bytes |
+| `CK_OP::_opr` | 8 bits |
+| `CK_IVAR::_opr` | 8 bits |
+
+The `CK_OP` subrecord has alignment space before its first pointer. A wider
+WOPT-local operator field may fit without increasing the 88-byte CODEREP on
+this ABI. This is an observation, not a portable guarantee. Any layout change
+must be compiled and measured for every supported target.
+
+The old disabled size assertion in `opt_main.cxx` expects a historical
+48-byte CODEREP and does not describe the current x86-64 layout.
+
+### Existing stack and pool protocol
+
+WOPT already follows the established temporary-node protocol:
+
+- `Alloc_stack_cr` allocates temporary CODEREP views on the stack.
+- `CR_Create` and related helpers initialize temporary expressions.
+- `CODEMAP::Hash_Op` canonicalizes and finds or creates the retained CODEREP.
+- `CXX_NEW_VARIANT` allocates retained CODEREPs and extra kid storage in the
+  WOPT memory pool.
+- Temporary stack inputs are discarded without memory-pool deletion.
+
+DSL adaptation must preserve this protocol.
+
+### Existing simplifier integration
+
+WOPT already reuses the traditional Open64 simplifier:
+
+- `opt_fold.h` defines `simpnode` as `CODEREP *`.
+- It provides CODEREP implementations of the `SIMPNODE_*` accessors and
+  constructors.
+- `opt_fold.cxx` includes `wn_simp_code.h`.
+- Simplifier-created expressions are sent through CODEREP hashing.
+
+The authoritative WOPT controls are:
+
+| Option | State | Purpose |
+| --- | --- | --- |
+| `-WOPT:cr_simp=on|off` | `WOPT_Enable_CRSIMP` | Enable CODEREP simplification |
+| `-WOPT:fold2const=on|off` | `WOPT_Enable_Fold2const` | Invoke folding and simplification entry points |
+
+`-OPT:wn_simp=on|off` controls construction-time WN simplification. It is not
+the WOPT CODEREP simplifier switch.
+
+DSL WOPT support must continue using the CODEREP instantiation of
+`wn_simp_code.h`. It must not create an independent WOPT algebraic engine.
+
+### Existing projectable-operation integration
+
+WOPT already has a reusable optimization model for related multiple results:
+
+- `Combine_Operations()` changes integral `DIV(a,b)` into
+  `DIVPART(DIVREM(a,b))` and `REM(a,b)` into
+  `REMPART(DIVREM(a,b))`.
+- CODEREP hashing, CSE, and PRE can share the common `DIVREM(a,b)`.
+- `opt_project.h` defines projectable-operation and projection queries.
+- DCE counts live projection uses of projectable EPRE temporaries.
+- CODEREP-to-WN emission calls `Uncombine_Operations()` so a sole surviving
+  projection becomes an ordinary DIV or REM.
+- `-WOPT:divrem` controls the transformation through
+  `WOPT_Enable_DIVREM`.
+
+Logical tensor DIV and REM must extend this framework instead of introducing a
+separate WOPT reconstruction peephole. Target profitability remains part of
+the contract. Traditional NVISA configuration disables DIVREM because it sees
+no advantage. Its virtual ISA models separate DIV and REM operations, and its
+`Expand_DivRem()` path is intentionally not implemented. The disable therefore
+also prevents WOPT from sending an unsupported combined operation to CG.
+Tensor targets must independently prove a combined lowering capability and
+profitability before enabling this transformation. If either gate fails,
+WOPT must retain standalone DIV and REM.
+
+## Unsafe Current Admission
+
+A physical `OPR_DSL` must not enter WOPT as an ordinary generic `CK_OP`
+without logical decoding.
+
+Current generic behavior is insufficient:
+
+- `CODEMAP::Hash_op_and_canon` hashes `cr->Op()` and kid CODEREP IDs.
+- `CODEREP::Match` compares `Op()`, kid count, kid pointers, and selected
+  native-operator fields.
+- `CODEREP::Print_node` obtains its name through `OPCODE_name`.
+- `wn_simp_ftable.h` has a null simplifier entry for `OPR_DSL`.
+
+The physical opcode does not carry logical DSL operator identity, version,
+canonical attributes, TensorDescriptorIR identity, or the complete effect
+contract. If these facts are omitted, two semantically different DSL
+expressions with the same kids could be incorrectly treated as the same value.
+
+The current compiler must therefore continue lowering DSL expressions before
+ordinary WOPT admission until the import, representation, hash, equality, and
+emission work in this plan is complete.
+
+## Required WOPT Representation
+
+### Logical operator identity
+
+Introduce a WOPT-local logical operator representation for `CK_OP`.
+
+Requirements:
+
+1. Represent every existing native `OPERATOR`.
+2. Represent the reviewed DSL operator namespace without consuming the
+   remaining native operator values.
+3. Distinguish native and DSL identities without manually decoding
+   `OPR_DSL`.
+4. Provide guarded APIs for native operator, DSL operator, name, category,
+   version, and properties.
+5. Reject narrowing conversions to the existing 8-bit native operator field.
+
+A 16-bit or 32-bit field can satisfy the current identity requirement. The
+implementation decision must account for namespace growth and layout results.
+A 32-bit WOPT-local identity is preferred unless target layout measurements
+show a material cost.
+
+### Version and semantic information
+
+Operator identity alone is not semantically complete. Each DSL CODEREP needs:
+
+- logical DSL operator;
+- operator contract version;
+- canonical opcode attributes;
+- result TensorDescriptorIR identity;
+- relevant operand TensorDescriptorIR identities or verified references;
+- effect and ownership contract;
+- source and transformation lineage references where required for emission;
+- mapped-image reconstruction reference.
+
+Use a WOPT-owned fixed-layout semantic-info table indexed from CODEREP rather
+than embedding STL containers in CODEREP. The table is runtime middle-end
+state; it is reconstructed from the binary DSL IR image on import and used to
+rebuild mapped-image relationships on emission.
+
+### Hash and equality
+
+For a pure DSL expression, value identity must include:
+
+```text
+logical operator
+operator version
+canonical opcode attributes
+result TensorDescriptorIR identity
+operand CODEREP identities
+effect-relevant semantic identity
+```
+
+Source position, diagnostics, profiling data, and nonsemantic lineage do not
+participate in value equivalence. They must still be preserved or merged when
+WOPT reuses an existing CODEREP.
+
+Effectful DSL operators must not enter ordinary expression CSE merely because
+their semantic keys and kids match.
+
+### Printing
+
+CODEREP and WOPT trace printers must:
+
+- print logical names such as `OPR_DSLADD`;
+- print operator version when needed to distinguish contracts;
+- expose canonical semantic attributes and result descriptor identity;
+- never print the private physical `OPR_DSL` escape or image-record index as
+  the operator identity.
+
+## WN-to-CODEREP Import
+
+Add an explicit DSL branch before generic expression handling in
+`CODEMAP::Add_expr`.
+
+The importer must:
+
+1. recognize a native DSL WN through public DSL WN APIs;
+2. obtain the logical opcode and version;
+3. load and validate the associated DSL image record;
+4. resolve the result TensorDescriptorIR and attributes;
+5. verify that the gatekeeper has accepted the operator;
+6. recursively import operand values;
+7. create a temporary first-class DSL CODEREP;
+8. hash it using DSL semantic identity; and
+9. retain source and reconstruction information.
+
+The importer must not teach generic WOPT code how to decode WN escape fields.
+
+## WOPT Simplifier Path
+
+### Preparation
+
+For each logical DSL operator, query the algebraic registry and tensor
+legality engine.
+
+Only when semantics are equivalent may preparation project a DSL CODEREP to a
+temporary native CODEREP view. For example:
+
+```text
+pure common.add.v1
+integer dtype
+identical logical shapes
+no broadcasting
+compatible representation
+no runtime state or effects
+  -> temporary native OPR_ADD CODEREP view
+```
+
+The projection is stack-local and is never published as the permanent
+identity of the DSL expression.
+
+### Existing engine
+
+Run the existing CODEREP instantiation of `wn_simp_code.h`.
+
+The engine continues to provide applicable canonicalization, constant folding,
+identity, cancellation, reassociation, and factorization rules under existing
+Open64 numeric and WOPT option controls.
+
+### Postprocessing
+
+Classify the simplifier result:
+
+- no replacement;
+- reuse of an existing operand or value;
+- folded constant;
+- rebuilt expression; or
+- rejected replacement.
+
+For a rebuilt DSL expression, restore logical operator identity, version,
+attributes, TensorDescriptorIR, effects, and source relationships before
+hashing the retained CODEREP.
+
+A returned native expression may remain native only when the transformation
+semantically lowers the DSL operator at an approved pipeline point. Algebraic
+simplification by itself must not accidentally lower domain-visible DSL
+semantics.
+
+## Other WOPT Services
+
+First-class operator identity is necessary but not sufficient. Review these
+WOPT services before enabling DSL admission:
+
+- expression hashing and CSE;
+- copy propagation;
+- value numbering;
+- SSA PRE and SSAPRE;
+- dead-code elimination;
+- use counts and recursive deletion;
+- alias, MU, CHI, and effect handling;
+- loop and induction-variable recognition;
+- type conversion and actual-data-size queries;
+- profitability and expression-cost models;
+- CODEREP copying and rehashing;
+- debug and trace printing;
+- CODEREP-to-WN emission.
+
+Each service must either understand the reviewed DSL contract or conservatively
+preserve the expression without transforming it.
+
+## CODEREP-to-WN Emission
+
+Intercept first-class DSL CODEREPs before generic `cr->Op()` emission.
+
+The emitter must:
+
+1. recover logical operator, version, operands, and semantic-info record;
+2. create the native DSL WN through public DSL WN APIs;
+3. restore attributes, result descriptor, effects, source position, and
+   lineage;
+4. recreate mapped-image DSL relationships;
+5. preserve retained high-level comment projection where required;
+6. emit logical DSL evidence in traces; and
+7. run the DSL gatekeeper on the emitted tree in validation builds.
+
+No new binary WHIRL operator allocation is required for this WOPT adaptation.
+
+## Option and Debugging Contract
+
+Preserve independent A/B controls:
+
+1. `-OPT:wn_simp=off` disables construction-time WN simplification.
+2. `-WOPT:cr_simp=off` disables CODEREP simplification.
+3. `-WOPT:fold2const=off` disables the WOPT folding entry path.
+4. DSL-specific WOPT controls may further disable a staged transformation but
+   must not override these master controls.
+
+Certification must retain separate artifact families and run:
+
+```text
+ir_b2a -st -src input.B input.T
+```
+
+The comparison matrix must distinguish:
+
+- construction simplification on/off;
+- VHO DSL simplification on/off;
+- WOPT CODEREP simplification on/off; and
+- WOPT folding on/off.
+
+## Compatibility Requirements
+
+1. Do not change WN layout or the binary 8-bit operator field.
+2. Do not allocate the remaining native operator slots as the DSL namespace.
+3. Preserve mapped-image and ELF section contracts.
+4. Preserve scalar WOPT behavior when no DSL CODEREP is present.
+5. Preserve existing WOPT option behavior and defaults.
+6. Preserve logical DSL operator names, versions, attributes, descriptors, and
+   effects across WN-to-CODEREP-to-WN conversion.
+7. Unknown or unsupported DSL contracts must be diagnosed or preserved
+   conservatively, never silently reinterpreted.
+8. WOPT runtime structures may change without a binary WHIRL version bump, but
+   their size and allocation effects must be measured and tested.
+
+## Initial Vertical Slice
+
+Use three operators to stage the integration:
+
+1. `common.tensor_const.v1`
+2. `common.add.v1`
+3. `common.mul.v1`
+
+The first optimization cases are:
+
+```text
+x + tensor_zero -> x
+tensor_zero + x -> x
+x * tensor_one  -> x
+tensor_one * x  -> x
+constant + constant -> folded tensor constant
+```
+
+Apply them initially only to pure, exact integer tensors with identical
+descriptors and no broadcasting, quantization, sharding, placement mismatch,
+or runtime state.
+
+## Staged Action Queue
+
+### M5 Progress
+
+M5 is active on `codex/dsl-wopt-m5` after PR #97 merged. The first W0/W1
+batch selected a 32-bit WOPT-local semantic-info index and placed it in the
+existing x86-64 `CK_OP` alignment space. Linux DWARF still reports
+`sizeof(CODEREP) == 88`. The fixed-layout semantic record is runtime-only and
+interns logical operator, version, canonical attributes, result descriptor,
+operand descriptor identity, effects, and algebraic flags. Initialization,
+copy, hash, equality, and logical printing now preserve that identity.
+
+The generic WN importer is intentionally still closed to DSL nodes. W3 may
+open it only after it can construct a complete semantic record before the
+first hash operation. WOPT simplification and emission remain disabled until
+W5 and W6 respectively; this prevents an incomplete first-class CODEREP from
+escaping the staged implementation.
+
+The same batch covers the non-behavioral W2 mechanics. `Init_op()` clears the
+semantic index, `CODEREP::Copy()` preserves it, and existing stack allocation,
+variant allocation, extra-kid storage, use counts, and rehashing continue to
+operate on the unchanged CODEREP size. Guarded APIs distinguish logical DSL
+identity from native `OPERATOR`; requesting a native operator from a logical
+DSL CODEREP is an assertion failure. Hashing and equality include the interned
+semantic identity, while native CODEREPs retain zero as the index and follow
+their previous paths.
+
+### W0: Baseline
+
+- Capture current scalar WOPT simplifier tests and traces.
+- Add a test proving unadapted physical `OPR_DSL` is rejected before generic
+  WOPT hashing.
+- Record target-specific CODEREP sizes and offsets.
+
+### W1: Representation prototype
+
+- Define the WOPT-local logical operator type.
+- Define the fixed-layout DSL CODEREP semantic-info record and table.
+- Prototype 16-bit and 32-bit layouts.
+- Measure CODEREP size on supported targets.
+- Add compile-time field-width, size, and offset guards.
+
+### W2: CODEREP mechanics
+
+- Update initialization, copy, stack allocation, variant allocation, extra-kid
+  handling, use counts, and rehashing.
+- Add guarded logical/native operator APIs.
+- Keep existing native CODEREP behavior unchanged.
+
+### W3: Import
+
+- Decode DSL WNs before generic `CODEMAP::Add_expr` handling.
+- Resolve semantic-info records and tensor descriptors.
+- Add hash and equality support.
+- Add negative tests for differing operator, version, attribute, descriptor,
+  and effect identity.
+
+### W4: Printing and inspection
+
+- Print logical DSL operators in CODEREP dumps and WOPT traces.
+- Add stable version, attribute, and descriptor evidence.
+- Prohibit physical escape details in developer-visible output.
+
+### W5: Simplifier bridge
+
+- Add stack-local DSL-to-native CODEREP preparation.
+- Route eligible rules through `wn_simp_code.h`.
+- Add DSL result postprocessing and rehashing.
+- Honor `WOPT_Enable_CRSIMP` and `WOPT_Enable_Fold2const`.
+
+### W6: Emission
+
+- Rebuild native DSL WNs through public APIs.
+- Restore mapped-image records, source positions, and comment projection.
+- Re-run the gatekeeper.
+- Verify binary WHIRL roundtrip behavior.
+
+### W7: WOPT service audit
+
+- Audit CSE, copy propagation, value numbering, PRE, DCE, effects, type
+  queries, and profitability.
+- Enable only services with reviewed DSL legality.
+- Make unsupported services conservatively preserve DSL expressions.
+- Extend context-sensitive control-flow simplification to logical DSL
+  expressions after WN-to-CODEREP import. Reuse CFG dominance, value ranges,
+  symbolic tensor-dimension facts, and branch constraints so a condition
+  proven by an enclosing region or branch is removed by WOPT rather than by
+  construction-time simplification.
+- Add positive and negative tests for nested conditions, loop/range facts,
+  symbolic shape bounds, unknown bounds, and effectful conditions.
+- Extend redundant store/result-update elimination to DSL tensor values only
+  after ordinary expression simplification. Require identical addressed
+  value, TensorDescriptorIR compatibility, unique ownership or proven
+  no-alias state, and an effect model proving that removing the update is
+  observable-state neutral.
+- Cover both direct self-assignment and cases exposed by simplification, such
+  as a tensor value updated with itself plus a folded zero.
+- Preserve MU, CHI, alias-class, source-position, and diagnostic contracts
+  when an update cannot be removed.
+- Generalize projectable-operation and projection queries to reviewed logical
+  DSL contracts without exposing `OPR_DSL`.
+- Combine matching tensor DIV and REM into logical DIVPART/REMPART projections
+  of one tensor DIVREM under `WOPT_Enable_DIVREM`.
+- Include logical operator/version, both result descriptors, attributes, and
+  operand identities in projectable CODEREP hashing and equality.
+- Extend DCE projection-use accounting and emission-time uncombining so one
+  surviving tensor projection becomes standalone DIV or REM.
+- Add enabled, disabled, one-projection, two-projection, mismatched-operand,
+  descriptor-rejection, effect-rejection, and target-unprofitable tests.
+
+### W8: Certification
+
+- Run scalar WOPT regression tests.
+- Run common/com and VHO DSL tests.
+- Run warning and no-tab checks.
+- Preserve `.B`, `.T`, phase traces, and diagnostics.
+- Compare the full simplifier option matrix.
+- Verify `ir_b2a -st -src` before and after WOPT.
+
+## Exit Criteria
+
+WOPT DSL admission is ready when:
+
+1. unlowered DSL WNs become first-class logical CODEREPs;
+2. hash and equality include complete semantic identity;
+3. WOPT traces never expose the physical escape as the logical operator;
+4. eligible DSL algebra uses the existing CODEREP simplifier;
+5. option-controlled A/B comparisons are reproducible;
+6. CODEREP-to-WN emission preserves all reviewed DSL semantics;
+7. mapped-image binary compatibility remains unchanged;
+8. scalar WOPT tests remain unchanged; and
+9. retained `ir_b2a -st -src` artifacts demonstrate the complete path.
+
+## Related Documents
+
+- `doc/WHIRL-DSL-SIMPLIFICATION-PLAN.md`
+- `doc/WHIRL-DSL-INFRASTRUCTURE.md`
+- `doc/WHIRL-DSL-TENSOR-TYPE-HANDLING.md`
+- `doc/VHO-DSL-OPTIMIZATION-PLAN.md`
+- `doc/Open64_Domain_Specific_Compiler_IR_Design.md`
+- `WHIRL.pdf`

--- a/doc/WOPT-DSL-ADAPTATION-PLAN.md
+++ b/doc/WOPT-DSL-ADAPTATION-PLAN.md
@@ -291,6 +291,92 @@ must become the temporary CODEREP expression `x + (y - x)` so that
 `simp_add_sub()` can produce `y`. The cancellation rule remains traditional
 `wn_simp` work; copy propagation is the enabling WOPT transformation.
 
+Operator relationships and propagation safety are separate decisions.
+`COPYPROP::Is_exp_cancellable()` classifies whether the producer and consumer
+right-hand-side operators belong to a reviewed cancellation family:
+
+```text
+BOOL Is_exp_cancellable(CODEREP *producer_rhs,
+                        CODEREP *consumer_rhs);
+```
+
+The first supported relationship is `ADD/SUB`. Although `MPY/DIV` is a
+potential mathematical cancellation family, it is not enabled from operator
+names alone. Integer truncation, division by zero, and floating-point
+NaN/infinity/rounding behavior require a more specific semantic contract.
+Traditional `wn_simp` implements `x/x -> 1` under its existing controls, but
+does not provide a general `(x*y)/x -> y` or `x*(y/x) -> y` rule.
+
+`COPYPROP::Is_simplification_propagatable()` combines an operator relationship
+with the def-use and semantic checks:
+
+```text
+BOOL Is_simplification_propagatable(
+         CODEREP *use,
+         STMTREP *producer,
+         STMTREP *consumer,
+         WOPT_DSL_SIMPLIFICATION_RELATION relation);
+```
+
+For the first adjacent cancellation slice it returns true only when all of the
+following hold:
+
+1. `producer` and `consumer` belong to the same basic block and
+   `producer->Next() == consumer`.
+2. `use` is the value defined by `producer`, has one use, and occurs as a
+   direct kid of `consumer->Rhs()`.
+3. Both right-hand sides are expressions in the reviewed cancellation
+   operator family. The first family is `ADD/SUB`; operator-pair matching
+   recognizes a possible cancellation opportunity but does not claim that
+   operands cancel.
+4. Every participating logical DSL operator is pure and projectable, has the
+   reviewed version and algebraic contract, and permits the reassociation
+   required by the traditional rule.
+5. Result and operand TensorDescriptorIR identities are compatible, effects
+   are empty, and integer or floating-point safety controls permit the
+   transformation.
+6. Neither statement introduces an intervening control, memory, region, or
+   runtime-state boundary.
+
+The predicate is only a propagation permission. It authorizes the exact
+producer CODEREP, not all nested DSL CODEREPs and not general propagation
+through later statements. After substitution, the CODEREP instantiation of
+`simp_add_sub()` compares the actual operands and either performs the
+cancellation or leaves the expression unchanged. For example, the same
+`SUB/ADD` operator pair in `t0 = y - z; t1 = x + t0` passes the opportunity
+classification but does not simplify unless the traditional engine proves an
+operand equality with opposite signs.
+
+Factorization needs a distinct operator classifier:
+
+```text
+BOOL Is_exp_factorable(CODEREP *producer_rhs,
+                       CODEREP *consumer_rhs,
+                       UINT32 consumer_kid);
+```
+
+For:
+
+```text
+t0 = x * y
+t1 = x * z
+t2 = t0 + t1
+```
+
+copy propagation must expose `(x*y) + (x*z)` before `simp_factor()` can compare
+all four possible common-factor positions. Strict adjacency cannot work for
+both producers, so the factorization relation permits a bounded same-BB walk
+over pure statements. The producer must dominate the consumer, remain
+single-use, cross no effect/control/runtime-state boundary, satisfy descriptor
+compatibility, and match the registered factorization operand mask.
+
+`simp_factor()` remains the authority that proves a common operand.
+`simp_factor_idty()` handles the product-plus-factor form, but its arithmetic
+caller uses `const_only=TRUE`; for example, `z*c + z -> z*(c+1)` requires `c`
+to be constant. Elementwise commutative `common.mul` may use all four operand
+positions. Matrix multiplication and other noncommutative operators require
+their own ordered relation and must not use `FACTOR_ALL`.
+
 Controlled DSL propagation may expand logical CODEREPs inside WOPT, but
 CODEREP-to-WN emission must reconstruct the reviewed DSL value model. Each
 retained operator result must again have one unique no-alias result STID, and
@@ -457,7 +543,8 @@ or runtime state.
 
 ### M5 Progress
 
-M5 is active on `codex/dsl-wopt-m5` after PR #97 merged. The W0/W1
+M5 implementation is complete on `codex/dsl-wopt-m5` after PR #97 merged.
+The W0/W1
 batch selected a 32-bit WOPT-local semantic-info index and placed it in the
 existing x86-64 `CK_OP` alignment space. Linux DWARF still reports
 `sizeof(CODEREP) == 88`. The fixed-layout semantic record is runtime-only and
@@ -516,6 +603,22 @@ temporary. Tensor constant folding instead follows the operand LDID's defining
 STID through `WOPT_DSL_Compact_TCON`, so keeping the value boundary does not
 forfeit the fold.
 
+The first controlled opportunity-forming transform is implemented for pure
+integer `common.mul.v1` producers consumed by `common.add.v1`. It performs a
+bounded same-BB walk across pure unique-ownership DSL result stores, requires
+single-use producer values, identical TensorDescriptorIR identities, and a
+registered four-position factor relation, then presents stack-local CODEREP
+views using the tensor element machine type to the traditional
+`wn_simp_code.h` factorization engine. When that engine proves the rewrite,
+WOPT reuses the first producer result as the inner `common.add`, emits the
+outer `common.mul` into the original consumer result, and leaves normal WOPT
+cleanup to remove the dead second product.
+
+Import and emission now recover each DSL result symbol from the authoritative
+`STMTREP`/`OPT_STAB` identity instead of the historical WN pointer. This is
+required when several `MTYPE_M` DSL result stores occur in one basic block and
+prevents one result from inheriting another result's mapped-image identity.
+
 `dsl_wopt_driver_test.sh` certifies the option and phase order through the
 real backend executable. It publishes one mapped-image input containing two
 rank-2 integer tensor constants, `common.add`, a unique no-alias result
@@ -526,6 +629,25 @@ contains one logical `OPR_DSLTENSORCONST` with splat value 1 assigned to the
 original result temporary, and the post-backend image contains only the
 tensor-constant runtime call. Both paths retain `.B`/`.O`, `ir_b2a -st -src`
 `.T`, and backend trace artifacts for review.
+
+The same test retains a positive integer factorization family and a
+no-common-factor negative family.
+The positive trace contains `wopt_xy = common.add(wopt_y,wopt_z)` followed by
+`wopt_factor = common.mul(wopt_x,wopt_xy)`. The negative trace preserves the
+original three operators. A second positive-input run with
+`-WOPT:cr_simp=off` also preserves the original form, proving that the DSL
+bridge does not bypass the traditional simplifier control. These algebra
+fixtures intentionally stop at the reviewed WOPT boundary:
+`common.mul.v1` remains marker-only, so the subsequent VHO lowering rejection
+is expected and retained as a diagnostic artifact.
+
+Strict floating-point legality is tested without relying on that later
+development assertion. `WOPT_DSL_Algebraic_Safety_Allows()` accepts
+floating-point factorization only when Open64's reassociation control is
+enabled. With strict FP active, meaning reassociation is disabled, it returns
+not-applicable, WOPT preserves the original expression, and the traditional
+simplifier is not entered. The standalone semantic-policy test covers both
+control states.
 
 The same batch covers the non-behavioral W2 mechanics. `Init_op()` clears the
 semantic index, `CODEREP::Copy()` preserves it, and existing stack allocation,
@@ -585,9 +707,10 @@ attribute identity, operand descriptor identity, and effect identity.
 - Honor `WOPT_Enable_CRSIMP` and `WOPT_Enable_Fold2const`.
 
 Status: the compact tensor constant extension calls the common M3 evaluator
-and honors both controls. Traditional scalar rules continue through the
-existing CODEREP instantiation of `wn_simp_code.h`; broader DSL preparation
-for traditional rules remains staged with W7 service review.
+and honors both controls. Integer multiply/add factorization projects
+stack-local CODEREP views into the existing CODEREP instantiation of
+`wn_simp_code.h` and uses the traditional result as the proof for DSL
+postprocessing. Other DSL preparation remains staged with W7 service review.
 
 ### W6: Emission
 
@@ -596,17 +719,30 @@ for traditional rules remains staged with W7 service review.
 - Re-run the gatekeeper.
 - Verify binary WHIRL roundtrip behavior.
 
-Status: native reconstruction, mapped-image rewrite, comment projection
-through the logical printer, source-position preservation on the owning
-statement, and post-emission gatekeeper verification are implemented.
-Process-boundary binary A/B certification remains paired with W7 driver
-admission.
+Status: native reconstruction, generic add/mul mapped-image rewrite, comment
+projection through the logical printer, source-position preservation on the
+owning statement, unique result STID rematerialization, and post-emission
+gatekeeper verification are implemented. Process-boundary binary A/B
+certification is complete for executable constant folding; marker-only
+algebraic graphs retain pre-lowering WOPT traces and expected diagnostics.
 
 ### W7: WOPT service audit
 
-- Replace the blanket non-propagatable DSL guard with controlled copy
-  propagation that exposes eligible cancellation, reassociation,
-  factorization, and constant-folding expressions to `wn_simp`.
+- Keep the blanket general DSL propagation guard until each relationship is
+  reviewed. The `Is_exp_cancellable()` and
+  `Is_simplification_propagatable()` classifiers are implemented; activate
+  ADD/SUB cancellation only after a native `common.sub` contract exists.
+- Add `Is_exp_factorable()` with a bounded pure same-BB producer search so both
+  multiplicative operands of an `ADD/SUB` consumer can become visible to
+  `simp_factor()`. Enforce the registered operand mask and do not generalize
+  this permission to unrelated DSL propagation.
+  Status: implemented for pure integer `common.mul.v1` under
+  `common.add.v1`, including positive and no-common-factor artifacts.
+  Strict-FP rejection and reassociation-enabled acceptance are covered by the
+  non-asserting semantic-policy test.
+- Defer general `MPY/DIV` cancellation until a reviewed operator contract,
+  nonzero/exception semantics, numeric-safety policy, and traditional
+  simplifier rule exist.
 - Re-materialize unique no-alias DSL result STIDs during emission and prove
   that internal propagation never creates duplicate native definitions in
   WHIRL or the mapped DSL image.

--- a/doc/WOPT-DSL-ADAPTATION-PLAN.md
+++ b/doc/WOPT-DSL-ADAPTATION-PLAN.md
@@ -395,7 +395,7 @@ or runtime state.
 
 ### M5 Progress
 
-M5 is active on `codex/dsl-wopt-m5` after PR #97 merged. The first W0/W1
+M5 is active on `codex/dsl-wopt-m5` after PR #97 merged. The W0/W1
 batch selected a 32-bit WOPT-local semantic-info index and placed it in the
 existing x86-64 `CK_OP` alignment space. Linux DWARF still reports
 `sizeof(CODEREP) == 88`. The fixed-layout semantic record is runtime-only and
@@ -403,11 +403,31 @@ interns logical operator, version, canonical attributes, result descriptor,
 operand descriptor identity, effects, and algebraic flags. Initialization,
 copy, hash, equality, and logical printing now preserve that identity.
 
-The generic WN importer is intentionally still closed to DSL nodes. W3 may
-open it only after it can construct a complete semantic record before the
-first hash operation. WOPT simplification and emission remain disabled until
-W5 and W6 respectively; this prevents an incomplete first-class CODEREP from
-escaping the staged implementation.
+W3-W6 now form one guarded vertical slice for pure `common.tensor_const`,
+`common.add`, and `common.mul`. `CODEMAP::Add_expr` resolves the result
+symbol, mapped-image node, logical opcode/version, canonical attributes,
+operand descriptor identity, result descriptor, effect identity, and compact
+tensor TCON before the first hash operation. Developer dumps expose the
+logical operator and semantic hashes without exposing physical `OPR_DSL`.
+Eligible constant add/mul expressions call
+`DSL_Tensor_Fold_Describe_Replacement`, the same evaluator/publication
+service used by WN and VHO folding. The emitter intercepts logical DSL
+CODEREPs before generic `WN_CreateExp*`, rebuilds them through the public DSL
+WN API, rewrites the mapped-image node when a fold changes the operator, and
+reruns the PU gatekeeper.
+
+The native `dsl_wopt_bridge_test` constructs real builder values and proves
+WN semantic import, shared tensor evaluation, folded tensor-constant
+emission, mapped-image rewrite, and gatekeeper acceptance. The lightweight
+semantic-info test separately proves operator/version/attribute/descriptor/
+TCON identity and proves that reconstruction provenance does not inhibit
+value numbering.
+
+Broad optimizer admission is intentionally deferred to W7. The normal backend
+still invokes `VHO_DSL_Lower_Driver` before WOPT, so driver reordering and
+full `-WOPT:cr_simp` / `-WOPT:fold2const` binary A/B certification must wait
+until CSE, copy propagation, PRE, DCE, type queries, effects, and profitability
+have conservative DSL policies.
 
 The same batch covers the non-behavioral W2 mechanics. `Init_op()` clears the
 semantic index, `CODEREP::Copy()` preserves it, and existing stack allocation,
@@ -448,11 +468,16 @@ their previous paths.
 - Add negative tests for differing operator, version, attribute, descriptor,
   and effect identity.
 
+Status: implemented for the M5 pure integer tensor vertical slice.
+
 ### W4: Printing and inspection
 
 - Print logical DSL operators in CODEREP dumps and WOPT traces.
 - Add stable version, attribute, and descriptor evidence.
 - Prohibit physical escape details in developer-visible output.
+
+Status: implemented for logical name/version, result type, canonical
+attribute identity, operand descriptor identity, and effect identity.
 
 ### W5: Simplifier bridge
 
@@ -461,12 +486,23 @@ their previous paths.
 - Add DSL result postprocessing and rehashing.
 - Honor `WOPT_Enable_CRSIMP` and `WOPT_Enable_Fold2const`.
 
+Status: the compact tensor constant extension calls the common M3 evaluator
+and honors both controls. Traditional scalar rules continue through the
+existing CODEREP instantiation of `wn_simp_code.h`; broader DSL preparation
+for traditional rules remains staged with W7 service review.
+
 ### W6: Emission
 
 - Rebuild native DSL WNs through public APIs.
 - Restore mapped-image records, source positions, and comment projection.
 - Re-run the gatekeeper.
 - Verify binary WHIRL roundtrip behavior.
+
+Status: native reconstruction, mapped-image rewrite, comment projection
+through the logical printer, source-position preservation on the owning
+statement, and post-emission gatekeeper verification are implemented.
+Process-boundary binary A/B certification remains paired with W7 driver
+admission.
 
 ### W7: WOPT service audit
 

--- a/doc/WOPT-DSL-ADAPTATION-PLAN.md
+++ b/doc/WOPT-DSL-ADAPTATION-PLAN.md
@@ -277,6 +277,28 @@ no runtime state or effects
 The projection is stack-local and is never published as the permanent
 identity of the DSL expression.
 
+### Opportunity formation
+
+WOPT copy propagation must form expressions before the traditional
+simplifier is invoked. For example:
+
+```text
+t0 = y - x
+t1 = x + t0
+```
+
+must become the temporary CODEREP expression `x + (y - x)` so that
+`simp_add_sub()` can produce `y`. The cancellation rule remains traditional
+`wn_simp` work; copy propagation is the enabling WOPT transformation.
+
+Controlled DSL propagation may expand logical CODEREPs inside WOPT, but
+CODEREP-to-WN emission must reconstruct the reviewed DSL value model. Each
+retained operator result must again have one unique no-alias result STID, and
+consumer operands must use those values rather than publish duplicated nested
+native DSL definitions. The current blanket `Is_dsl_op()` non-propagatable
+guard is transitional and must be replaced by this controlled propagation and
+boundary-rematerialization protocol.
+
 ### Existing engine
 
 Run the existing CODEREP instantiation of `wn_simp_code.h`.
@@ -337,9 +359,16 @@ DSL WHIRL.
   hook creates a temporary REGION/RID context only because the transitional
   broad PREOPT entry requires it; that context is discarded before final DSL
   lowering.
+- Controlled copy propagation sufficient to expose traditional algebraic
+  rules is part of the immediate expression-simplification milestone.
+- Context-sensitive control-flow optimization is staged later in WOPT and
+  covers the previously classified TVM item 5.
+- WOPT PRE admission is staged later and covers the previously classified TVM
+  item 6.
 - Create the DSL ROOT RID when DSL parallelization optimization begins. At
   that milestone, review and harvest applicable existing LNO analyses and
-  transformations instead of developing an unrelated parallel framework.
+  transformations, including tiling for the previously classified TVM item 8,
+  instead of developing an unrelated parallel framework.
 - Enable PRE services when a reviewed DSL domain requires them. Forthcoming
   fully homomorphic encryption (FHE) domains are expected to provide an early
   motivating use case, but PRE admission still requires explicit operator,
@@ -575,7 +604,13 @@ admission.
 
 ### W7: WOPT service audit
 
-- Audit CSE, copy propagation, value numbering, PRE, DCE, effects, type
+- Replace the blanket non-propagatable DSL guard with controlled copy
+  propagation that exposes eligible cancellation, reassociation,
+  factorization, and constant-folding expressions to `wn_simp`.
+- Re-materialize unique no-alias DSL result STIDs during emission and prove
+  that internal propagation never creates duplicate native definitions in
+  WHIRL or the mapped DSL image.
+- Audit CSE, value numbering, PRE, DCE, effects, type
   queries, and profitability.
 - Enable only services with reviewed DSL legality.
 - Make unsupported services conservatively preserve DSL expressions.

--- a/doc/WOPT-DSL-ADAPTATION-PLAN.md
+++ b/doc/WOPT-DSL-ADAPTATION-PLAN.md
@@ -435,10 +435,46 @@ TCON identity and proves that reconstruction provenance does not inhibit
 value numbering.
 
 Broad optimizer admission is intentionally deferred to W7. The normal backend
-still invokes `VHO_DSL_Lower_Driver` before WOPT, so driver reordering and
-full `-WOPT:cr_simp` / `-WOPT:fold2const` binary A/B certification must wait
-until CSE, copy propagation, PRE, DCE, type queries, effects, and profitability
-have conservative DSL policies.
+now provides an opt-in `-DSL:wopt=on|off` hook immediately before
+`VHO_DSL_Lower_Driver`. The option is off by default. When enabled, the driver
+loads and initializes WOPT even if the later scalar WOPT phase is disabled,
+creates the temporary REGION/RID analysis context required by WOPT, invokes
+`Perform_Preopt_Optimization` on the Very High Level DSL WHIRL PU, and discards
+that temporary REGION context before passing the returned PU to final DSL
+lowering. The normal post-lowering REGION initialization then reconstructs
+authoritative RID state from the lowered tree. The later scalar WOPT pipeline
+remains unchanged.
+
+The hook makes full `-DSL:wopt`, `-WOPT:cr_simp`, and
+`-WOPT:fold2const` binary A/B certification possible. Broad enablement still
+depends on W7 review of CSE, copy propagation, PRE, DCE, type queries, effects,
+and profitability. Unsupported DSL operators must fail through the existing
+import/gatekeeper boundary rather than being silently lowered or skipped.
+
+Driver-level validation exposed and corrected an existing PREOPT lifetime bug
+in `Manage_pu_level_memory`: a `PREOPT_PHASE` `COMP_UNIT` was deleted from
+`Opt_preopt_pool` and then deleted a second time from `Opt_global_pool`.
+The PREOPT caller now passes the same pool selected for construction. The
+helper verifies that caller-provided owner, releases the PREOPT object and pool
+once, and returns before the global-pool cleanup path.
+
+WOPT input propagation preserves DSL value boundaries. It does not substitute
+a producer DSL CODEREP directly beneath a consumer DSL CODEREP because native
+DSL WHIRL requires each operator result to retain its unique no-alias result
+temporary. Tensor constant folding instead follows the operand LDID's defining
+STID through `WOPT_DSL_Compact_TCON`, so keeping the value boundary does not
+forfeit the fold.
+
+`dsl_wopt_driver_test.sh` certifies the option and phase order through the
+real backend executable. It publishes one mapped-image input containing two
+rank-2 integer tensor constants, `common.add`, a unique no-alias result
+temporary, and a returned aggregate result. With `-DSL:wopt=off`, the retained
+post-backend image contains two tensor-constant runtime calls and
+`__open64_dsl_add_v1`. With `-DSL:wopt=on`, the pre-lowering driver trace
+contains one logical `OPR_DSLTENSORCONST` with splat value 1 assigned to the
+original result temporary, and the post-backend image contains only the
+tensor-constant runtime call. Both paths retain `.B`/`.O`, `ir_b2a -st -src`
+`.T`, and backend trace artifacts for review.
 
 The same batch covers the non-behavioral W2 mechanics. `Init_op()` clears the
 semantic index, `CODEREP::Copy()` preserves it, and existing stack allocation,

--- a/doc/WOPT-DSL-ADAPTATION-PLAN.md
+++ b/doc/WOPT-DSL-ADAPTATION-PLAN.md
@@ -326,6 +326,28 @@ WOPT services before enabling DSL admission:
 Each service must either understand the reviewed DSL contract or conservatively
 preserve the expression without transforming it.
 
+## Future Optimizer Activation
+
+The immediate DSL WOPT objective is the focused expression-simplification
+pipeline. It must not imply that all WOPT, LNO, or PRE services are enabled for
+DSL WHIRL.
+
+- The focused expression-simplification path should not create or persist an
+  architectural ROOT RID merely to simplify expressions. The current backend
+  hook creates a temporary REGION/RID context only because the transitional
+  broad PREOPT entry requires it; that context is discarded before final DSL
+  lowering.
+- Create the DSL ROOT RID when DSL parallelization optimization begins. At
+  that milestone, review and harvest applicable existing LNO analyses and
+  transformations instead of developing an unrelated parallel framework.
+- Enable PRE services when a reviewed DSL domain requires them. Forthcoming
+  fully homomorphic encryption (FHE) domains are expected to provide an early
+  motivating use case, but PRE admission still requires explicit operator,
+  effect, ownership, descriptor, cost, and legality contracts.
+- Treat ROOT RID parallelization, LNO transformation reuse, and PRE admission
+  as staged capabilities. They are planned extensions, not prerequisites for
+  the first DSL expression-simplification milestone.
+
 ## CODEREP-to-WN Emission
 
 Intercept first-class DSL CODEREPs before generic `cr->Op()` emission.

--- a/osprey/be/be/driver.cxx
+++ b/osprey/be/be/driver.cxx
@@ -165,6 +165,7 @@
 #include "comp_decl.h"
 #include "report.h"
 #include "config_vsa.h"
+#include "config_dsl.h"
 
 extern ERROR_DESC EDESC_BE[], EDESC_CG[];
 
@@ -474,7 +475,8 @@ load_components (INT argc, char **argv)
     }
 
     if ((Run_wopt || (Run_vsaopt || Run_ipsaopt))
-	|| Run_preopt || Run_lno || Run_autopar) {
+        || Run_preopt || Run_lno || Run_autopar ||
+        VHO_DSL_Enable_WOPT) {
       Get_Phase_Args (PHASE_WOPT, &phase_argc, &phase_argv);
 #if !defined(BUILD_FAST_BIN)
       load_so (WOPT_SO_NAME, WOPT_Path, Show_Progress);
@@ -553,7 +555,8 @@ Phase_Init (void)
 
     if (Run_cg)
 	CG_Init ();
-    if ((Run_wopt || (Run_vsaopt || Run_ipsaopt))  || Run_preopt)
+    if ((Run_wopt || (Run_vsaopt || Run_ipsaopt)) || Run_preopt ||
+        VHO_DSL_Enable_WOPT)
 	Wopt_Init ();
     if (Run_ipl)
 	Ipl_Init ();
@@ -649,7 +652,8 @@ Phase_Fini (void)
 	Lno_Fini ();
     if (Run_ipl)
 	Ipl_Fini ();
-    if ((Run_wopt || (Run_vsaopt || Run_ipsaopt)) || Run_preopt)
+    if ((Run_wopt || (Run_vsaopt || Run_ipsaopt)) || Run_preopt ||
+        VHO_DSL_Enable_WOPT)
 	Wopt_Fini ();
     if (Run_cg)
 	CG_Fini ();
@@ -1618,7 +1622,7 @@ Preprocess_PU (PU_Info *current_pu)
   BOOL w2c_only = Run_w2c &&
                   !Run_lno && !Run_preopt &&
                   !Run_wopt && !Run_vsaopt && !Run_ipsaopt &&
-                  !Run_cg && !Run_ipl;
+                  !Run_cg && !Run_ipl && !VHO_DSL_Enable_WOPT;
 
   Initialize_PU_Stats ();  /* Needed for Olimit as well as tracing */
 
@@ -1815,6 +1819,18 @@ Preprocess_PU (PU_Info *current_pu)
     CYG_Instrument_Driver( pu );
   }
 #endif
+
+  if (!w2c_only && VHO_DSL_Enable_WOPT) {
+    Is_True(wopt_loaded,
+            ("DSL WOPT requested but the WOPT component is unavailable"));
+    REGION_Initialize(pu, PU_has_region(Get_Current_PU()));
+    Set_Error_Phase ( "DSL WOPT Processing" );
+    pu = Perform_Preopt_Optimization(pu, pu);
+    Is_True(pu != NULL, ("DSL WOPT returned a NULL PU"));
+    Set_PU_Info_tree_ptr(current_pu, pu);
+    Check_for_IR_Dump(TP_GLOBOPT, pu, "DSL_WOPT");
+    REGION_Finalize();
+  }
 
   if (!w2c_only) {
     Set_Error_Phase ( "DSL VHO Processing" );

--- a/osprey/be/opt/Makefile.gbase
+++ b/osprey/be/opt/Makefile.gbase
@@ -223,6 +223,7 @@ BE_OPT_CXX_SRCS = \
   opt_find.cxx		\
   opt_fold.cxx		\
   opt_dsl.cxx		\
+  opt_dsl_semantic.cxx	\
   opt_htable.cxx	\
   opt_htable_emit.cxx	\
   opt_ivr.cxx		\

--- a/osprey/be/opt/Makefile.gbase
+++ b/osprey/be/opt/Makefile.gbase
@@ -222,6 +222,7 @@ BE_OPT_CXX_SRCS = \
   opt_fb.cxx		\
   opt_find.cxx		\
   opt_fold.cxx		\
+  opt_dsl.cxx		\
   opt_htable.cxx	\
   opt_htable_emit.cxx	\
   opt_ivr.cxx		\
@@ -490,4 +491,3 @@ include $(COMMONRULES)
 #----------------------------------------------------------------------
 
 DSONAMEOPT =
-

--- a/osprey/be/opt/opt_dsl.cxx
+++ b/osprey/be/opt/opt_dsl.cxx
@@ -56,6 +56,53 @@ WOPT_DSL_Result_Value(ST_IDX result_st, const char *owner_pu,
 }
 
 static BOOL
+WOPT_DSL_Result_Value_For_WN(const DSL_LOGICAL_OPCODE *logical,
+                             UINT32 operand_count, const char *owner_pu,
+                             DSL_IR_VALUE_RECORD *value,
+                             DSL_IR_NODE_RECORD *node)
+{
+  DSL_IR_VALUE_RECORD match_value;
+  DSL_IR_NODE_RECORD match_node;
+  BOOL found = FALSE;
+
+  if (logical == NULL || owner_pu == NULL || value == NULL || node == NULL)
+    return FALSE;
+
+  for (UINT32 id = 1; id <= DSL_IR_Image_Node_Count(); ++id) {
+    DSL_IR_NODE_RECORD candidate;
+    DSL_IR_OPCODE_DESCRIPTOR_RECORD descriptor;
+    DSL_IR_VALUE_RECORD result;
+    DSL_IR_VALUE_RECORD owned_result;
+    if (!DSL_IR_Image_Get_Node(id, &candidate) ||
+        !DSL_IR_Image_Get_Opcode_Descriptor
+            (candidate.opcode_descriptor_id, &descriptor) ||
+        descriptor.logical_operator != (UINT32)logical->dsl_operator ||
+        descriptor.version != logical->effective_version ||
+        candidate.operand_count != operand_count ||
+        strcmp(candidate.payload == STR_IDX_ZERO ? "" :
+                   Index_To_Str(candidate.payload),
+               logical->payload == NULL ? "" : logical->payload) != 0 ||
+        !DSL_IR_Image_Get_Value(candidate.result_value_id, &result) ||
+        result.st == ST_IDX_ZERO || result.name == STR_IDX_ZERO ||
+        !DSL_IR_Image_Find_PU_Value
+            (result.st, Index_To_Str(result.name), owner_pu, &owned_result) ||
+        owned_result.id != result.id)
+      continue;
+    if (found)
+      return FALSE;
+    match_value = result;
+    match_node = candidate;
+    found = TRUE;
+  }
+
+  if (!found)
+    return FALSE;
+  *value = match_value;
+  *node = match_node;
+  return TRUE;
+}
+
+static BOOL
 WOPT_DSL_TCON_Index(ST_IDX st, TCON_IDX *tcon_idx)
 {
   DSL_TENSOR_TCON_RECORD record;
@@ -88,6 +135,7 @@ WOPT_DSL_Import_Semantic_Info(const WN *wn, ST_IDX result_st,
   DSL_IR_NODE_RECORD node;
   UINT64 attribute_hash = 1469598103934665603ULL;
   UINT64 operand_hash = 1469598103934665603ULL;
+  ST_IDX semantic_result_st = result_st;
 
   if (info != NULL)
     memset(info, 0, sizeof(*info));
@@ -95,13 +143,17 @@ WOPT_DSL_Import_Semantic_Info(const WN *wn, ST_IDX result_st,
       !DSL_WN_Get_Logical_Opcode(wn, &logical, diagnostic) ||
       !DSL_Operator_Get_Info_Version
           (logical.dsl_operator, logical.effective_version, &operator_info) ||
-      !WOPT_DSL_Result_Value
-          (result_st, owner_pu, &result_value, &node) ||
+      (!WOPT_DSL_Result_Value
+           (result_st, owner_pu, &result_value, &node) &&
+       !WOPT_DSL_Result_Value_For_WN
+           (&logical, (UINT32)WN_kid_count(wn), owner_pu,
+            &result_value, &node)) ||
       node.operand_count != (UINT32)WN_kid_count(wn)) {
     if (diagnostic != NULL)
       fprintf(diagnostic, "WOPT DSL import: incomplete semantic identity\n");
     return FALSE;
   }
+  semantic_result_st = result_value.st;
 
   if (logical.dsl_operator != OPR_DSLTENSORCONST &&
       logical.dsl_operator != OPR_DSLADD &&
@@ -153,7 +205,7 @@ WOPT_DSL_Import_Semantic_Info(const WN *wn, ST_IDX result_st,
   info->operand_descriptor_hash = operand_hash;
   info->effect_identity = operator_info.effect_model;
   if (logical.dsl_operator == OPR_DSLTENSORCONST &&
-      !WOPT_DSL_TCON_Index(result_st, &info->tensor_tcon_idx)) {
+      !WOPT_DSL_TCON_Index(semantic_result_st, &info->tensor_tcon_idx)) {
     if (diagnostic != NULL)
       fprintf(diagnostic,
               "WOPT DSL import: tensor constant has no compact TCON\n");
@@ -300,10 +352,25 @@ WOPT_DSL_Emit_WN(const WOPT_DSL_SEMANTIC_INFO *info,
   const char *payload = NULL;
 
   if (info == NULL ||
-      (kid_count != 0 && kids == NULL) ||
-      !WOPT_DSL_Result_Value
-          (result_st, owner_pu, &result_value, &node))
+      (kid_count != 0 && kids == NULL))
     return NULL;
+  if (!WOPT_DSL_Result_Value
+          (result_st, owner_pu, &result_value, &node)) {
+    DSL_IR_VALUE_RECORD owned_result;
+    if (info->origin_result_value_id == DSL_IR_VALUE_INVALID_ID ||
+        !DSL_IR_Image_Get_Value
+            (info->origin_result_value_id, &result_value) ||
+        result_value.st == ST_IDX_ZERO ||
+        result_value.name == STR_IDX_ZERO ||
+        !DSL_IR_Image_Find_PU_Value
+            (result_value.st, Index_To_Str(result_value.name), owner_pu,
+             &owned_result) ||
+        owned_result.id != result_value.id ||
+        result_value.producer_node_id == DSL_IR_NODE_INVALID_ID ||
+        !DSL_IR_Image_Get_Node(result_value.producer_node_id, &node))
+      return NULL;
+  }
+  result_st = result_value.st;
 
   if (original != NULL &&
       DSL_WN_Get_Logical_Opcode(original, &original_logical, NULL) &&
@@ -311,6 +378,8 @@ WOPT_DSL_Emit_WN(const WOPT_DSL_SEMANTIC_INFO *info,
       original_logical.effective_version == info->version &&
       DSL_WN_Get_Opcode_Annotation(original, &annotation))
     payload = annotation.payload;
+  if (payload == NULL && node.payload != STR_IDX_ZERO)
+    payload = Index_To_Str(node.payload);
 
   if (info->logical_operator == OPR_DSLTENSORCONST) {
     DSL_TENSOR_TCON_RECORD tcon;

--- a/osprey/be/opt/opt_dsl.cxx
+++ b/osprey/be/opt/opt_dsl.cxx
@@ -3,26 +3,19 @@
  */
 
 #include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string>
 #include <vector>
 
 #include "opt_dsl.h"
-
-static std::vector<WOPT_DSL_SEMANTIC_INFO> WOPT_dsl_semantic_info;
-
-static BOOL
-WOPT_DSL_Semantic_Info_Equal(const WOPT_DSL_SEMANTIC_INFO *left,
-                             const WOPT_DSL_SEMANTIC_INFO *right)
-{
-  return left->logical_operator == right->logical_operator &&
-         left->version == right->version &&
-         left->flags == right->flags &&
-         left->result_ty == right->result_ty &&
-         left->canonical_attribute_hash ==
-             right->canonical_attribute_hash &&
-         left->operand_descriptor_hash ==
-             right->operand_descriptor_hash &&
-         left->effect_identity == right->effect_identity;
-}
+#include "dsl_ir_image.h"
+#include "dsl_tensor_fold.h"
+#include "pu_info.h"
+#include "strtab.h"
+#include "symtab.h"
+#include "wn.h"
 
 static UINT64
 WOPT_DSL_Hash_Combine(UINT64 hash, UINT64 value)
@@ -32,63 +25,343 @@ WOPT_DSL_Hash_Combine(UINT64 hash, UINT64 value)
   return hash;
 }
 
-void
-WOPT_DSL_Semantic_Info_Reset(void)
+static UINT64
+WOPT_DSL_Hash_String(UINT64 hash, const char *text)
 {
-  WOPT_dsl_semantic_info.clear();
+  if (text == NULL)
+    return WOPT_DSL_Hash_Combine(hash, 0);
+  while (*text != '\0') {
+    hash ^= (unsigned char)*text++;
+    hash *= 1099511628211ULL;
+  }
+  return WOPT_DSL_Hash_Combine(hash, 0xff);
 }
 
-WOPT_DSL_SEMANTIC_INFO_ID
-WOPT_DSL_Semantic_Info_Intern(const WOPT_DSL_SEMANTIC_INFO *info)
+static BOOL
+WOPT_DSL_Result_Value(ST_IDX result_st, const char *owner_pu,
+                      DSL_IR_VALUE_RECORD *value,
+                      DSL_IR_NODE_RECORD *node)
 {
-  if (info == NULL || info->logical_operator == OPR_DSLUNKNOWN ||
-      info->version == 0 || info->reserved != 0)
-    return WOPT_DSL_SEMANTIC_INFO_INVALID_ID;
+  const char *name;
 
-  for (UINT32 i = 0; i < WOPT_dsl_semantic_info.size(); ++i) {
-    if (WOPT_DSL_Semantic_Info_Equal
-            (&WOPT_dsl_semantic_info[i], info))
-      return i + 1;
-  }
+  if (ST_IDX_index(result_st) == 0 || owner_pu == NULL ||
+      value == NULL || node == NULL)
+    return FALSE;
+  name = ST_name(St_Table[result_st]);
+  return name != NULL &&
+         DSL_IR_Image_Find_PU_Value
+             (result_st, name, owner_pu, value) &&
+         value->producer_node_id != DSL_IR_NODE_INVALID_ID &&
+         DSL_IR_Image_Get_Node(value->producer_node_id, node);
+}
 
-  WOPT_DSL_SEMANTIC_INFO copy = *info;
-  copy.id = WOPT_dsl_semantic_info.size() + 1;
-  WOPT_dsl_semantic_info.push_back(copy);
-  return copy.id;
+static BOOL
+WOPT_DSL_TCON_Index(ST_IDX st, TCON_IDX *tcon_idx)
+{
+  DSL_TENSOR_TCON_RECORD record;
+  const char *text = ST_tensor_metadata(st, "tensor_tcon_idx");
+  char *end;
+  unsigned long value;
+
+  if (tcon_idx != NULL)
+    *tcon_idx = TCON_IDX_ZERO;
+  if (text == NULL || text[0] == '\0' || tcon_idx == NULL)
+    return FALSE;
+  errno = 0;
+  value = strtoul(text, &end, 10);
+  if (errno == ERANGE || end == text || *end != '\0' ||
+      value == 0 || value > UINT32_MAX)
+    return FALSE;
+  *tcon_idx = (TCON_IDX)value;
+  return DSL_Tensor_TCON_Get(*tcon_idx, &record);
 }
 
 BOOL
-WOPT_DSL_Semantic_Info_Get(WOPT_DSL_SEMANTIC_INFO_ID id,
-                           WOPT_DSL_SEMANTIC_INFO *info)
+WOPT_DSL_Import_Semantic_Info(const WN *wn, ST_IDX result_st,
+                              const char *owner_pu,
+                              WOPT_DSL_SEMANTIC_INFO *info,
+                              FILE *diagnostic)
 {
-  if (id == WOPT_DSL_SEMANTIC_INFO_INVALID_ID ||
-      id > WOPT_dsl_semantic_info.size())
-    return FALSE;
+  DSL_LOGICAL_OPCODE logical;
+  DSL_OPERATOR_INFO operator_info;
+  DSL_IR_VALUE_RECORD result_value;
+  DSL_IR_NODE_RECORD node;
+  UINT64 attribute_hash = 1469598103934665603ULL;
+  UINT64 operand_hash = 1469598103934665603ULL;
+
   if (info != NULL)
-    *info = WOPT_dsl_semantic_info[id - 1];
+    memset(info, 0, sizeof(*info));
+  if (wn == NULL || info == NULL ||
+      !DSL_WN_Get_Logical_Opcode(wn, &logical, diagnostic) ||
+      !DSL_Operator_Get_Info_Version
+          (logical.dsl_operator, logical.effective_version, &operator_info) ||
+      !WOPT_DSL_Result_Value
+          (result_st, owner_pu, &result_value, &node) ||
+      node.operand_count != (UINT32)WN_kid_count(wn)) {
+    if (diagnostic != NULL)
+      fprintf(diagnostic, "WOPT DSL import: incomplete semantic identity\n");
+    return FALSE;
+  }
+
+  if (logical.dsl_operator != OPR_DSLTENSORCONST &&
+      logical.dsl_operator != OPR_DSLADD &&
+      logical.dsl_operator != OPR_DSLMUL) {
+    if (diagnostic != NULL)
+      fprintf(diagnostic, "WOPT DSL import: %s is outside M5 scope\n",
+              DSL_OPERATOR_name(logical.dsl_operator));
+    return FALSE;
+  }
+  if (operator_info.effect_model != DSL_EFFECT_MODEL_PURE) {
+    if (diagnostic != NULL)
+      fprintf(diagnostic, "WOPT DSL import: effectful operator %s rejected\n",
+              operator_info.logical_name);
+    return FALSE;
+  }
+
+  for (UINT32 i = 0; i < node.attribute_count; ++i) {
+    DSL_IR_ATTRIBUTE_RECORD attribute;
+    if (!DSL_IR_Image_Get_Attribute
+            (node.first_attribute_id + i, &attribute))
+      return FALSE;
+    attribute_hash = WOPT_DSL_Hash_String
+                         (attribute_hash, Index_To_Str(attribute.name));
+    attribute_hash = WOPT_DSL_Hash_Combine
+                         (attribute_hash, attribute.value_kind);
+    attribute_hash = WOPT_DSL_Hash_String
+                         (attribute_hash,
+                          attribute.value == STR_IDX_ZERO ?
+                              "" : Index_To_Str(attribute.value));
+  }
+  for (UINT32 i = 0; i < node.operand_count; ++i) {
+    DSL_IR_VALUE_REFERENCE_RECORD reference;
+    DSL_IR_VALUE_RECORD operand;
+    if (!DSL_IR_Image_Get_Value_Reference
+            (node.first_operand_reference_id + i, &reference) ||
+        !DSL_IR_Image_Get_Value(reference.value_id, &operand))
+      return FALSE;
+    operand_hash = WOPT_DSL_Hash_Combine(operand_hash, operand.ty);
+  }
+
+  info->logical_operator = logical.dsl_operator;
+  info->version = logical.effective_version;
+  info->flags = WOPT_DSL_SEMANTIC_PURE |
+                WOPT_DSL_SEMANTIC_PROJECTABLE;
+  info->result_ty = result_value.ty;
+  info->origin_node_id = node.id;
+  info->origin_result_value_id = result_value.id;
+  info->canonical_attribute_hash = attribute_hash;
+  info->operand_descriptor_hash = operand_hash;
+  info->effect_identity = operator_info.effect_model;
+  if (logical.dsl_operator == OPR_DSLTENSORCONST &&
+      !WOPT_DSL_TCON_Index(result_st, &info->tensor_tcon_idx)) {
+    if (diagnostic != NULL)
+      fprintf(diagnostic,
+              "WOPT DSL import: tensor constant has no compact TCON\n");
+    return FALSE;
+  }
   return TRUE;
 }
 
-UINT32
-WOPT_DSL_Semantic_Info_Hash(WOPT_DSL_SEMANTIC_INFO_ID id)
+BOOL
+WOPT_DSL_Create_Folded_Tensor_Info
+    (const WOPT_DSL_SEMANTIC_INFO *origin, TCON_IDX result_tcon_idx,
+     WOPT_DSL_SEMANTIC_INFO *result)
 {
-  WOPT_DSL_SEMANTIC_INFO info;
-  UINT64 hash = 1469598103934665603ULL;
+  DSL_TENSOR_TCON_RECORD record;
 
-  if (!WOPT_DSL_Semantic_Info_Get(id, &info))
-    return 0;
-  hash = WOPT_DSL_Hash_Combine(hash, info.logical_operator);
-  hash = WOPT_DSL_Hash_Combine(hash, info.version);
-  hash = WOPT_DSL_Hash_Combine(hash, info.flags);
-  hash = WOPT_DSL_Hash_Combine(hash, info.result_ty);
-  hash = WOPT_DSL_Hash_Combine(hash, info.canonical_attribute_hash);
-  hash = WOPT_DSL_Hash_Combine(hash, info.operand_descriptor_hash);
-  hash = WOPT_DSL_Hash_Combine(hash, info.effect_identity);
-  return (UINT32)(hash ^ (hash >> 32));
+  if (origin == NULL || result == NULL ||
+      !DSL_Tensor_TCON_Get(result_tcon_idx, &record) ||
+      record.descriptor_ty != origin->result_ty)
+    return FALSE;
+  *result = *origin;
+  result->id = WOPT_DSL_SEMANTIC_INFO_INVALID_ID;
+  result->logical_operator = OPR_DSLTENSORCONST;
+  result->version = 1;
+  result->tensor_tcon_idx = result_tcon_idx;
+  result->canonical_attribute_hash =
+      WOPT_DSL_Hash_Combine
+          (WOPT_DSL_Hash_Combine(1469598103934665603ULL,
+                                 DSL_TENSOR_TCON_STORAGE_SPLAT),
+           (UINT64)record.scalar_integer_value);
+  result->operand_descriptor_hash = 1469598103934665603ULL;
+  return TRUE;
 }
 
-UINT32
-WOPT_DSL_Semantic_Info_Count(void)
+BOOL
+WOPT_DSL_Fold_Compact_Tensors
+    (const WOPT_DSL_SEMANTIC_INFO *origin,
+     const TCON_IDX *operand_tcon_idx, UINT32 operand_count,
+     WOPT_DSL_SEMANTIC_INFO *result, FILE *diagnostic)
 {
-  return WOPT_dsl_semantic_info.size();
+  DSL_IR_NODE_RECORD node;
+  DSL_TENSOR_FOLD_POLICY policy;
+  DSL_TENSOR_FOLD_CANDIDATE candidate;
+  DSL_TENSOR_FOLD_REPLACEMENT_CONTEXT context;
+  DSL_TENSOR_FOLD_REPLACEMENT replacement;
+  TCON operands[2];
+  TY_IDX operand_ty[2];
+  TY_IDX result_ty[1];
+  std::vector<DSL_IR_ATTRIBUTE_RECORD> attributes;
+
+  if (origin == NULL || operand_tcon_idx == NULL || result == NULL ||
+      operand_count != 2 ||
+      (origin->logical_operator != OPR_DSLADD &&
+       origin->logical_operator != OPR_DSLMUL) ||
+      !DSL_IR_Image_Get_Node(origin->origin_node_id, &node) ||
+      node.operand_count != operand_count)
+    return FALSE;
+
+  for (UINT32 i = 0; i < operand_count; ++i) {
+    DSL_TENSOR_TCON_RECORD record;
+    if (!DSL_Tensor_TCON_Get(operand_tcon_idx[i], &record) ||
+        !DSL_Tensor_TCON_Get_Carrier(operand_tcon_idx[i], &operands[i]))
+      return FALSE;
+    operand_ty[i] = record.descriptor_ty;
+  }
+
+  for (UINT32 i = 0; i < node.attribute_count; ++i) {
+    DSL_IR_ATTRIBUTE_RECORD attribute;
+    if (!DSL_IR_Image_Get_Attribute
+            (node.first_attribute_id + i, &attribute))
+      return FALSE;
+    attributes.push_back(attribute);
+  }
+
+  DSL_Tensor_Fold_Default_Policy(&policy);
+  result_ty[0] = origin->result_ty;
+  memset(&candidate, 0, sizeof(candidate));
+  candidate.dsl_operator = origin->logical_operator;
+  candidate.version = origin->version;
+  candidate.result_count = 1;
+  candidate.operand_count = operand_count;
+  candidate.operands = operands;
+  candidate.operand_ty = operand_ty;
+  candidate.result_ty = result_ty;
+  candidate.attributes =
+      attributes.empty() ? NULL : &attributes[0];
+  candidate.attribute_count = attributes.size();
+  candidate.policy = &policy;
+
+  memset(&context, 0, sizeof(context));
+  context.result_ty = origin->result_ty;
+  context.origin_node_id = origin->origin_node_id;
+  context.origin_result_value_id = origin->origin_result_value_id;
+  DSL_TENSOR_FOLD_STATUS status =
+      DSL_Tensor_Fold_Describe_Replacement
+          (&candidate, &context, &replacement);
+  if (status != DSL_TENSOR_FOLD_SUCCESS) {
+    if (diagnostic != NULL)
+      fprintf(diagnostic, "WOPT DSL fold: %s rejected: %s\n",
+              DSL_OPERATOR_name(origin->logical_operator),
+              DSL_Tensor_Fold_Status_Name(status));
+    return FALSE;
+  }
+  return WOPT_DSL_Create_Folded_Tensor_Info
+             (origin, replacement.result_tcon_idx, result);
+}
+
+static std::string
+WOPT_DSL_Tensor_Constant_Payload(const char *name, TY_IDX ty,
+                                INT64 value)
+{
+  char rank[32];
+  char scalar[32];
+  const char *dtype = TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_DTYPE);
+  const char *shape = TY_tensor_attribute(ty, TY_TENSOR_SCHEMA_SHAPE);
+
+  snprintf(rank, sizeof(rank), "%d", TY_tensor_rank(ty));
+  snprintf(scalar, sizeof(scalar), "%lld", (long long)value);
+  std::string payload = "name=";
+  payload += name == NULL ? "" : name;
+  payload += ";dtype=";
+  payload += dtype == NULL ? "" : dtype;
+  payload += ";rank=";
+  payload += rank;
+  payload += ";shape=";
+  payload += shape == NULL ? "" : shape;
+  payload += ";value_kind=splat;value=";
+  payload += scalar;
+  return payload;
+}
+
+WN *
+WOPT_DSL_Emit_WN(const WOPT_DSL_SEMANTIC_INFO *info,
+                 const WN *original, ST_IDX result_st,
+                 WN **kids, UINT32 kid_count, FILE *diagnostic)
+{
+  DSL_OPCODE_ANNOTATION annotation;
+  DSL_LOGICAL_OPCODE original_logical;
+  DSL_IR_VALUE_RECORD result_value;
+  DSL_IR_NODE_RECORD node;
+  const char *owner_pu =
+      Current_PU_Info == NULL ? NULL :
+          ST_name(PU_Info_proc_sym(Current_PU_Info));
+  std::string generated_payload;
+  const char *payload = NULL;
+
+  if (info == NULL ||
+      (kid_count != 0 && kids == NULL) ||
+      !WOPT_DSL_Result_Value
+          (result_st, owner_pu, &result_value, &node))
+    return NULL;
+
+  if (original != NULL &&
+      DSL_WN_Get_Logical_Opcode(original, &original_logical, NULL) &&
+      original_logical.dsl_operator == info->logical_operator &&
+      original_logical.effective_version == info->version &&
+      DSL_WN_Get_Opcode_Annotation(original, &annotation))
+    payload = annotation.payload;
+
+  if (info->logical_operator == OPR_DSLTENSORCONST) {
+    DSL_TENSOR_TCON_RECORD tcon;
+    if (!DSL_Tensor_TCON_Get(info->tensor_tcon_idx, &tcon))
+      return NULL;
+    generated_payload = WOPT_DSL_Tensor_Constant_Payload
+                            (ST_name(St_Table[result_st]), info->result_ty,
+                             tcon.scalar_integer_value);
+    payload = generated_payload.c_str();
+
+    DSL_IR_ATTRIBUTE_RECORD attributes[2];
+    DSL_IR_Attribute_Record_Init(&attributes[0]);
+    attributes[0].value_kind = DSL_IR_ATTRIBUTE_VALUE_STRING;
+    attributes[0].name = Save_Str("value_kind");
+    attributes[0].value = Save_Str("splat");
+    DSL_IR_Attribute_Record_Init(&attributes[1]);
+    attributes[1].value_kind = DSL_IR_ATTRIBUTE_VALUE_STRING;
+    attributes[1].name = Save_Str("value");
+    char scalar[32];
+    snprintf(scalar, sizeof(scalar), "%lld",
+             (long long)tcon.scalar_integer_value);
+    attributes[1].value = Save_Str(scalar);
+
+    DSL_IR_NODE_REWRITE_REQUEST request;
+    memset(&request, 0, sizeof(request));
+    request.node_id = node.id;
+    request.opcode_descriptor_id =
+        DSL_IR_Image_Ensure_Opcode_Descriptor
+            (OPR_DSLTENSORCONST, info->version);
+    request.payload = Save_Str(payload);
+    request.attributes = attributes;
+    request.attribute_count = 2;
+    request.result_value_kind = DSL_IR_VALUE_CONSTANT;
+    if (request.opcode_descriptor_id ==
+            DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID ||
+        !DSL_IR_Image_Rewrite_Node(&request))
+      return NULL;
+
+    char tcon_text[32];
+    snprintf(tcon_text, sizeof(tcon_text), "%u",
+             (UINT32)info->tensor_tcon_idx);
+    ST_tensor_bind_metadata(result_st, "tensor_tcon_idx", tcon_text);
+    ST_tensor_bind_metadata(result_st, "tensor_fold.origin", "WOPT");
+  }
+
+  if (payload == NULL) {
+    if (diagnostic != NULL)
+      fprintf(diagnostic, "WOPT DSL emission: payload unavailable for %s\n",
+              DSL_OPERATOR_name(info->logical_operator));
+    return NULL;
+  }
+  return DSL_WN_Create_Native(info->logical_operator, info->version,
+                              payload, kids, kid_count);
 }

--- a/osprey/be/opt/opt_dsl.cxx
+++ b/osprey/be/opt/opt_dsl.cxx
@@ -336,6 +336,64 @@ WOPT_DSL_Tensor_Constant_Payload(const char *name, TY_IDX ty,
   return payload;
 }
 
+static BOOL
+WOPT_DSL_Copy_Node_Attributes(
+    const DSL_IR_NODE_RECORD *node,
+    std::vector<DSL_IR_ATTRIBUTE_RECORD> *attributes)
+{
+  if (node == NULL || attributes == NULL)
+    return FALSE;
+  attributes->clear();
+  for (UINT32 i = 0; i < node->attribute_count; ++i) {
+    DSL_IR_ATTRIBUTE_RECORD attribute;
+    if (!DSL_IR_Image_Get_Attribute
+            (node->first_attribute_id + i, &attribute))
+      return FALSE;
+    attribute.id = DSL_IR_ATTRIBUTE_INVALID_ID;
+    attribute.owner_node_id = DSL_IR_NODE_INVALID_ID;
+    attributes->push_back(attribute);
+  }
+  return TRUE;
+}
+
+static BOOL
+WOPT_DSL_Operand_Value(const WN *operand, const char *owner_pu,
+                       DSL_IR_VALUE_RECORD *value)
+{
+  return operand != NULL && WN_operator(operand) == OPR_LDID &&
+         owner_pu != NULL && value != NULL &&
+         DSL_IR_Image_Find_PU_Value
+             (WN_st_idx(operand), ST_name(WN_st(operand)),
+              owner_pu, value);
+}
+
+static std::string
+WOPT_DSL_Binary_Payload(
+    WN **kids, UINT32 kid_count,
+    const std::vector<DSL_IR_ATTRIBUTE_RECORD> &attributes)
+{
+  std::string payload;
+  for (UINT32 i = 0; i < kid_count; ++i) {
+    char ordinal[32];
+    snprintf(ordinal, sizeof(ordinal), "%u", i);
+    if (!payload.empty())
+      payload += ";";
+    payload += "kid";
+    payload += ordinal;
+    payload += "=";
+    payload += ST_name(WN_st(kids[i]));
+  }
+  for (UINT32 i = 0; i < attributes.size(); ++i) {
+    if (!payload.empty())
+      payload += ";";
+    payload += Index_To_Str(attributes[i].name);
+    payload += "=";
+    if (attributes[i].value != STR_IDX_ZERO)
+      payload += Index_To_Str(attributes[i].value);
+  }
+  return payload;
+}
+
 WN *
 WOPT_DSL_Emit_WN(const WOPT_DSL_SEMANTIC_INFO *info,
                  const WN *original, ST_IDX result_st,
@@ -349,6 +407,7 @@ WOPT_DSL_Emit_WN(const WOPT_DSL_SEMANTIC_INFO *info,
       Current_PU_Info == NULL ? NULL :
           ST_name(PU_Info_proc_sym(Current_PU_Info));
   std::string generated_payload;
+  std::vector<DSL_IR_ATTRIBUTE_RECORD> attributes;
   const char *payload = NULL;
 
   if (info == NULL ||
@@ -423,6 +482,39 @@ WOPT_DSL_Emit_WN(const WOPT_DSL_SEMANTIC_INFO *info,
              (UINT32)info->tensor_tcon_idx);
     ST_tensor_bind_metadata(result_st, "tensor_tcon_idx", tcon_text);
     ST_tensor_bind_metadata(result_st, "tensor_fold.origin", "WOPT");
+  } else if (info->logical_operator == OPR_DSLADD ||
+             info->logical_operator == OPR_DSLMUL) {
+    DSL_IR_VALUE_ID operand_ids[2];
+    if (kid_count != 2 ||
+        !WOPT_DSL_Copy_Node_Attributes(&node, &attributes))
+      return NULL;
+    for (UINT32 i = 0; i < kid_count; ++i) {
+      DSL_IR_VALUE_RECORD operand;
+      if (!WOPT_DSL_Operand_Value(kids[i], owner_pu, &operand))
+        return NULL;
+      operand_ids[i] = operand.id;
+    }
+
+    generated_payload =
+        WOPT_DSL_Binary_Payload(kids, kid_count, attributes);
+    payload = generated_payload.c_str();
+    DSL_IR_NODE_REWRITE_REQUEST request;
+    memset(&request, 0, sizeof(request));
+    request.node_id = node.id;
+    request.opcode_descriptor_id =
+        DSL_IR_Image_Ensure_Opcode_Descriptor
+            (info->logical_operator, info->version);
+    request.payload = Save_Str(payload);
+    request.operand_value_ids = operand_ids;
+    request.operand_count = kid_count;
+    request.attributes =
+        attributes.empty() ? NULL : &attributes[0];
+    request.attribute_count = (UINT32)attributes.size();
+    request.result_value_kind = result_value.value_kind;
+    if (request.opcode_descriptor_id ==
+            DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID ||
+        !DSL_IR_Image_Rewrite_Node(&request))
+      return NULL;
   }
 
   if (payload == NULL) {

--- a/osprey/be/opt/opt_dsl.cxx
+++ b/osprey/be/opt/opt_dsl.cxx
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 Open64 Project
+ */
+
+#include <string.h>
+#include <vector>
+
+#include "opt_dsl.h"
+
+static std::vector<WOPT_DSL_SEMANTIC_INFO> WOPT_dsl_semantic_info;
+
+static BOOL
+WOPT_DSL_Semantic_Info_Equal(const WOPT_DSL_SEMANTIC_INFO *left,
+                             const WOPT_DSL_SEMANTIC_INFO *right)
+{
+  return left->logical_operator == right->logical_operator &&
+         left->version == right->version &&
+         left->flags == right->flags &&
+         left->result_ty == right->result_ty &&
+         left->canonical_attribute_hash ==
+             right->canonical_attribute_hash &&
+         left->operand_descriptor_hash ==
+             right->operand_descriptor_hash &&
+         left->effect_identity == right->effect_identity;
+}
+
+static UINT64
+WOPT_DSL_Hash_Combine(UINT64 hash, UINT64 value)
+{
+  hash ^= value;
+  hash *= 1099511628211ULL;
+  return hash;
+}
+
+void
+WOPT_DSL_Semantic_Info_Reset(void)
+{
+  WOPT_dsl_semantic_info.clear();
+}
+
+WOPT_DSL_SEMANTIC_INFO_ID
+WOPT_DSL_Semantic_Info_Intern(const WOPT_DSL_SEMANTIC_INFO *info)
+{
+  if (info == NULL || info->logical_operator == OPR_DSLUNKNOWN ||
+      info->version == 0 || info->reserved != 0)
+    return WOPT_DSL_SEMANTIC_INFO_INVALID_ID;
+
+  for (UINT32 i = 0; i < WOPT_dsl_semantic_info.size(); ++i) {
+    if (WOPT_DSL_Semantic_Info_Equal
+            (&WOPT_dsl_semantic_info[i], info))
+      return i + 1;
+  }
+
+  WOPT_DSL_SEMANTIC_INFO copy = *info;
+  copy.id = WOPT_dsl_semantic_info.size() + 1;
+  WOPT_dsl_semantic_info.push_back(copy);
+  return copy.id;
+}
+
+BOOL
+WOPT_DSL_Semantic_Info_Get(WOPT_DSL_SEMANTIC_INFO_ID id,
+                           WOPT_DSL_SEMANTIC_INFO *info)
+{
+  if (id == WOPT_DSL_SEMANTIC_INFO_INVALID_ID ||
+      id > WOPT_dsl_semantic_info.size())
+    return FALSE;
+  if (info != NULL)
+    *info = WOPT_dsl_semantic_info[id - 1];
+  return TRUE;
+}
+
+UINT32
+WOPT_DSL_Semantic_Info_Hash(WOPT_DSL_SEMANTIC_INFO_ID id)
+{
+  WOPT_DSL_SEMANTIC_INFO info;
+  UINT64 hash = 1469598103934665603ULL;
+
+  if (!WOPT_DSL_Semantic_Info_Get(id, &info))
+    return 0;
+  hash = WOPT_DSL_Hash_Combine(hash, info.logical_operator);
+  hash = WOPT_DSL_Hash_Combine(hash, info.version);
+  hash = WOPT_DSL_Hash_Combine(hash, info.flags);
+  hash = WOPT_DSL_Hash_Combine(hash, info.result_ty);
+  hash = WOPT_DSL_Hash_Combine(hash, info.canonical_attribute_hash);
+  hash = WOPT_DSL_Hash_Combine(hash, info.operand_descriptor_hash);
+  hash = WOPT_DSL_Hash_Combine(hash, info.effect_identity);
+  return (UINT32)(hash ^ (hash >> 32));
+}
+
+UINT32
+WOPT_DSL_Semantic_Info_Count(void)
+{
+  return WOPT_dsl_semantic_info.size();
+}

--- a/osprey/be/opt/opt_dsl.h
+++ b/osprey/be/opt/opt_dsl.h
@@ -9,6 +9,8 @@
 #include "dsl_opcode.h"
 #include "symtab_idx.h"
 
+class WN;
+
 typedef UINT32 WOPT_DSL_SEMANTIC_INFO_ID;
 
 #define WOPT_DSL_SEMANTIC_INFO_INVALID_ID 0
@@ -30,7 +32,9 @@ typedef struct {
   UINT32 version;
   UINT32 flags;
   TY_IDX result_ty;
-  UINT32 reserved;
+  TCON_IDX tensor_tcon_idx;
+  UINT32 origin_node_id;
+  UINT32 origin_result_value_id;
   UINT64 canonical_attribute_hash;
   UINT64 operand_descriptor_hash;
   UINT64 effect_identity;
@@ -39,7 +43,7 @@ typedef struct {
 typedef char WOPT_DSL_Semantic_Info_Id_Size_Check
     [sizeof(WOPT_DSL_SEMANTIC_INFO_ID) == 4 ? 1 : -1];
 typedef char WOPT_DSL_Semantic_Info_Size_Check
-    [sizeof(WOPT_DSL_SEMANTIC_INFO) == 48 ? 1 : -1];
+    [sizeof(WOPT_DSL_SEMANTIC_INFO) == 56 ? 1 : -1];
 
 extern void WOPT_DSL_Semantic_Info_Reset(void);
 extern WOPT_DSL_SEMANTIC_INFO_ID WOPT_DSL_Semantic_Info_Intern
@@ -49,5 +53,18 @@ extern BOOL WOPT_DSL_Semantic_Info_Get
 extern UINT32 WOPT_DSL_Semantic_Info_Hash
     (WOPT_DSL_SEMANTIC_INFO_ID id);
 extern UINT32 WOPT_DSL_Semantic_Info_Count(void);
+extern BOOL WOPT_DSL_Import_Semantic_Info
+    (const WN *wn, ST_IDX result_st, const char *owner_pu,
+     WOPT_DSL_SEMANTIC_INFO *info, FILE *diagnostic);
+extern BOOL WOPT_DSL_Create_Folded_Tensor_Info
+    (const WOPT_DSL_SEMANTIC_INFO *origin, TCON_IDX result_tcon_idx,
+     WOPT_DSL_SEMANTIC_INFO *result);
+extern BOOL WOPT_DSL_Fold_Compact_Tensors
+    (const WOPT_DSL_SEMANTIC_INFO *origin,
+     const TCON_IDX *operand_tcon_idx, UINT32 operand_count,
+     WOPT_DSL_SEMANTIC_INFO *result, FILE *diagnostic);
+extern WN *WOPT_DSL_Emit_WN
+    (const WOPT_DSL_SEMANTIC_INFO *info, const WN *original,
+     ST_IDX result_st, WN **kids, UINT32 kid_count, FILE *diagnostic);
 
 #endif /* opt_dsl_INCLUDED */

--- a/osprey/be/opt/opt_dsl.h
+++ b/osprey/be/opt/opt_dsl.h
@@ -53,6 +53,9 @@ extern BOOL WOPT_DSL_Semantic_Info_Get
 extern UINT32 WOPT_DSL_Semantic_Info_Hash
     (WOPT_DSL_SEMANTIC_INFO_ID id);
 extern UINT32 WOPT_DSL_Semantic_Info_Count(void);
+extern BOOL WOPT_DSL_Algebraic_Safety_Allows
+    (DSL_ALGEBRAIC_SAFETY safety, BOOL floating_point,
+     BOOL reassociation_enabled);
 extern BOOL WOPT_DSL_Import_Semantic_Info
     (const WN *wn, ST_IDX result_st, const char *owner_pu,
      WOPT_DSL_SEMANTIC_INFO *info, FILE *diagnostic);

--- a/osprey/be/opt/opt_dsl.h
+++ b/osprey/be/opt/opt_dsl.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 Open64 Project
+ */
+
+#ifndef opt_dsl_INCLUDED
+#define opt_dsl_INCLUDED
+
+#include "defs.h"
+#include "dsl_opcode.h"
+#include "symtab_idx.h"
+
+typedef UINT32 WOPT_DSL_SEMANTIC_INFO_ID;
+
+#define WOPT_DSL_SEMANTIC_INFO_INVALID_ID 0
+
+enum {
+  WOPT_DSL_SEMANTIC_PURE = 1U << 0,
+  WOPT_DSL_SEMANTIC_PROJECTABLE = 1U << 1
+};
+
+/*
+ * Runtime-only semantic identity for a logical DSL CODEREP.  Source
+ * positions, diagnostics, profiling, and reconstruction provenance do not
+ * participate in this record because they must not inhibit WOPT value
+ * equivalence.
+ */
+typedef struct {
+  WOPT_DSL_SEMANTIC_INFO_ID id;
+  DSL_OPERATOR logical_operator;
+  UINT32 version;
+  UINT32 flags;
+  TY_IDX result_ty;
+  UINT32 reserved;
+  UINT64 canonical_attribute_hash;
+  UINT64 operand_descriptor_hash;
+  UINT64 effect_identity;
+} WOPT_DSL_SEMANTIC_INFO;
+
+typedef char WOPT_DSL_Semantic_Info_Id_Size_Check
+    [sizeof(WOPT_DSL_SEMANTIC_INFO_ID) == 4 ? 1 : -1];
+typedef char WOPT_DSL_Semantic_Info_Size_Check
+    [sizeof(WOPT_DSL_SEMANTIC_INFO) == 48 ? 1 : -1];
+
+extern void WOPT_DSL_Semantic_Info_Reset(void);
+extern WOPT_DSL_SEMANTIC_INFO_ID WOPT_DSL_Semantic_Info_Intern
+    (const WOPT_DSL_SEMANTIC_INFO *info);
+extern BOOL WOPT_DSL_Semantic_Info_Get
+    (WOPT_DSL_SEMANTIC_INFO_ID id, WOPT_DSL_SEMANTIC_INFO *info);
+extern UINT32 WOPT_DSL_Semantic_Info_Hash
+    (WOPT_DSL_SEMANTIC_INFO_ID id);
+extern UINT32 WOPT_DSL_Semantic_Info_Count(void);
+
+#endif /* opt_dsl_INCLUDED */

--- a/osprey/be/opt/opt_dsl_semantic.cxx
+++ b/osprey/be/opt/opt_dsl_semantic.cxx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 Open64 Project
+ */
+
+#include <vector>
+
+#include "opt_dsl.h"
+
+static std::vector<WOPT_DSL_SEMANTIC_INFO> WOPT_dsl_semantic_info;
+
+static BOOL
+WOPT_DSL_Semantic_Info_Equal(const WOPT_DSL_SEMANTIC_INFO *left,
+                             const WOPT_DSL_SEMANTIC_INFO *right)
+{
+  return left->logical_operator == right->logical_operator &&
+         left->version == right->version &&
+         left->flags == right->flags &&
+         left->result_ty == right->result_ty &&
+         left->tensor_tcon_idx == right->tensor_tcon_idx &&
+         left->canonical_attribute_hash ==
+             right->canonical_attribute_hash &&
+         left->operand_descriptor_hash ==
+             right->operand_descriptor_hash &&
+         left->effect_identity == right->effect_identity;
+}
+
+static UINT64
+WOPT_DSL_Hash_Combine(UINT64 hash, UINT64 value)
+{
+  hash ^= value;
+  hash *= 1099511628211ULL;
+  return hash;
+}
+
+void
+WOPT_DSL_Semantic_Info_Reset(void)
+{
+  WOPT_dsl_semantic_info.clear();
+}
+
+WOPT_DSL_SEMANTIC_INFO_ID
+WOPT_DSL_Semantic_Info_Intern(const WOPT_DSL_SEMANTIC_INFO *info)
+{
+  if (info == NULL || info->logical_operator == OPR_DSLUNKNOWN ||
+      info->version == 0)
+    return WOPT_DSL_SEMANTIC_INFO_INVALID_ID;
+
+  for (UINT32 i = 0; i < WOPT_dsl_semantic_info.size(); ++i) {
+    if (WOPT_DSL_Semantic_Info_Equal
+            (&WOPT_dsl_semantic_info[i], info))
+      return i + 1;
+  }
+
+  WOPT_DSL_SEMANTIC_INFO copy = *info;
+  copy.id = WOPT_dsl_semantic_info.size() + 1;
+  WOPT_dsl_semantic_info.push_back(copy);
+  return copy.id;
+}
+
+BOOL
+WOPT_DSL_Semantic_Info_Get(WOPT_DSL_SEMANTIC_INFO_ID id,
+                           WOPT_DSL_SEMANTIC_INFO *info)
+{
+  if (id == WOPT_DSL_SEMANTIC_INFO_INVALID_ID ||
+      id > WOPT_dsl_semantic_info.size())
+    return FALSE;
+  if (info != NULL)
+    *info = WOPT_dsl_semantic_info[id - 1];
+  return TRUE;
+}
+
+UINT32
+WOPT_DSL_Semantic_Info_Hash(WOPT_DSL_SEMANTIC_INFO_ID id)
+{
+  WOPT_DSL_SEMANTIC_INFO info;
+  UINT64 hash = 1469598103934665603ULL;
+
+  if (!WOPT_DSL_Semantic_Info_Get(id, &info))
+    return 0;
+  hash = WOPT_DSL_Hash_Combine(hash, info.logical_operator);
+  hash = WOPT_DSL_Hash_Combine(hash, info.version);
+  hash = WOPT_DSL_Hash_Combine(hash, info.flags);
+  hash = WOPT_DSL_Hash_Combine(hash, info.result_ty);
+  hash = WOPT_DSL_Hash_Combine(hash, info.tensor_tcon_idx);
+  hash = WOPT_DSL_Hash_Combine(hash, info.canonical_attribute_hash);
+  hash = WOPT_DSL_Hash_Combine(hash, info.operand_descriptor_hash);
+  hash = WOPT_DSL_Hash_Combine(hash, info.effect_identity);
+  return (UINT32)(hash ^ (hash >> 32));
+}
+
+UINT32
+WOPT_DSL_Semantic_Info_Count(void)
+{
+  return WOPT_dsl_semantic_info.size();
+}

--- a/osprey/be/opt/opt_dsl_semantic.cxx
+++ b/osprey/be/opt/opt_dsl_semantic.cxx
@@ -93,3 +93,21 @@ WOPT_DSL_Semantic_Info_Count(void)
 {
   return WOPT_dsl_semantic_info.size();
 }
+
+BOOL
+WOPT_DSL_Algebraic_Safety_Allows
+    (DSL_ALGEBRAIC_SAFETY safety, BOOL floating_point,
+     BOOL reassociation_enabled)
+{
+  switch (safety) {
+  case DSL_ALGEBRAIC_SAFETY_EXACT:
+    return TRUE;
+  case DSL_ALGEBRAIC_SAFETY_INTEGER:
+    return !floating_point;
+  case DSL_ALGEBRAIC_SAFETY_INTEGER_OR_FP_REASSOCIATE:
+  case DSL_ALGEBRAIC_SAFETY_RELAXED_MATH:
+    return !floating_point || reassociation_enabled;
+  default:
+    return FALSE;
+  }
+}

--- a/osprey/be/opt/opt_emit_template.h
+++ b/osprey/be/opt/opt_emit_template.h
@@ -128,6 +128,13 @@ Gen_exp_wn(STMTREP* stmt, CODEREP *exp, EMITTER *emitter)
             WN_operator(WN_kid0(statement_wn)) == OPR_DSL)
           original = WN_kid0(statement_wn);
       }
+      if (stmt != NULL && stmt->Lhs() != NULL &&
+          stmt->Lhs()->Kind() == CK_VAR) {
+        ST *result =
+            emitter->Opt_stab()->St(stmt->Lhs()->Aux_id());
+        if (result != NULL)
+          result_st = ST_st_idx(result);
+      }
       wn = WOPT_DSL_Emit_WN
                (&info, original, result_st, dsl_kids,
                 exp->Kid_count(), TFile);

--- a/osprey/be/opt/opt_emit_template.h
+++ b/osprey/be/opt/opt_emit_template.h
@@ -105,6 +105,38 @@ Gen_exp_wn(STMTREP* stmt, CODEREP *exp, EMITTER *emitter)
 
   switch (exp->Kind()) {
   case CK_OP:
+    if (exp->Is_dsl_op()) {
+      WOPT_DSL_SEMANTIC_INFO info;
+      WN *dsl_kids[2];
+      WN *original = NULL;
+      WN *statement_wn = stmt == NULL ? NULL : stmt->Wn();
+      ST_IDX result_st = ST_IDX_ZERO;
+
+      FmtAssert(exp->Kid_count() <= 2 &&
+                WOPT_DSL_Semantic_Info_Get
+                    (exp->Dsl_semantic_info_id(), &info),
+                ("Gen_exp_wn: invalid logical DSL CODEREP"));
+      for (INT i = 0; i < exp->Kid_count(); ++i)
+        dsl_kids[i] =
+            Gen_exp_wn(stmt, exp->Get_opnd(i), emitter);
+
+      if (statement_wn != NULL &&
+          (WN_operator(statement_wn) == OPR_STID ||
+           WN_operator(statement_wn) == OPR_STBITS)) {
+        result_st = WN_st_idx(statement_wn);
+        if (WN_kid_count(statement_wn) != 0 &&
+            WN_operator(WN_kid0(statement_wn)) == OPR_DSL)
+          original = WN_kid0(statement_wn);
+      }
+      FmtAssert(result_st != ST_IDX_ZERO,
+                ("Gen_exp_wn: DSL result has no owning symbol"));
+      wn = WOPT_DSL_Emit_WN
+               (&info, original, result_st, dsl_kids,
+                exp->Kid_count(), TFile);
+      FmtAssert(wn != NULL,
+                ("Gen_exp_wn: failed to emit logical DSL CODEREP"));
+      break;
+    }
     opr = exp->Opr();
     switch (opr) {
     /* CVTL-RELATED start (performance) */

--- a/osprey/be/opt/opt_emit_template.h
+++ b/osprey/be/opt/opt_emit_template.h
@@ -128,8 +128,6 @@ Gen_exp_wn(STMTREP* stmt, CODEREP *exp, EMITTER *emitter)
             WN_operator(WN_kid0(statement_wn)) == OPR_DSL)
           original = WN_kid0(statement_wn);
       }
-      FmtAssert(result_st != ST_IDX_ZERO,
-                ("Gen_exp_wn: DSL result has no owning symbol"));
       wn = WOPT_DSL_Emit_WN
                (&info, original, result_st, dsl_kids,
                 exp->Kid_count(), TFile);

--- a/osprey/be/opt/opt_fold.cxx
+++ b/osprey/be/opt/opt_fold.cxx
@@ -260,6 +260,80 @@ FOLD::Fold_Tree(CODEREP *cr)
   return CR_Simplify_Tree(cr);
 }
 
+BOOL
+FOLD::Prove_DSL_Factorization(CODEREP *left, CODEREP *right,
+                              OPERATOR outer_opr,
+                              DSL_ALGEBRAIC_SAFETY safety)
+{
+  if (!WOPT_Enable_CRSIMP || left == NULL || right == NULL ||
+      !left->Is_dsl_op() || !right->Is_dsl_op() ||
+      left->Kid_count() != 2 || right->Kid_count() != 2 ||
+      (outer_opr != OPR_ADD && outer_opr != OPR_SUB))
+    return FALSE;
+
+  WOPT_DSL_SEMANTIC_INFO left_info;
+  WOPT_DSL_SEMANTIC_INFO right_info;
+  if (!left->Dsl_semantic_info(&left_info) ||
+      !right->Dsl_semantic_info(&right_info) ||
+      left_info.result_ty != right_info.result_ty ||
+      !TY_is_tensor_extension(left_info.result_ty))
+    return FALSE;
+  TYPE_ID element_mtype =
+      TY_mtype(TY_tensor_element_ty(left_info.result_ty));
+  BOOL floating_point = MTYPE_is_float(element_mtype);
+  if ((!MTYPE_is_integral(element_mtype) && !floating_point) ||
+      !WOPT_DSL_Algebraic_Safety_Allows
+          (safety, floating_point, Enable_Cfold_Reassociate))
+    return FALSE;
+
+  CODEREP *leaf[4] = {
+      left->Get_opnd(0), left->Get_opnd(1),
+      right->Get_opnd(0), right->Get_opnd(1)
+  };
+  INT32 saved_usecnt[4];
+  for (INT i = 0; i < 4; ++i)
+    saved_usecnt[i] = leaf[i]->Usecnt();
+
+  CODEREP *left_view = Alloc_stack_cr(2);
+  left_view->Init_op
+      (OPCODE_make_op(OPR_MPY, element_mtype, MTYPE_V), 2);
+  left_view->Set_opnd(0, leaf[0]);
+  left_view->Set_opnd(1, leaf[1]);
+  left_view->Set_usecnt(1);
+  leaf[0]->IncUsecnt();
+  leaf[1]->IncUsecnt();
+
+  CODEREP *right_view = Alloc_stack_cr(2);
+  right_view->Init_op
+      (OPCODE_make_op(OPR_MPY, element_mtype, MTYPE_V), 2);
+  right_view->Set_opnd(0, leaf[2]);
+  right_view->Set_opnd(1, leaf[3]);
+  right_view->Set_usecnt(1);
+  leaf[2]->IncUsecnt();
+  leaf[3]->IncUsecnt();
+
+  CODEREP *outer_view = Alloc_stack_cr(2);
+  outer_view->Init_op
+      (OPCODE_make_op(outer_opr, element_mtype, MTYPE_V), 2);
+  outer_view->Set_opnd(0, left_view);
+  outer_view->Set_opnd(1, right_view);
+  outer_view->Set_usecnt(1);
+
+  CODEREP *result = CR_Simplify_Expr(outer_view);
+  BOOL proved = result != NOHASH && result->Kind() == CK_OP &&
+                result->Opr() == OPR_MPY &&
+                ((result->Get_opnd(0)->Kind() == CK_OP &&
+                  result->Get_opnd(0)->Opr() == outer_opr) ||
+                 (result->Get_opnd(1)->Kind() == CK_OP &&
+                  result->Get_opnd(1)->Opr() == outer_opr));
+  if (result != NOHASH)
+    result->DecUsecnt_rec();
+
+  for (INT i = 0; i < 4; ++i)
+    leaf[i]->Set_usecnt(saved_usecnt[i]);
+  return proved;
+}
+
 //============================================================================
 // default constructor sets debug flag
 FOLD::FOLD(void)

--- a/osprey/be/opt/opt_fold.cxx
+++ b/osprey/be/opt/opt_fold.cxx
@@ -166,6 +166,66 @@ Initialize_CR_simp(CODEMAP *htable)
   return NULL;
 }
 
+static BOOL
+WOPT_DSL_Compact_TCON(CODEREP *cr, UINT32 depth, TCON_IDX *tcon_idx)
+{
+  WOPT_DSL_SEMANTIC_INFO info;
+
+  if (tcon_idx != NULL)
+    *tcon_idx = TCON_IDX_ZERO;
+  if (cr == NULL || tcon_idx == NULL || depth > 8)
+    return FALSE;
+
+  if (cr->Is_dsl_op()) {
+    if (!WOPT_DSL_Semantic_Info_Get
+            (cr->Dsl_semantic_info_id(), &info) ||
+        info.logical_operator != OPR_DSLTENSORCONST ||
+        info.tensor_tcon_idx == TCON_IDX_ZERO)
+      return FALSE;
+    *tcon_idx = info.tensor_tcon_idx;
+    return TRUE;
+  }
+
+  if (cr->Kind() == CK_VAR && cr->Defstmt() != NULL &&
+      cr->Defstmt()->Rhs() != cr)
+    return WOPT_DSL_Compact_TCON
+               (cr->Defstmt()->Rhs(), depth + 1, tcon_idx);
+  return FALSE;
+}
+
+static CODEREP *
+WOPT_DSL_Fold_Expr(CODEREP *cr)
+{
+  WOPT_DSL_SEMANTIC_INFO origin;
+  WOPT_DSL_SEMANTIC_INFO folded;
+  WOPT_DSL_SEMANTIC_INFO_ID folded_id;
+  TCON_IDX operand_tcon_idx[2];
+  CODEREP *replacement;
+
+  if (!WOPT_Enable_CRSIMP || cr == NULL || !cr->Is_dsl_op() ||
+      cr->Kid_count() != 2 ||
+      !WOPT_DSL_Semantic_Info_Get
+          (cr->Dsl_semantic_info_id(), &origin) ||
+      (origin.logical_operator != OPR_DSLADD &&
+       origin.logical_operator != OPR_DSLMUL))
+    return NULL;
+  if (!WOPT_DSL_Compact_TCON
+          (cr->Get_opnd(0), 0, &operand_tcon_idx[0]) ||
+      !WOPT_DSL_Compact_TCON
+          (cr->Get_opnd(1), 0, &operand_tcon_idx[1]) ||
+      !WOPT_DSL_Fold_Compact_Tensors
+          (&origin, operand_tcon_idx, 2, &folded, TFile))
+    return NULL;
+
+  folded_id = WOPT_DSL_Semantic_Info_Intern(&folded);
+  if (folded_id == WOPT_DSL_SEMANTIC_INFO_INVALID_ID)
+    return NULL;
+  replacement = Alloc_stack_cr(0);
+  replacement->Init_op(cr->Op(), 0);
+  replacement->Set_dsl_semantic_info_id(folded_id);
+  return fold_htable->Hash_Op(replacement, FALSE);
+}
+
 // entry point for single level constant folder
 CODEREP *
 FOLD::Fold_Expr(CODEREP *cr)
@@ -180,6 +240,9 @@ FOLD::Fold_Expr(CODEREP *cr)
 
   if (cr->Kind() != CK_OP)
     return NOHASH;
+
+  if (cr->Is_dsl_op())
+    return WOPT_DSL_Fold_Expr(cr);
 
   return CR_Simplify_Expr(cr);
 }

--- a/osprey/be/opt/opt_fold.h
+++ b/osprey/be/opt/opt_fold.h
@@ -84,6 +84,8 @@ public:
   // main entry points for folding to a constant
   CODEREP *Fold_Expr(CODEREP *);	// one level
   CODEREP *Fold_Tree(CODEREP *);	// entire tree
+  BOOL Prove_DSL_Factorization(CODEREP *, CODEREP *, OPERATOR,
+                               DSL_ALGEBRAIC_SAFETY);
 
 private:
   // a pointer is returned

--- a/osprey/be/opt/opt_htable.cxx
+++ b/osprey/be/opt/opt_htable.cxx
@@ -104,6 +104,7 @@
 #include "opt_fold.h"
 #include "config_targ.h"		// ISA info
 #include "opt_prop.h"
+#include "pu_info.h"
 #include "bb_node_set.h"
 #include "opt_bb.h"
 #include "opt_cvtl_rule.h"
@@ -904,9 +905,13 @@ CODEREP::Print_node(INT32 indent, FILE *fp) const
     if (Is_dsl_op()) {
       WOPT_DSL_SEMANTIC_INFO info;
       if (Dsl_semantic_info(&info))
-        fprintf(fp, "%s.v%u ty=%u",
+        fprintf(fp,
+                "%s.v%u ty=%u attrs=%llx operands=%llx effect=%llu",
                 DSL_OPERATOR_name(info.logical_operator), info.version,
-                (UINT32)info.result_ty);
+                (UINT32)info.result_ty,
+                (unsigned long long)info.canonical_attribute_hash,
+                (unsigned long long)info.operand_descriptor_hash,
+                (unsigned long long)info.effect_identity);
       else
         fprintf(fp, "OPR_DSLUNKNOWN");
     } else {
@@ -3200,11 +3205,43 @@ CODEMAP::Add_expr(WN *wn, OPT_STAB *opt_stab, STMTREP *stmt, CANON_CR *ccr,
   const OPERATOR    oper = WN_operator(wn);
   BOOL  propagated = FALSE;
 
-  FmtAssert(oper != OPR_DSL,
-            ("CODEMAP::Add_expr: logical DSL import is not enabled; "
-             "run VHO DSL lowering before WOPT"));
   FmtAssert (OPCODE_is_expression(op) || OPCODE_is_fake(op),
 	     ("CODEMAP::Hash: opcode %s is not an expression",OPCODE_name(op)));
+
+  if (oper == OPR_DSL) {
+    WN *statement_wn = stmt == NULL ? NULL : stmt->Wn();
+    ST_IDX result_st =
+        statement_wn != NULL &&
+        (WN_operator(statement_wn) == OPR_STID ||
+         WN_operator(statement_wn) == OPR_STBITS) ?
+            WN_st_idx(statement_wn) : ST_IDX_ZERO;
+    WOPT_DSL_SEMANTIC_INFO info;
+    WOPT_DSL_SEMANTIC_INFO_ID info_id;
+
+    FmtAssert(result_st != ST_IDX_ZERO &&
+              WOPT_DSL_Import_Semantic_Info
+                  (wn, result_st,
+                   Current_PU_Info == NULL ? NULL :
+                       ST_name(PU_Info_proc_sym(Current_PU_Info)),
+                   &info, TFile),
+              ("CODEMAP::Add_expr: incomplete logical DSL import"));
+    info_id = WOPT_DSL_Semantic_Info_Intern(&info);
+    FmtAssert(info_id != WOPT_DSL_SEMANTIC_INFO_INVALID_ID,
+              ("CODEMAP::Add_expr: failed to intern logical DSL identity"));
+
+    cr->Init_op(op, WN_kid_count(wn));
+    cr->Set_dsl_semantic_info_id(info_id);
+    for (INT i = 0; i < WN_kid_count(wn); ++i) {
+      CODEREP *kid = Add_expr
+                         (WN_kid(wn, i), opt_stab, stmt, &propagated,
+                          copyprop);
+      cr->Set_opnd(i, kid);
+    }
+    retv = Hash_Op(cr, FALSE);
+    ccr->Set_tree(retv);
+    ccr->Set_scale(0);
+    return propagated;
+  }
 
   if (OPCODE_is_leaf(op)) {
     if (OPERATOR_is_scalar_load (oper)) {

--- a/osprey/be/opt/opt_htable.cxx
+++ b/osprey/be/opt/opt_htable.cxx
@@ -95,6 +95,7 @@
 #include "opt_cfg.h"
 #include "opt_sym.h"
 #include "opt_htable.h"
+#include "opt_dsl.h"
 #include "opt_ssa.h"
 #include "opt_combine.h"
 #include "opt_main.h"
@@ -110,6 +111,11 @@
 
 #include <strings.h>   // bcopy
 #include "opt_sys.h"
+
+#if defined(TARG_X8664) && defined(_LP64)
+typedef char WOPT_DSL_Coderep_Size_Check
+    [sizeof(CODEREP) == 88 ? 1 : -1];
+#endif
 
 #ifdef BUILD_MASTIFF
 #include "opt_dbg.h"   // g_ipsa_manager
@@ -320,6 +326,7 @@ CODEREP::Copy(const CODEREP &cr)
   }
   else if (kind == CK_OP) {
     Set_opr(cr.Opr());
+    Set_dsl_semantic_info_id(cr.Dsl_semantic_info_id());
     Set_kid_count(cr.Kid_count());
     for (INT i = 0; i < Kid_count(); i++) {
       Set_opnd(i, cr.Get_opnd(i));
@@ -515,7 +522,9 @@ CODEREP::Match(CODEREP* cr, INT32 mu_vsym_depth, OPT_STAB *sym)
 
 
   case CK_OP:
-    if (Op() == cr->Op() && Kid_count() == cr->Kid_count()) {
+    if (Op() == cr->Op() &&
+        Dsl_semantic_info_id() == cr->Dsl_semantic_info_id() &&
+        Kid_count() == cr->Kid_count()) {
       for (INT i = 0; i < Kid_count(); i++)
 	if (Get_opnd(i) != cr->Get_opnd(i))
 	  return FALSE;
@@ -892,8 +901,18 @@ CODEREP::Print_node(INT32 indent, FILE *fp) const
     fprintf(fp, ">");	// mark line visually as htable dump
     for (i = 0; i < indent; i++) fprintf(fp, " ");
     char buf[32];
-    sprintf(buf, "%s", OPCODE_name(Op()));
-    fprintf(fp, "%s", buf+4);
+    if (Is_dsl_op()) {
+      WOPT_DSL_SEMANTIC_INFO info;
+      if (Dsl_semantic_info(&info))
+        fprintf(fp, "%s.v%u ty=%u",
+                DSL_OPERATOR_name(info.logical_operator), info.version,
+                (UINT32)info.result_ty);
+      else
+        fprintf(fp, "OPR_DSLUNKNOWN");
+    } else {
+      sprintf(buf, "%s", OPCODE_name(Op()));
+      fprintf(fp, "%s", buf+4);
+    }
     switch (Opr()) {
     case OPR_CVTL:
       fprintf(fp, " %d", Offset());
@@ -1502,6 +1521,8 @@ CODEMAP::Hash_op_and_canon(CODEREP *cr, BOOL canonicalize)
   }
 
   INT val = cr->Op();
+  if (cr->Is_dsl_op())
+    val += WOPT_DSL_Semantic_Info_Hash(cr->Dsl_semantic_info_id());
 
   for (INT i = 0; i < cr->Kid_count(); i++) {
     CODEREP *opnd = cr->Get_opnd(i);
@@ -3179,6 +3200,9 @@ CODEMAP::Add_expr(WN *wn, OPT_STAB *opt_stab, STMTREP *stmt, CANON_CR *ccr,
   const OPERATOR    oper = WN_operator(wn);
   BOOL  propagated = FALSE;
 
+  FmtAssert(oper != OPR_DSL,
+            ("CODEMAP::Add_expr: logical DSL import is not enabled; "
+             "run VHO DSL lowering before WOPT"));
   FmtAssert (OPCODE_is_expression(op) || OPCODE_is_fake(op),
 	     ("CODEMAP::Hash: opcode %s is not an expression",OPCODE_name(op)));
 
@@ -6343,4 +6367,3 @@ STMTREP_LIST_CONTAINER::Prepend(STMTREP *sr, MEM_POOL *pool)
     ErrMsg ( EC_No_Mem, "STMTREP_LIST_CONTAINER::Prepend" );
   Prepend(new_srlst);
 }
-

--- a/osprey/be/opt/opt_htable.cxx
+++ b/osprey/be/opt/opt_htable.cxx
@@ -3217,6 +3217,12 @@ CODEMAP::Add_expr(WN *wn, OPT_STAB *opt_stab, STMTREP *stmt, CANON_CR *ccr,
         (WN_operator(statement_wn) == OPR_STID ||
          WN_operator(statement_wn) == OPR_STBITS) ?
             WN_st_idx(statement_wn) : ST_IDX_ZERO;
+    if (stmt != NULL && stmt->Lhs() != NULL &&
+        stmt->Lhs()->Kind() == CK_VAR) {
+      ST *result = opt_stab->St(stmt->Lhs()->Aux_id());
+      if (result != NULL)
+        result_st = ST_st_idx(result);
+    }
     WOPT_DSL_SEMANTIC_INFO info;
     WOPT_DSL_SEMANTIC_INFO_ID info_id;
 

--- a/osprey/be/opt/opt_htable.cxx
+++ b/osprey/be/opt/opt_htable.cxx
@@ -114,8 +114,10 @@
 #include "opt_sys.h"
 
 #if defined(TARG_X8664) && defined(_LP64)
-typedef char WOPT_DSL_Coderep_Size_Check
+typedef char WOPT_X8664_Coderep_Size_Check
     [sizeof(CODEREP) == 88 ? 1 : -1];
+typedef char WOPT_X8664_Stmtrep_Size_Check
+    [sizeof(STMTREP) == 112 ? 1 : -1];
 #endif
 
 #ifdef BUILD_MASTIFF

--- a/osprey/be/opt/opt_htable.h
+++ b/osprey/be/opt/opt_htable.h
@@ -109,6 +109,7 @@
 
 #include "tracing.h"
 #include "id_map.h"
+#include "opt_dsl.h"
 #include "opt_ssa.h"
 
 #include <vector>
@@ -427,6 +428,7 @@ private:
       mINT32    _num_of_min_max:6;   // number of minmax, collectively
       mUINT8    max_depth;           // used in estimating rehash cost (SSAPRE)
       IDTYPE    _temp_id:24;         // processing this CR in new PRE step1
+      mUINT32   dsl_semantic_info_id; // runtime logical DSL identity
       void * node_cache;             // Hold CR or BB pointer for parents on new differnt paths       
       CODEREP  *kids[3];             // array of kid pointers
     } isop;
@@ -582,6 +584,7 @@ public:
       Set_dsctyp(OPCODE_desc(c));
       Set_kid_count(kcnt);
       Set_temp_id(0);
+      Set_dsl_semantic_info_id(0);
       Reset_isop_flags();
       Set_max_depth(0);
       Set_ISOP_mtype_b_cache(NULL);
@@ -1158,6 +1161,31 @@ public:
 				            ("CODEREP::Set_opr, illegal kind"));
 					(Kind() == CK_OP) ? u2.isop._opr = c :
 						u2.isivar._opr = c; }
+  mUINT32   Dsl_semantic_info_id(void) const
+                                      { Is_True(Kind() == CK_OP,
+                                          ("CODEREP::Dsl_semantic_info_id, "
+                                           "illegal kind"));
+                                        return u2.isop.dsl_semantic_info_id; }
+  void      Set_dsl_semantic_info_id(mUINT32 id)
+                                      { Is_True(Kind() == CK_OP,
+                                          ("CODEREP::Set_dsl_semantic_info_id, "
+                                           "illegal kind"));
+                                        u2.isop.dsl_semantic_info_id = id; }
+  BOOL      Is_dsl_op(void) const      { return Kind() == CK_OP &&
+                                        Dsl_semantic_info_id() != 0; }
+  BOOL      Dsl_semantic_info(WOPT_DSL_SEMANTIC_INFO *info) const
+                                      { return Is_dsl_op() &&
+                                        WOPT_DSL_Semantic_Info_Get
+                                            (Dsl_semantic_info_id(), info); }
+  DSL_OPERATOR Dsl_operator(void) const
+                                      { WOPT_DSL_SEMANTIC_INFO info;
+                                        return Dsl_semantic_info(&info) ?
+                                            info.logical_operator :
+                                            OPR_DSLUNKNOWN; }
+  OPERATOR  Native_opr(void) const     { Is_True(!Is_dsl_op(),
+                                          ("CODEREP::Native_opr called for "
+                                           "logical DSL operator"));
+                                        return Opr(); }
   mINT16    Kid_count(void) const     { Is_True(Kind() == CK_OP,
 				        ("CODEREP::Kid_count, illegal kind %s",
 					  Print_kind()));

--- a/osprey/be/opt/opt_main.cxx
+++ b/osprey/be/opt/opt_main.cxx
@@ -446,15 +446,20 @@ static void Terminate_opt_memory_pools(void)
 static void Manage_pu_level_memory(COMP_UNIT *comp_unit, MEM_POOL *pool)
 {
   if (comp_unit->Phase() == PREOPT_PHASE) {
-    CXX_DELETE(comp_unit, &Opt_preopt_pool);
+    Is_True(pool == &Opt_preopt_pool,
+            ("PREOPT COMP_UNIT is not owned by Opt_preopt_pool"));
+    CXX_DELETE(comp_unit, pool);
     OPT_POOL_Pop(&Opt_preopt_pool, MEM_DUMP_FLAG+1);
+    return;
   }
 
 #ifdef BUILD_MASTIFF
   if (IPSA_manager != NULL) return;
 #endif
 
-  CXX_DELETE(comp_unit, &Opt_global_pool);
+  Is_True(pool == &Opt_global_pool,
+          ("non-PREOPT COMP_UNIT is not owned by Opt_global_pool"));
+  CXX_DELETE(comp_unit, pool);
   Terminate_opt_memory_pools();
 }
 
@@ -2295,7 +2300,7 @@ Pre_Optimizer(OPT_PHASE phase, WN *wn_tree, DU_MANAGER *du_mgr,
 
     // free up optimizer's pools
     // NOTE that the rvi phase uses its own
-    Manage_pu_level_memory(comp_unit, &Opt_global_pool);
+    Manage_pu_level_memory(comp_unit, gpool);
 
   } /* if ( phase == MAINOPT_PHASE ) */
   else { 
@@ -2423,7 +2428,7 @@ Pre_Optimizer(OPT_PHASE phase, WN *wn_tree, DU_MANAGER *du_mgr,
     // Identify redudant mem clears that follow a calloc and remove them
     remove_redundant_mem_clears(opt_wn, alias_mgr, du_mgr);
 
-    Manage_pu_level_memory(comp_unit, &Opt_global_pool);
+    Manage_pu_level_memory(comp_unit, gpool);
 
     if (WN_opcode(opt_wn) == OPC_FUNC_ENTRY)
       Verify_SYMTAB (CURRENT_SYMTAB);

--- a/osprey/be/opt/opt_main.cxx
+++ b/osprey/be/opt/opt_main.cxx
@@ -1668,10 +1668,15 @@ Pre_Optimizer(OPT_PHASE phase, WN *wn_tree, DU_MANAGER *du_mgr,
 
   SET_OPT_PHASE("Preparation");
 
+#if defined(TARG_X8664) && defined(_LP64)
+  // Guard the measured x86-64 LP64 layout against inadvertent expansion.
+  Is_True(sizeof(CODEREP) == 88,
+    ("x86-64 LP64 CODEREP size changed (is now %lu, expected 88)!",
+     (unsigned long)sizeof(CODEREP)));
+#endif
+
 #ifdef SKIP
-  // check for inadvertent increase in size of data structures
-  Is_True(sizeof(CODEREP) == 48,
-    ("Size of CODEREP has been changed (is now %d)!",sizeof(CODEREP)));
+  // Historical STMTREP size checks remain disabled.
 #if defined(linux) || defined(BUILD_OS_DARWIN)
   Is_True(sizeof(STMTREP) == 60,
     ("Size of STMTREP has been changed (is now %d)!",sizeof(STMTREP)));

--- a/osprey/be/opt/opt_main.cxx
+++ b/osprey/be/opt/opt_main.cxx
@@ -344,6 +344,7 @@
 #include "opt_dbg.h"
 #include "opt_goto.h"
 #include "opt_rvi.h"
+#include "dsl_gatekeeper.h"
 #include "opt_util.h"
 #include "opt_alias_mgr.h"
 #include "opt_alias_interface.h"	/* for Verify_alias() */
@@ -1462,6 +1463,8 @@ Pre_Optimizer(OPT_PHASE phase, WN *wn_tree, DU_MANAGER *du_mgr,
   Is_True(WN_opcode(wn_orig)==OPC_FUNC_ENTRY || WN_opcode(wn_orig)==OPC_REGION,
 	  ("Pre_Optimizer, unknown WHIRL entry point"));
 
+  WOPT_DSL_Semantic_Info_Reset();
+
   // sets Opt_current_pu_st static
   Opt_set_current_pu_name(wn_tree);
 
@@ -2458,6 +2461,14 @@ Pre_Optimizer(OPT_PHASE phase, WN *wn_tree, DU_MANAGER *du_mgr,
 
   if (WN_opcode(opt_wn) == OPC_FUNC_ENTRY)
     Set_PU_Info_tree_ptr (Current_PU_Info, opt_wn);
+
+  if (WOPT_DSL_Semantic_Info_Count() != 0 &&
+      Current_PU_Info != NULL) {
+    DSL_GATEKEEPER_RESULT result;
+    FmtAssert(DSL_Gatekeeper_Verify_PU
+                  (Current_PU_Info, TFile, &result),
+              ("WOPT emitted invalid DSL WHIRL"));
+  }
 
   WN_CopyMap(opt_wn, WN_MAP_FEEDBACK, wn_orig);
 

--- a/osprey/be/opt/opt_main.cxx
+++ b/osprey/be/opt/opt_main.cxx
@@ -1669,21 +1669,13 @@ Pre_Optimizer(OPT_PHASE phase, WN *wn_tree, DU_MANAGER *du_mgr,
   SET_OPT_PHASE("Preparation");
 
 #if defined(TARG_X8664) && defined(_LP64)
-  // Guard the measured x86-64 LP64 layout against inadvertent expansion.
+  // Guard the measured x86-64 LP64 WOPT layouts against inadvertent expansion.
   Is_True(sizeof(CODEREP) == 88,
     ("x86-64 LP64 CODEREP size changed (is now %lu, expected 88)!",
      (unsigned long)sizeof(CODEREP)));
-#endif
-
-#ifdef SKIP
-  // Historical STMTREP size checks remain disabled.
-#if defined(linux) || defined(BUILD_OS_DARWIN)
-  Is_True(sizeof(STMTREP) == 60,
-    ("Size of STMTREP has been changed (is now %d)!",sizeof(STMTREP)));
-#else
-  Is_True(sizeof(STMTREP) == 64,
-    ("Size of STMTREP has been changed (is now %d)!",sizeof(STMTREP)));
-#endif
+  Is_True(sizeof(STMTREP) == 112,
+    ("x86-64 LP64 STMTREP size changed (is now %lu, expected 112)!",
+     (unsigned long)sizeof(STMTREP)));
 #endif
 
   // allocate space for cfg, htable, and itable

--- a/osprey/be/opt/opt_prop.cxx
+++ b/osprey/be/opt/opt_prop.cxx
@@ -430,6 +430,9 @@ COPYPROP::Propagatable(CODEREP *x, BOOL chk_inverse,
       return prop;
     }
   case CK_OP: {
+    if (x->Is_dsl_op())
+      return NOT_PROPAGATABLE;
+
     if (OPERATOR_is_volatile(x->Opr()))
       return NOT_PROPAGATABLE;
 
@@ -2449,4 +2452,3 @@ COMP_UNIT::Do_copy_propagate()
   Opt_tlog( "MAINPROP", 0, "%d copy propagations",
 	    Htable()->Num_mainprops() );
 }
-

--- a/osprey/be/opt/opt_prop.cxx
+++ b/osprey/be/opt/opt_prop.cxx
@@ -106,6 +106,76 @@
 #include "opt_vsa.h"
 #endif
 
+static OPERATOR
+WOPT_DSL_Projected_Operator(CODEREP *cr)
+{
+  if (cr == NULL || cr->Kind() != CK_OP)
+    return OPERATOR_UNKNOWN;
+  if (!cr->Is_dsl_op())
+    return cr->Opr();
+
+  WOPT_DSL_SEMANTIC_INFO info;
+  if (!cr->Dsl_semantic_info(&info))
+    return OPERATOR_UNKNOWN;
+  switch (info.logical_operator) {
+  case OPR_DSLADD:
+    return OPR_ADD;
+  case OPR_DSLMUL:
+    return OPR_MPY;
+  default:
+    return OPERATOR_UNKNOWN;
+  }
+}
+
+static BOOL
+WOPT_DSL_Pure_Projectable(CODEREP *cr,
+                          WOPT_DSL_SEMANTIC_INFO *info)
+{
+  return cr != NULL && cr->Is_dsl_op() &&
+         cr->Dsl_semantic_info(info) &&
+         (info->flags & (WOPT_DSL_SEMANTIC_PURE |
+                         WOPT_DSL_SEMANTIC_PROJECTABLE)) ==
+             (WOPT_DSL_SEMANTIC_PURE |
+              WOPT_DSL_SEMANTIC_PROJECTABLE) &&
+         info->effect_identity == DSL_EFFECT_MODEL_PURE;
+}
+
+static BOOL
+WOPT_DSL_Derive_Semantic_Info(
+    const WOPT_DSL_SEMANTIC_INFO *result_owner,
+    const WOPT_DSL_SEMANTIC_INFO *operator_semantics,
+    WOPT_DSL_SEMANTIC_INFO *derived)
+{
+  if (result_owner == NULL || operator_semantics == NULL ||
+      derived == NULL || result_owner->result_ty == TY_IDX_ZERO)
+    return FALSE;
+
+  *derived = *operator_semantics;
+  derived->id = WOPT_DSL_SEMANTIC_INFO_INVALID_ID;
+  derived->result_ty = result_owner->result_ty;
+  derived->origin_node_id = result_owner->origin_node_id;
+  derived->origin_result_value_id =
+      result_owner->origin_result_value_id;
+  derived->tensor_tcon_idx = TCON_IDX_ZERO;
+  return TRUE;
+}
+
+static BOOL
+WOPT_DSL_Unique_Result_Store(CODEMAP *htable, STMTREP *stmt)
+{
+  if (htable == NULL || stmt == NULL || stmt->Lhs() == NULL ||
+      stmt->Lhs()->Kind() != CK_VAR)
+    return FALSE;
+  ST *st = htable->Opt_stab()->St(stmt->Lhs()->Aux_id());
+  if (st == NULL || !ST_is_temp_var(*st))
+    return FALSE;
+  const char *no_alias =
+      ST_tensor_attribute
+          (ST_st_idx(*st),
+           TY_tensor_schema_key_name(TY_TENSOR_SCHEMA_NO_ALIAS));
+  return no_alias != NULL && strcmp(no_alias, "true") == 0;
+}
+
 // ====================================================================
 // Contains_only_constants - see if the expr contains only constants
 // ====================================================================
@@ -1695,6 +1765,194 @@ COPYPROP::Copy_propagate_cr(CODEREP *x, STMTREP* curstmt, BB_NODE *curbb,
   return NULL;
 }
 
+BOOL
+COPYPROP::Is_exp_cancellable(CODEREP *producer_rhs,
+                             CODEREP *consumer_rhs) const
+{
+  OPERATOR producer_opr = WOPT_DSL_Projected_Operator(producer_rhs);
+  OPERATOR consumer_opr = WOPT_DSL_Projected_Operator(consumer_rhs);
+  BOOL additive =
+      (producer_opr == OPR_ADD || producer_opr == OPR_SUB) &&
+      (consumer_opr == OPR_ADD || consumer_opr == OPR_SUB) &&
+      (producer_opr == OPR_SUB || consumer_opr == OPR_SUB);
+  BOOL multiplicative =
+      (producer_opr == OPR_MPY || producer_opr == OPR_DIV) &&
+      (consumer_opr == OPR_MPY || consumer_opr == OPR_DIV) &&
+      (producer_opr == OPR_DIV || consumer_opr == OPR_DIV);
+  return additive || multiplicative;
+}
+
+BOOL
+COPYPROP::Is_exp_factorable(CODEREP *producer_rhs,
+                            CODEREP *consumer_rhs,
+                            UINT32 consumer_kid) const
+{
+  WOPT_DSL_SEMANTIC_INFO producer_info;
+  WOPT_DSL_SEMANTIC_INFO consumer_info;
+  DSL_ALGEBRAIC_RELATION_INFO relation;
+
+  if (consumer_kid >= 2 ||
+      WOPT_DSL_Projected_Operator(producer_rhs) != OPR_MPY ||
+      (WOPT_DSL_Projected_Operator(consumer_rhs) != OPR_ADD &&
+       WOPT_DSL_Projected_Operator(consumer_rhs) != OPR_SUB) ||
+      !WOPT_DSL_Pure_Projectable(producer_rhs, &producer_info) ||
+      !WOPT_DSL_Pure_Projectable(consumer_rhs, &consumer_info) ||
+      producer_info.result_ty != consumer_info.result_ty ||
+      !TY_is_tensor_extension(producer_info.result_ty))
+    return FALSE;
+
+  TYPE_ID element_mtype =
+      TY_mtype(TY_tensor_element_ty(producer_info.result_ty));
+  BOOL floating_point = MTYPE_is_float(element_mtype);
+  return (MTYPE_is_integral(element_mtype) || floating_point) &&
+         DSL_Algebraic_Relation_Get
+             (consumer_info.logical_operator, consumer_info.version,
+              producer_info.logical_operator, producer_info.version,
+              DSL_ALGEBRAIC_RELATION_FACTOR, &relation) &&
+         relation.operand_mask != 0 &&
+         WOPT_DSL_Algebraic_Safety_Allows
+             (relation.safety, floating_point,
+              Enable_Cfold_Reassociate);
+}
+
+BOOL
+COPYPROP::Is_simplification_propagatable(
+    CODEREP *use, STMTREP *producer, STMTREP *consumer,
+    BOOL adjacent_only) const
+{
+  if (use == NULL || producer == NULL || consumer == NULL ||
+      use->Kind() != CK_VAR || use->Defstmt() != producer ||
+      use->Usecnt() != 1 || producer->Bb() != consumer->Bb() ||
+      producer->Rhs() == NULL || consumer->Rhs() == NULL ||
+      consumer->Rhs()->Kind() != CK_OP ||
+      (consumer->Rhs()->Get_opnd(0) != use &&
+       consumer->Rhs()->Get_opnd(1) != use))
+    return FALSE;
+
+  UINT32 distance = 0;
+  STMTREP *cursor = (STMTREP *)producer->Next();
+  while (cursor != NULL && cursor != consumer && distance < 8) {
+    WOPT_DSL_SEMANTIC_INFO info;
+    if (cursor->Black_box() ||
+        !OPERATOR_is_scalar_store(cursor->Opr()) ||
+        cursor->Rhs() == NULL ||
+        !WOPT_DSL_Pure_Projectable(cursor->Rhs(), &info) ||
+        !WOPT_DSL_Unique_Result_Store(Htable(), cursor))
+      return FALSE;
+    cursor = (STMTREP *)cursor->Next();
+    ++distance;
+  }
+  if (cursor != consumer || (adjacent_only && distance != 0))
+    return FALSE;
+  return TRUE;
+}
+
+BOOL
+COPYPROP::Try_dsl_factorization(STMTREP *stmt)
+{
+  static const UINT32 factor_mask[2][2] = {
+      { DSL_ALGEBRAIC_OPERAND_11, DSL_ALGEBRAIC_OPERAND_12 },
+      { DSL_ALGEBRAIC_OPERAND_21, DSL_ALGEBRAIC_OPERAND_22 }
+  };
+  CODEREP *outer = stmt == NULL ? NULL : stmt->Rhs();
+  if (outer == NULL || outer->Kind() != CK_OP ||
+      outer->Kid_count() != 2 ||
+      WOPT_DSL_Projected_Operator(outer) != OPR_ADD)
+    return FALSE;
+
+  CODEREP *use[2] = { outer->Get_opnd(0), outer->Get_opnd(1) };
+  if (use[0]->Kind() != CK_VAR || use[1]->Kind() != CK_VAR)
+    return FALSE;
+
+  STMTREP *producer[2] = { use[0]->Defstmt(), use[1]->Defstmt() };
+  CODEREP *product[2] = {
+      producer[0] == NULL ? NULL : producer[0]->Rhs(),
+      producer[1] == NULL ? NULL : producer[1]->Rhs()
+  };
+  if (!Is_exp_factorable(product[0], outer, 0) ||
+      !Is_exp_factorable(product[1], outer, 1) ||
+      !Is_simplification_propagatable
+          (use[0], producer[0], stmt, FALSE) ||
+      !Is_simplification_propagatable
+          (use[1], producer[1], stmt, FALSE))
+    return FALSE;
+
+  WOPT_DSL_SEMANTIC_INFO outer_info;
+  WOPT_DSL_SEMANTIC_INFO product_info[2];
+  DSL_ALGEBRAIC_RELATION_INFO relation;
+  if (!outer->Dsl_semantic_info(&outer_info) ||
+      !product[0]->Dsl_semantic_info(&product_info[0]) ||
+      !product[1]->Dsl_semantic_info(&product_info[1]) ||
+      product_info[0].result_ty != product_info[1].result_ty ||
+      product_info[0].result_ty != outer_info.result_ty ||
+      !DSL_Algebraic_Relation_Get
+          (outer_info.logical_operator, outer_info.version,
+           product_info[0].logical_operator, product_info[0].version,
+           DSL_ALGEBRAIC_RELATION_FACTOR, &relation))
+    return FALSE;
+
+  INT common0 = -1;
+  INT common1 = -1;
+  for (INT i = 0; i < 2 && common0 < 0; ++i) {
+    for (INT j = 0; j < 2; ++j) {
+      if ((relation.operand_mask & factor_mask[i][j]) != 0 &&
+          product[0]->Get_opnd(i) == product[1]->Get_opnd(j)) {
+        common0 = i;
+        common1 = j;
+        break;
+      }
+    }
+  }
+  if (common0 < 0)
+    return FALSE;
+
+  FOLD simplifier;
+  if (!simplifier.Prove_DSL_Factorization
+          (product[0], product[1], OPR_ADD, relation.safety))
+    return FALSE;
+
+  WOPT_DSL_SEMANTIC_INFO inner_info;
+  WOPT_DSL_SEMANTIC_INFO result_info;
+  if (!WOPT_DSL_Derive_Semantic_Info
+          (&product_info[0], &outer_info, &inner_info) ||
+      !WOPT_DSL_Derive_Semantic_Info
+          (&outer_info, &product_info[0], &result_info))
+    return FALSE;
+
+  WOPT_DSL_SEMANTIC_INFO_ID inner_id =
+      WOPT_DSL_Semantic_Info_Intern(&inner_info);
+  WOPT_DSL_SEMANTIC_INFO_ID result_id =
+      WOPT_DSL_Semantic_Info_Intern(&result_info);
+  if (inner_id == WOPT_DSL_SEMANTIC_INFO_INVALID_ID ||
+      result_id == WOPT_DSL_SEMANTIC_INFO_INVALID_ID)
+    return FALSE;
+
+  CODEREP *inner_view = Alloc_stack_cr(2);
+  inner_view->Init_op(OPC_MDSL, 2);
+  inner_view->Set_dsl_semantic_info_id(inner_id);
+  inner_view->Set_opnd(0, product[0]->Get_opnd(1 - common0));
+  inner_view->Set_opnd(1, product[1]->Get_opnd(1 - common1));
+  CODEREP *inner = Htable()->Hash_Op(inner_view, FALSE);
+
+  CODEREP *result_view = Alloc_stack_cr(2);
+  result_view->Init_op(OPC_MDSL, 2);
+  result_view->Set_dsl_semantic_info_id(result_id);
+  result_view->Set_opnd(0, product[0]->Get_opnd(common0));
+  result_view->Set_opnd(1, use[0]);
+  CODEREP *result = Htable()->Hash_Op(result_view, FALSE);
+
+  product[0]->DecUsecnt_rec();
+  producer[0]->Set_rhs(inner);
+  outer->DecUsecnt_rec();
+  stmt->Set_rhs(result);
+
+  if (Get_Trace(TP_GLOBOPT, PROP_DUMP_FLAG))
+    fprintf(TFile,
+            "DSL WOPT factorization: stmt %d reuses stmt %d result\n",
+            stmt->Stmtrep_id(), producer[0]->Stmtrep_id());
+  return TRUE;
+}
+
 // ====================================================================
 //  Determine if we should propagate into this statement
 // ====================================================================
@@ -1727,6 +1985,7 @@ COPYPROP::Copy_propagate_stmt(STMTREP *stmt, BB_NODE *bb)
 
   CODEREP* orig_rhs = stmt->Rhs();
   if (orig_rhs) {
+    Try_dsl_factorization(stmt);
     x = Copy_propagate_cr(stmt->Rhs(), stmt, bb, FALSE, FALSE/*in_array*/);
     if (x) {
       CODEREP *y = Htable()->Canon_rhs(x);

--- a/osprey/be/opt/opt_prop.h
+++ b/osprey/be/opt/opt_prop.h
@@ -119,6 +119,16 @@ private:
   INT32 Invertible_occurrences(CODEREP *var, CODEREP *cr);
   BOOL Is_function_of_itself(STMTREP *stmt, OPT_STAB *sym);
   BOOL Is_function_of_cur(CODEREP *var, CODEREP *cur_var);
+  BOOL Is_exp_cancellable(CODEREP *producer_rhs,
+                          CODEREP *consumer_rhs) const;
+  BOOL Is_exp_factorable(CODEREP *producer_rhs,
+                         CODEREP *consumer_rhs,
+                         UINT32 consumer_kid) const;
+  BOOL Is_simplification_propagatable(CODEREP *use,
+                                      STMTREP *producer,
+                                      STMTREP *consumer,
+                                      BOOL adjacent_only) const;
+  BOOL Try_dsl_factorization(STMTREP *stmt);
   CODEREP *Form_inverse(CODEREP *v, CODEREP *x, CODEREP *forming_x);
   CODEREP *Rehash_inverted_expr(CODEREP *x, BOOL icopy_phase);
   BB_NODE *Propagated_to_loop_branch(BB_NODE *srcbb, BB_NODE *destbb);

--- a/osprey/be/opt/tests/dsl_wopt_bridge_test.cxx
+++ b/osprey/be/opt/tests/dsl_wopt_bridge_test.cxx
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2026 Open64 Project
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "defs.h"
+#include "mempool.h"
+#include "wn.h"
+#include "stab.h"
+#include "pu_info.h"
+#include "ir_reader.h"
+#include "glob.h"
+#include "erglob.h"
+#include "errors.h"
+#include "err_host.tab"
+#include "config.h"
+#include "config_opt.h"
+#include "controls.h"
+#include "config_targ_opt.h"
+#include "dwarf_DST_mem.h"
+#include "dsl_builder.h"
+#include "dsl_gatekeeper.h"
+#include "dsl_ir_image.h"
+#include "opt_dsl.h"
+
+BOOL Run_vsaopt = FALSE;
+INT8 Debug_Level = 0;
+
+void
+Signal_Cleanup(INT sig)
+{
+}
+
+const char *
+Host_Format_Parm(INT kind, MEM_PTR parm)
+{
+  return "";
+}
+
+static void
+Initialize_Test_Context(void)
+{
+  MEM_Initialize();
+  Set_Error_Tables(Phases, host_errlist);
+  Init_Error_Handler(10);
+  Set_Error_File(NULL);
+  Set_Error_Line(ERROR_LINE_UNKNOWN);
+  Preconfigure();
+  Init_Controls_Tbl();
+  ABI_Name = "n64";
+  Configure();
+  IR_reader_init();
+  Initialize_Symbol_Tables(TRUE);
+  DST_Init(NULL, 0);
+}
+
+static TY_IDX
+Create_Tensor_Type(void)
+{
+  DSL_BUILDER_TENSOR_TYPE_CORE core;
+  DSL_BUILDER_TENSOR_DESCRIPTOR descriptor;
+  memset(&core, 0, sizeof(core));
+  memset(&descriptor, 0, sizeof(descriptor));
+  core.kind = "tensor";
+  core.dtype = "int32";
+  core.rank = 2;
+  core.logical_shape = "[2,2]";
+  descriptor.type_core = core;
+  descriptor.representation.layout = "row_major";
+  return DSL_Builder_Intern_Tensor_Type
+             ("wopt_tensor_i32_2x2", MTYPE_To_TY(MTYPE_I4), &descriptor);
+}
+
+int
+main(void)
+{
+  Initialize_Test_Context();
+  if (!DSL_Builder_Begin_Program()) {
+    fprintf(stderr, "failed to begin DSL builder program\n");
+    return 1;
+  }
+  DSL_BUILDER_PROGRAM_UNIT pu =
+      DSL_Builder_Create_Minimal_PU("dsl_wopt_bridge_test");
+  if (pu == NULL || !DSL_Builder_Select_PU(pu)) {
+    fprintf(stderr, "failed to create/select DSL builder PU\n");
+    return 1;
+  }
+  Current_PU_Info = pu;
+
+  TY_IDX ty = Create_Tensor_Type();
+  DSL_BUILDER_VALUE zero =
+      DSL_Builder_Create_Tensor_Constant
+          ("wopt_zero", ty, "int32", 2, "[2,2]", "splat", "0");
+  DSL_BUILDER_VALUE one =
+      DSL_Builder_Create_Tensor_Constant
+          ("wopt_one", ty, "int32", 2, "[2,2]", "splat", "1");
+  DSL_Opcode_Register_Common_Substrate();
+  DSL_DOMAIN_ID common = DSL_Domain_Find("common");
+  DSL_OPCODE_ID add_opcode =
+      DSL_Opcode_Find(common, DSL_OPCODE_COMMON_ADD, 1);
+  DSL_BUILDER_VALUE kids[2] = { zero, one };
+  DSL_BUILDER_OPERATOR_ATTRIBUTE attribute = {
+      "attr.broadcast_rule", "none"
+  };
+  Enable_WN_Simp = FALSE;
+  DSL_BUILDER_VALUE add =
+      DSL_Builder_Create_Operator_With_Result
+          (add_opcode, 1, kids, 2, &attribute, 1, "wopt_add", ty);
+  if (ty == TY_IDX_ZERO || zero == NULL || one == NULL || add == NULL ||
+      !DSL_Builder_Append_PU_Value(pu, zero) ||
+      !DSL_Builder_Append_PU_Value(pu, one) ||
+      !DSL_Builder_Append_PU_Value(pu, add)) {
+    fprintf(stderr,
+            "failed to create DSL values: ty=%u zero=%p one=%p add=%p "
+            "domain=%u opcode=%u\n",
+            (UINT32)ty, zero, one, add, common, add_opcode);
+    return 1;
+  }
+
+  const char *owner = ST_name(St_Table[PU_Info_proc_sym(pu)]);
+  WOPT_DSL_SEMANTIC_INFO zero_info;
+  WOPT_DSL_SEMANTIC_INFO one_info;
+  WOPT_DSL_SEMANTIC_INFO add_info;
+  if (!WOPT_DSL_Import_Semantic_Info
+          (WN_kid0(zero), DSL_Builder_Get_Value_Result_Symbol(zero),
+           owner, &zero_info, stderr) ||
+      !WOPT_DSL_Import_Semantic_Info
+          (WN_kid0(one), DSL_Builder_Get_Value_Result_Symbol(one),
+           owner, &one_info, stderr) ||
+      !WOPT_DSL_Import_Semantic_Info
+          (WN_kid0(add), DSL_Builder_Get_Value_Result_Symbol(add),
+           owner, &add_info, stderr))
+    return 1;
+
+  TCON_IDX operand_tcon[2] = {
+      zero_info.tensor_tcon_idx, one_info.tensor_tcon_idx
+  };
+  WOPT_DSL_SEMANTIC_INFO folded;
+  if (add_info.logical_operator != OPR_DSLADD ||
+      !WOPT_DSL_Fold_Compact_Tensors
+          (&add_info, operand_tcon, 2, &folded, stderr) ||
+      folded.logical_operator != OPR_DSLTENSORCONST ||
+      folded.tensor_tcon_idx == TCON_IDX_ZERO) {
+    fprintf(stderr, "WOPT DSL fold bridge failed\n");
+    return 1;
+  }
+
+  WN *emitted = WOPT_DSL_Emit_WN
+                    (&folded, WN_kid0(add),
+                     DSL_Builder_Get_Value_Result_Symbol(add),
+                     NULL, 0, stderr);
+  DSL_LOGICAL_OPCODE logical;
+  DSL_IR_NODE_RECORD node;
+  if (emitted == NULL || WN_operator(emitted) != OPR_DSL ||
+      WN_kid_count(emitted) != 0 ||
+      !DSL_WN_Get_Logical_Opcode(emitted, &logical, stderr) ||
+      logical.dsl_operator != OPR_DSLTENSORCONST ||
+      !DSL_IR_Image_Get_Node(add_info.origin_node_id, &node) ||
+      node.operand_count != 0) {
+    fprintf(stderr,
+            "WOPT DSL emission bridge failed: emitted=%p physical=%d "
+            "kids=%d logical=%d node=%u operands=%u\n",
+            emitted, emitted == NULL ? -1 : (INT)WN_operator(emitted),
+            emitted == NULL ? -1 : (INT)WN_kid_count(emitted),
+            (INT)logical.dsl_operator, add_info.origin_node_id,
+            node.operand_count);
+    return 1;
+  }
+
+  DSL_GATEKEEPER_RESULT gatekeeper;
+  WN_kid0(add) = emitted;
+  if (!DSL_Gatekeeper_Verify_PU(pu, stderr, &gatekeeper)) {
+    fprintf(stderr, "WOPT DSL emitted PU failed gatekeeper\n");
+    return 1;
+  }
+
+  printf("import.operator=%s.v%u\n",
+         DSL_OPERATOR_name(add_info.logical_operator), add_info.version);
+  printf("import.result_ty=%u attributes=%llx operands=%llx effect=%llu\n",
+         (UINT32)add_info.result_ty,
+         (unsigned long long)add_info.canonical_attribute_hash,
+         (unsigned long long)add_info.operand_descriptor_hash,
+         (unsigned long long)add_info.effect_identity);
+  printf("fold.operands=tcon[%u],tcon[%u]\n",
+         (UINT32)operand_tcon[0], (UINT32)operand_tcon[1]);
+  printf("fold.result=%s.v%u tcon[%u]\n",
+         DSL_OPERATOR_name(folded.logical_operator), folded.version,
+         (UINT32)folded.tensor_tcon_idx);
+  printf("emit.physical=private logical=%s.v%u kids=%u\n",
+         DSL_OPERATOR_name(logical.dsl_operator),
+         logical.effective_version, (UINT32)WN_kid_count(emitted));
+  printf("image.node=%u operands=%u\n",
+         add_info.origin_node_id, node.operand_count);
+  printf("gatekeeper.native_nodes=%u results=%u errors=%u\n",
+         gatekeeper.native_node_count, gatekeeper.result_symbol_count,
+         gatekeeper.error_count);
+  printf("WOPT DSL import/fold/emission bridge passed\n");
+  return 0;
+}

--- a/osprey/be/opt/tests/dsl_wopt_bridge_test.cxx
+++ b/osprey/be/opt/tests/dsl_wopt_bridge_test.cxx
@@ -89,7 +89,14 @@ main(int argc, char **argv)
   }
   Current_PU_Info = pu;
 
+  BOOL factor_fixture = argc > 2 && strcmp(argv[2], "factor") == 0;
+  BOOL no_factor_fixture =
+      argc > 2 && strcmp(argv[2], "no-factor") == 0;
+  BOOL algebra_fixture = factor_fixture || no_factor_fixture;
   TY_IDX ty = Create_Tensor_Type();
+  DSL_BUILDER_VALUE x = NULL;
+  DSL_BUILDER_VALUE y = NULL;
+  DSL_BUILDER_VALUE z = NULL;
   if (argc > 1) {
     DSL_BUILDER_SOURCE_POSITION position;
     memset(&position, 0, sizeof(position));
@@ -97,7 +104,13 @@ main(int argc, char **argv)
                            (pu, "dsl_wopt_bridge_test.cxx");
     position.line = 1;
     position.statement_begin = 1;
+    if (algebra_fixture && position.file_id != 0) {
+      x = DSL_Builder_Declare_PU_Formal(pu, "wopt_x", 0, ty, &position);
+      y = DSL_Builder_Declare_PU_Formal(pu, "wopt_y", 1, ty, &position);
+      z = DSL_Builder_Declare_PU_Formal(pu, "wopt_z", 2, ty, &position);
+    }
     if (position.file_id == 0 ||
+        (algebra_fixture && (x == NULL || y == NULL || z == NULL)) ||
         DSL_Builder_Declare_PU_Result
             (pu, "wopt_result", 0, ty, DSL_PU_RESULT_TENSOR,
              &position) == NULL) {
@@ -105,32 +118,62 @@ main(int argc, char **argv)
       return 1;
     }
   }
-  DSL_BUILDER_VALUE zero =
-      DSL_Builder_Create_Tensor_Constant
-          ("wopt_zero", ty, "int32", 2, "[2,2]", "splat", "0");
-  DSL_BUILDER_VALUE one =
-      DSL_Builder_Create_Tensor_Constant
-          ("wopt_one", ty, "int32", 2, "[2,2]", "splat", "1");
   DSL_Opcode_Register_Common_Substrate();
   DSL_DOMAIN_ID common = DSL_Domain_Find("common");
   DSL_OPCODE_ID add_opcode =
       DSL_Opcode_Find(common, DSL_OPCODE_COMMON_ADD, 1);
-  DSL_BUILDER_VALUE kids[2] = { zero, one };
+  DSL_OPCODE_ID mul_opcode =
+      DSL_Opcode_Find(common, DSL_OPCODE_COMMON_MUL, 1);
   DSL_BUILDER_OPERATOR_ATTRIBUTE attribute = {
       "attr.broadcast_rule", "none"
   };
   Enable_WN_Simp = FALSE;
-  DSL_BUILDER_VALUE add =
-      DSL_Builder_Create_Operator_With_Result
-          (add_opcode, 1, kids, 2, &attribute, 1, "wopt_add", ty);
-  if (ty == TY_IDX_ZERO || zero == NULL || one == NULL || add == NULL ||
-      !DSL_Builder_Append_PU_Value(pu, zero) ||
-      !DSL_Builder_Append_PU_Value(pu, one) ||
-      !DSL_Builder_Append_PU_Value(pu, add)) {
-    fprintf(stderr,
-            "failed to create DSL values: ty=%u zero=%p one=%p add=%p "
-            "domain=%u opcode=%u\n",
-            (UINT32)ty, zero, one, add, common, add_opcode);
+  DSL_BUILDER_VALUE zero = NULL;
+  DSL_BUILDER_VALUE one = NULL;
+  DSL_BUILDER_VALUE add = NULL;
+  if (algebra_fixture) {
+    DSL_BUILDER_VALUE xy_kids[2] = { x, y };
+    DSL_BUILDER_VALUE xz_kids[2] = {
+        no_factor_fixture ? z : x, z
+    };
+    DSL_BUILDER_VALUE xy =
+        DSL_Builder_Create_Operator_With_Result
+            (mul_opcode, 1, xy_kids, 2, &attribute, 1, "wopt_xy", ty);
+    DSL_BUILDER_VALUE xz =
+        DSL_Builder_Create_Operator_With_Result
+            (mul_opcode, 1, xz_kids, 2, &attribute, 1, "wopt_xz", ty);
+    DSL_BUILDER_VALUE factor_kids[2] = { xy, xz };
+    add = DSL_Builder_Create_Operator_With_Result
+              (add_opcode, 1, factor_kids, 2, &attribute, 1,
+               "wopt_factor", ty);
+    if (x == NULL || y == NULL || z == NULL || xy == NULL || xz == NULL ||
+        add == NULL || !DSL_Builder_Append_PU_Value(pu, xy) ||
+        !DSL_Builder_Append_PU_Value(pu, xz) ||
+        !DSL_Builder_Append_PU_Value(pu, add)) {
+      fprintf(stderr, "failed to create DSL factorization fixture\n");
+      return 1;
+    }
+  } else {
+    zero = DSL_Builder_Create_Tensor_Constant
+               ("wopt_zero", ty, "int32", 2, "[2,2]", "splat", "0");
+    one = DSL_Builder_Create_Tensor_Constant
+              ("wopt_one", ty, "int32", 2, "[2,2]", "splat", "1");
+    DSL_BUILDER_VALUE kids[2] = { zero, one };
+    add = DSL_Builder_Create_Operator_With_Result
+              (add_opcode, 1, kids, 2, &attribute, 1, "wopt_add", ty);
+    if (zero == NULL || one == NULL || add == NULL ||
+        !DSL_Builder_Append_PU_Value(pu, zero) ||
+        !DSL_Builder_Append_PU_Value(pu, one) ||
+        !DSL_Builder_Append_PU_Value(pu, add)) {
+      fprintf(stderr,
+              "failed to create DSL fold fixture: zero=%p one=%p add=%p\n",
+              zero, one, add);
+      return 1;
+    }
+  }
+  if (ty == TY_IDX_ZERO || add_opcode == DSL_OPCODE_INVALID_ID ||
+      mul_opcode == DSL_OPCODE_INVALID_ID) {
+    fprintf(stderr, "failed to register DSL WOPT operators\n");
     return 1;
   }
 
@@ -147,7 +190,10 @@ main(int argc, char **argv)
               request.path);
       return 1;
     }
-    printf("wrote unfused DSL WOPT input image: %s\n", request.path);
+    const char *fixture =
+        factor_fixture ? "factorization" :
+        no_factor_fixture ? "no-factor" : "fold";
+    printf("wrote DSL WOPT %s input image: %s\n", fixture, request.path);
     return 0;
   }
 

--- a/osprey/be/opt/tests/dsl_wopt_bridge_test.cxx
+++ b/osprey/be/opt/tests/dsl_wopt_bridge_test.cxx
@@ -74,7 +74,7 @@ Create_Tensor_Type(void)
 }
 
 int
-main(void)
+main(int argc, char **argv)
 {
   Initialize_Test_Context();
   if (!DSL_Builder_Begin_Program()) {
@@ -90,6 +90,21 @@ main(void)
   Current_PU_Info = pu;
 
   TY_IDX ty = Create_Tensor_Type();
+  if (argc > 1) {
+    DSL_BUILDER_SOURCE_POSITION position;
+    memset(&position, 0, sizeof(position));
+    position.file_id = DSL_Builder_Register_Source_File
+                           (pu, "dsl_wopt_bridge_test.cxx");
+    position.line = 1;
+    position.statement_begin = 1;
+    if (position.file_id == 0 ||
+        DSL_Builder_Declare_PU_Result
+            (pu, "wopt_result", 0, ty, DSL_PU_RESULT_TENSOR,
+             &position) == NULL) {
+      fprintf(stderr, "failed to declare DSL WOPT fixture result\n");
+      return 1;
+    }
+  }
   DSL_BUILDER_VALUE zero =
       DSL_Builder_Create_Tensor_Constant
           ("wopt_zero", ty, "int32", 2, "[2,2]", "splat", "0");
@@ -117,6 +132,23 @@ main(void)
             "domain=%u opcode=%u\n",
             (UINT32)ty, zero, one, add, common, add_opcode);
     return 1;
+  }
+
+  if (argc > 1) {
+    DSL_BUILDER_MAPPED_IMAGE_REQUEST request;
+    if (!DSL_Builder_Return_PU_Values(pu, &add, 1)) {
+      fprintf(stderr, "failed to return DSL WOPT fixture result\n");
+      return 1;
+    }
+    request.path = argv[1];
+    request.flags = 0;
+    if (!DSL_Builder_Finalize_Mapped_Image(&request)) {
+      fprintf(stderr, "failed to finalize DSL WOPT input image: %s\n",
+              request.path);
+      return 1;
+    }
+    printf("wrote unfused DSL WOPT input image: %s\n", request.path);
+    return 0;
   }
 
   const char *owner = ST_name(St_Table[PU_Info_proc_sym(pu)]);

--- a/osprey/be/opt/tests/dsl_wopt_driver_test.sh
+++ b/osprey/be/opt/tests/dsl_wopt_driver_test.sh
@@ -54,30 +54,46 @@ on_object="$artifact_dir/dsl_wopt_on.o"
 on_image="$artifact_dir/dsl_wopt_on.O"
 on_text="$artifact_dir/dsl_wopt_on.T"
 on_trace="$artifact_dir/dsl_wopt_on.trc"
+factor_input_image="$artifact_dir/dsl_wopt_factor_input.B"
+factor_input_text="$artifact_dir/dsl_wopt_factor_input.T"
+factor_on_object="$artifact_dir/.dsl_wopt_factor_on.tmp.o"
+factor_on_trace="$artifact_dir/dsl_wopt_factor_on.trc"
+factor_on_stderr="$artifact_dir/dsl_wopt_factor_on.stderr"
+factor_simp_off_object="$artifact_dir/.dsl_wopt_factor_simp_off.tmp.o"
+factor_simp_off_trace="$artifact_dir/dsl_wopt_factor_simp_off.trc"
+factor_simp_off_stderr="$artifact_dir/dsl_wopt_factor_simp_off.stderr"
+no_factor_input_image="$artifact_dir/dsl_wopt_no_factor_input.B"
+no_factor_input_text="$artifact_dir/dsl_wopt_no_factor_input.T"
+no_factor_on_object="$artifact_dir/.dsl_wopt_no_factor_on.tmp.o"
+no_factor_on_trace="$artifact_dir/dsl_wopt_no_factor_on.trc"
+no_factor_on_stderr="$artifact_dir/dsl_wopt_no_factor_on.stderr"
 
 "$producer" "$input_image"
 "$ir_b2a" -st -src "$input_image" "$input_text"
 
 run_backend()
 {
-  local enabled="$1"
-  local object="$2"
-  local trace="$3"
+  local input="$1"
+  local enabled="$2"
+  local object="$3"
+  local trace="$4"
+  local cr_simp="${5:-on}"
 
   LD_LIBRARY_PATH="$(dirname "$backend"):$wopt_dir:${LD_LIBRARY_PATH:-}" \
     "$backend" \
-      "-fB,$input_image" \
+      "-fB,$input" \
       "-fo,$object" \
       "-ft,$trace" \
       "-PHASE:w=on:c=off:wpath=$wopt_dir" \
       -O2 \
       "-DSL:wopt=$enabled" \
+      "-WOPT:cr_simp=$cr_simp" \
       -tr25 \
       "$source_file"
 }
 
-run_backend off "$off_object" "$off_trace"
-run_backend on "$on_object" "$on_trace"
+run_backend "$input_image" off "$off_object" "$off_trace"
+run_backend "$input_image" on "$on_object" "$on_trace"
 
 "$ir_b2a" -st -src "$off_image" "$off_text"
 "$ir_b2a" -st -src "$on_image" "$on_text"
@@ -96,6 +112,59 @@ if grep -Fq "OPR_DSLADD" "$on_trace"; then
   echo "enabled DSL WOPT did not fold common.add" >&2
   exit 1
 fi
+
+"$producer" "$factor_input_image" factor
+"$ir_b2a" -st -src "$factor_input_image" "$factor_input_text"
+if run_backend "$factor_input_image" on \
+     "$factor_on_object" "$factor_on_trace" 2>"$factor_on_stderr"; then
+  echo "factorization fixture unexpectedly passed marker-only lowering" >&2
+  exit 1
+fi
+rm -f "$factor_on_object" "${factor_on_object%.o}.O"
+
+require_text "$factor_input_text" \
+  "payload=kid0=wopt_xy;kid1=wopt_xz;attr.broadcast_rule=none"
+require_text "$factor_on_trace" \
+  "payload=kid0=wopt_y;kid1=wopt_z;attr.broadcast_rule=none"
+require_text "$factor_on_trace" \
+  "payload=kid0=wopt_x;kid1=wopt_xy;attr.broadcast_rule=none"
+require_text "$factor_on_stderr" \
+  "OPR_DSLMUL.v1 has no executable VHO lowering route"
+
+if run_backend "$factor_input_image" on \
+     "$factor_simp_off_object" "$factor_simp_off_trace" off \
+     2>"$factor_simp_off_stderr"; then
+  echo "simplifier-disabled fixture unexpectedly passed lowering" >&2
+  exit 1
+fi
+rm -f "$factor_simp_off_object" "${factor_simp_off_object%.o}.O"
+require_text "$factor_simp_off_trace" \
+  "payload=kid0=wopt_x;kid1=wopt_y;attr.broadcast_rule=none"
+require_text "$factor_simp_off_trace" \
+  "payload=kid0=wopt_x;kid1=wopt_z;attr.broadcast_rule=none"
+require_text "$factor_simp_off_trace" \
+  "payload=kid0=wopt_xy;kid1=wopt_xz;attr.broadcast_rule=none"
+require_text "$factor_simp_off_stderr" \
+  "OPR_DSLMUL.v1 has no executable VHO lowering route"
+
+"$producer" "$no_factor_input_image" no-factor
+"$ir_b2a" -st -src "$no_factor_input_image" "$no_factor_input_text"
+if run_backend "$no_factor_input_image" on \
+     "$no_factor_on_object" "$no_factor_on_trace" \
+     2>"$no_factor_on_stderr"; then
+  echo "no-factor fixture unexpectedly passed marker-only lowering" >&2
+  exit 1
+fi
+rm -f "$no_factor_on_object" "${no_factor_on_object%.o}.O"
+
+require_text "$no_factor_on_trace" \
+  "payload=kid0=wopt_x;kid1=wopt_y;attr.broadcast_rule=none"
+require_text "$no_factor_on_trace" \
+  "payload=kid0=wopt_z;kid1=wopt_z;attr.broadcast_rule=none"
+require_text "$no_factor_on_trace" \
+  "payload=kid0=wopt_xy;kid1=wopt_xz;attr.broadcast_rule=none"
+require_text "$no_factor_on_stderr" \
+  "OPR_DSLMUL.v1 has no executable VHO lowering route"
 
 echo "backend DSL WOPT option and phase-order fixture passed"
 echo "review artifacts: $artifact_dir"

--- a/osprey/be/opt/tests/dsl_wopt_driver_test.sh
+++ b/osprey/be/opt/tests/dsl_wopt_driver_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Exercise the backend DSL WOPT hook with the same mapped WHIRL image.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+build_root="${OPEN64_BUILD_ROOT:-$repo_root/build/osprey/targdir}"
+producer="${OPEN64_DSL_WOPT_PRODUCER:-$build_root/ir_tools/dsl_wopt_bridge_test}"
+ir_b2a="${OPEN64_IR_B2A:-$build_root/ir_tools/ir_b2a}"
+backend="${OPEN64_BE:-$build_root/be/be}"
+wopt_dir="${OPEN64_WOPT_DIR:-$build_root/wopt}"
+artifact_dir="${OPEN64_DSL_WOPT_ARTIFACT_DIR:-${TMPDIR:-/tmp}/open64-dsl-wopt-driver}"
+source_file="$repo_root/osprey/be/opt/tests/dsl_wopt_bridge_test.cxx"
+
+require_executable()
+{
+  if [[ ! -x "$1" ]]; then
+    echo "missing executable: $1" >&2
+    exit 1
+  fi
+}
+
+require_text()
+{
+  local file="$1"
+  local pattern="$2"
+
+  if ! grep -Fq "$pattern" "$file"; then
+    echo "missing DSL WOPT evidence '$pattern' in $file" >&2
+    exit 1
+  fi
+}
+
+require_executable "$producer"
+require_executable "$ir_b2a"
+require_executable "$backend"
+if [[ ! -f "$wopt_dir/wopt.so" ]]; then
+  echo "missing WOPT shared library: $wopt_dir/wopt.so" >&2
+  exit 1
+fi
+
+mkdir -p "$artifact_dir"
+find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -delete
+
+input_image="$artifact_dir/dsl_wopt_input.B"
+input_text="$artifact_dir/dsl_wopt_input.T"
+off_object="$artifact_dir/dsl_wopt_off.o"
+off_image="$artifact_dir/dsl_wopt_off.O"
+off_text="$artifact_dir/dsl_wopt_off.T"
+off_trace="$artifact_dir/dsl_wopt_off.trc"
+on_object="$artifact_dir/dsl_wopt_on.o"
+on_image="$artifact_dir/dsl_wopt_on.O"
+on_text="$artifact_dir/dsl_wopt_on.T"
+on_trace="$artifact_dir/dsl_wopt_on.trc"
+
+"$producer" "$input_image"
+"$ir_b2a" -st -src "$input_image" "$input_text"
+
+run_backend()
+{
+  local enabled="$1"
+  local object="$2"
+  local trace="$3"
+
+  LD_LIBRARY_PATH="$(dirname "$backend"):$wopt_dir:${LD_LIBRARY_PATH:-}" \
+    "$backend" \
+      "-fB,$input_image" \
+      "-fo,$object" \
+      "-ft,$trace" \
+      "-PHASE:w=on:c=off:wpath=$wopt_dir" \
+      -O2 \
+      "-DSL:wopt=$enabled" \
+      -tr25 \
+      "$source_file"
+}
+
+run_backend off "$off_object" "$off_trace"
+run_backend on "$on_object" "$on_trace"
+
+"$ir_b2a" -st -src "$off_image" "$off_text"
+"$ir_b2a" -st -src "$on_image" "$on_text"
+
+require_text "$input_text" "OPR_DSLADD"
+require_text "$off_trace" "__open64_dsl_add_v1"
+if grep -Fq "Driver dump after DSL_WOPT" "$off_trace"; then
+  echo "disabled DSL WOPT unexpectedly executed" >&2
+  exit 1
+fi
+require_text "$on_trace" "Driver dump after DSL_WOPT"
+require_text "$on_trace" "OPR_DSLTENSORCONST"
+require_text "$on_trace" "name=wopt_add"
+require_text "$on_trace" "value=1"
+if grep -Fq "OPR_DSLADD" "$on_trace"; then
+  echo "enabled DSL WOPT did not fold common.add" >&2
+  exit 1
+fi
+
+echo "backend DSL WOPT option and phase-order fixture passed"
+echo "review artifacts: $artifact_dir"

--- a/osprey/be/opt/tests/dsl_wopt_semantic_info_test.cxx
+++ b/osprey/be/opt/tests/dsl_wopt_semantic_info_test.cxx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Open64 Project
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "opt_dsl.h"
+
+int
+main(void)
+{
+  WOPT_DSL_SEMANTIC_INFO add;
+  WOPT_DSL_SEMANTIC_INFO other;
+  WOPT_DSL_SEMANTIC_INFO fetched;
+
+  WOPT_DSL_Semantic_Info_Reset();
+  memset(&add, 0, sizeof(add));
+  add.logical_operator = OPR_DSLADD;
+  add.version = 1;
+  add.flags = WOPT_DSL_SEMANTIC_PURE |
+              WOPT_DSL_SEMANTIC_PROJECTABLE;
+  add.result_ty = 17;
+  add.canonical_attribute_hash = 0x1234;
+  add.operand_descriptor_hash = 0x5678;
+
+  WOPT_DSL_SEMANTIC_INFO_ID add_id =
+      WOPT_DSL_Semantic_Info_Intern(&add);
+  if (add_id == WOPT_DSL_SEMANTIC_INFO_INVALID_ID ||
+      WOPT_DSL_Semantic_Info_Intern(&add) != add_id ||
+      WOPT_DSL_Semantic_Info_Count() != 1 ||
+      WOPT_DSL_Semantic_Info_Hash(add_id) == 0 ||
+      !WOPT_DSL_Semantic_Info_Get(add_id, &fetched) ||
+      fetched.logical_operator != OPR_DSLADD ||
+      fetched.result_ty != add.result_ty) {
+    fprintf(stderr, "WOPT DSL semantic interning contract failed\n");
+    return 1;
+  }
+
+  other = add;
+  other.logical_operator = OPR_DSLMUL;
+  WOPT_DSL_SEMANTIC_INFO_ID other_id =
+      WOPT_DSL_Semantic_Info_Intern(&other);
+  if (other_id == add_id || WOPT_DSL_Semantic_Info_Count() != 2 ||
+      WOPT_DSL_Semantic_Info_Hash(other_id) ==
+          WOPT_DSL_Semantic_Info_Hash(add_id)) {
+    fprintf(stderr, "logical DSL operators collapsed in WOPT identity\n");
+    return 1;
+  }
+
+  other = add;
+  ++other.version;
+  if (WOPT_DSL_Semantic_Info_Intern(&other) == add_id) {
+    fprintf(stderr, "DSL operator versions collapsed in WOPT identity\n");
+    return 1;
+  }
+
+  other = add;
+  ++other.canonical_attribute_hash;
+  if (WOPT_DSL_Semantic_Info_Intern(&other) == add_id) {
+    fprintf(stderr, "DSL opcode attributes collapsed in WOPT identity\n");
+    return 1;
+  }
+
+  other = add;
+  ++other.result_ty;
+  if (WOPT_DSL_Semantic_Info_Intern(&other) == add_id) {
+    fprintf(stderr, "tensor descriptor identities collapsed in WOPT identity\n");
+    return 1;
+  }
+
+  printf("WOPT DSL semantic-info contract passed\n");
+  return 0;
+}

--- a/osprey/be/opt/tests/dsl_wopt_semantic_info_test.cxx
+++ b/osprey/be/opt/tests/dsl_wopt_semantic_info_test.cxx
@@ -69,6 +69,21 @@ main(void)
     return 1;
   }
 
+  other = add;
+  other.tensor_tcon_idx = 41;
+  if (WOPT_DSL_Semantic_Info_Intern(&other) == add_id) {
+    fprintf(stderr, "tensor constant identities collapsed in WOPT identity\n");
+    return 1;
+  }
+
+  other = add;
+  other.origin_node_id = 73;
+  other.origin_result_value_id = 91;
+  if (WOPT_DSL_Semantic_Info_Intern(&other) != add_id) {
+    fprintf(stderr, "DSL reconstruction provenance inhibited value numbering\n");
+    return 1;
+  }
+
   printf("WOPT DSL semantic-info contract passed\n");
   return 0;
 }

--- a/osprey/be/opt/tests/dsl_wopt_semantic_info_test.cxx
+++ b/osprey/be/opt/tests/dsl_wopt_semantic_info_test.cxx
@@ -84,6 +84,20 @@ main(void)
     return 1;
   }
 
+  if (!WOPT_DSL_Algebraic_Safety_Allows
+          (DSL_ALGEBRAIC_SAFETY_INTEGER, FALSE, FALSE) ||
+      WOPT_DSL_Algebraic_Safety_Allows
+          (DSL_ALGEBRAIC_SAFETY_INTEGER, TRUE, TRUE) ||
+      WOPT_DSL_Algebraic_Safety_Allows
+          (DSL_ALGEBRAIC_SAFETY_INTEGER_OR_FP_REASSOCIATE,
+           TRUE, FALSE) ||
+      !WOPT_DSL_Algebraic_Safety_Allows
+          (DSL_ALGEBRAIC_SAFETY_INTEGER_OR_FP_REASSOCIATE,
+           TRUE, TRUE)) {
+    fprintf(stderr, "DSL strict-FP algebraic safety contract failed\n");
+    return 1;
+  }
+
   printf("WOPT DSL semantic-info contract passed\n");
   return 0;
 }

--- a/osprey/be/opt/tests/dsl_wopt_semantic_info_test.sh
+++ b/osprey/be/opt/tests/dsl_wopt_semantic_info_test.sh
@@ -14,7 +14,7 @@ cxx="${CXX:-g++}"
   -I"$repo_root/osprey/common/util" \
   -I"$repo_root/osprey/linux/include" \
   -I"$repo_root/osprey/be/opt" \
-  "$repo_root/osprey/be/opt/opt_dsl.cxx" \
+  "$repo_root/osprey/be/opt/opt_dsl_semantic.cxx" \
   "$repo_root/osprey/be/opt/tests/dsl_wopt_semantic_info_test.cxx" \
   -o "$tmp_dir/dsl_wopt_semantic_info_test"
 

--- a/osprey/be/opt/tests/dsl_wopt_semantic_info_test.sh
+++ b/osprey/be/opt/tests/dsl_wopt_semantic_info_test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+tmp_dir="${TMPDIR:-/tmp}/open64-dsl-wopt-semantic-$$"
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir"
+
+cxx="${CXX:-g++}"
+"$cxx" -std=gnu++98 \
+  -I"$repo_root/osprey/common/com" \
+  -I"$repo_root/osprey/common/util" \
+  -I"$repo_root/osprey/linux/include" \
+  -I"$repo_root/osprey/be/opt" \
+  "$repo_root/osprey/be/opt/opt_dsl.cxx" \
+  "$repo_root/osprey/be/opt/tests/dsl_wopt_semantic_info_test.cxx" \
+  -o "$tmp_dir/dsl_wopt_semantic_info_test"
+
+"$tmp_dir/dsl_wopt_semantic_info_test"

--- a/osprey/common/com/config_dsl.cxx
+++ b/osprey/common/com/config_dsl.cxx
@@ -7,6 +7,8 @@
 
 #include "config_dsl.h"
 
+BOOL VHO_DSL_Enable_WOPT = FALSE;
+BOOL VHO_DSL_Enable_WOPT_Set = FALSE;
 BOOL VHO_DSL_Enable_Canonicalization = FALSE;
 BOOL VHO_DSL_Enable_Canonicalization_Set = FALSE;
 BOOL VHO_DSL_Enable_Descriptor_Propagation = FALSE;
@@ -33,6 +35,9 @@ BOOL VHO_DSL_Dump_After_Lowering = FALSE;
 BOOL VHO_DSL_Dump_After_Lowering_Set = FALSE;
 
 static OPTION_DESC Options_DSL[] = {
+  { OVK_BOOL, OV_VISIBLE, TRUE, "wopt", "wopt",
+    FALSE, 0, 0, &VHO_DSL_Enable_WOPT,
+    &VHO_DSL_Enable_WOPT_Set },
   { OVK_BOOL, OV_VISIBLE, TRUE, "canon", "canon",
     FALSE, 0, 0, &VHO_DSL_Enable_Canonicalization,
     &VHO_DSL_Enable_Canonicalization_Set },

--- a/osprey/common/com/config_dsl.h
+++ b/osprey/common/com/config_dsl.h
@@ -5,6 +5,8 @@
 #ifndef config_dsl_INCLUDED
 #define config_dsl_INCLUDED
 
+extern BOOL VHO_DSL_Enable_WOPT;
+extern BOOL VHO_DSL_Enable_WOPT_Set;
 extern BOOL VHO_DSL_Enable_Canonicalization;
 extern BOOL VHO_DSL_Enable_Canonicalization_Set;
 extern BOOL VHO_DSL_Enable_Descriptor_Propagation;

--- a/osprey/common/com/tests/dsl_native_syntax_test.sh
+++ b/osprey/common/com/tests/dsl_native_syntax_test.sh
@@ -42,6 +42,8 @@ cxxflags=(
 
 sources=(
   "osprey/be/opt/opt_dsl.cxx"
+  "osprey/be/opt/opt_dsl_semantic.cxx"
+  "osprey/be/opt/tests/dsl_wopt_bridge_test.cxx"
   "osprey/be/opt/tests/dsl_wopt_semantic_info_test.cxx"
   "osprey/be/vho/dsl_lower.cxx"
   "osprey/be/vho/dsl_opt.cxx"

--- a/osprey/common/com/tests/dsl_native_syntax_test.sh
+++ b/osprey/common/com/tests/dsl_native_syntax_test.sh
@@ -30,6 +30,7 @@ cxxflags=(
   -I"$python_include"
   -I"$repo_root/osprey/linux/include"
   -I"$repo_root/osprey/ir_tools"
+  -I"$repo_root/osprey/be/opt"
   -I"$repo_root/osprey/be/vho"
   -I"$repo_root/osprey/common/com"
   -I"$repo_root/osprey/common/com/x8664"
@@ -40,6 +41,8 @@ cxxflags=(
 )
 
 sources=(
+  "osprey/be/opt/opt_dsl.cxx"
+  "osprey/be/opt/tests/dsl_wopt_semantic_info_test.cxx"
   "osprey/be/vho/dsl_lower.cxx"
   "osprey/be/vho/dsl_opt.cxx"
   "osprey/be/vho/tests/dsl_lower_contract_test.cxx"
@@ -76,5 +79,6 @@ done
 "$script_dir/dsl_canonicalization_contract_test.sh"
 "$script_dir/dsl_tensor_fold_contract_test.sh"
 "$script_dir/dsl_operator_layout_test.sh"
+bash "$repo_root/osprey/be/opt/tests/dsl_wopt_semantic_info_test.sh"
 
 echo "DSL native syntax fixture passed"

--- a/osprey/ir_tools/Makefile.gbase
+++ b/osprey/ir_tools/Makefile.gbase
@@ -157,6 +157,8 @@ BE_OPT_DIR= $(BUILD_TOT)/be/opt
 LDIRT = $(TARGETS)
 LDIRT += dsl_builder_contract_test dsl_builder_contract_test.o
 LDIRT += dsl_lower_contract_test dsl_lower_contract_test.o
+LDIRT += dsl_wopt_bridge_test dsl_wopt_bridge_test.o
+LDIRT += opt_dsl_wopt_test.o opt_dsl_semantic_wopt_test.o
 
 LCINCS = -I$(BUILD_BASE) -I$(COMMON_COM_DIR) -I$(COMMON_COM_TARG_DIR) \
 	-I$(COMMON_UTIL_DIR) -I$(BE_COM_DIR) -I$(BE_VHO_DIR) -I$(BE_OPT_DIR) $(XINC)  \
@@ -300,6 +302,21 @@ dsl_lower_contract_test: $(OBJECTS) controls.o dsl_lower.o \
 
 dsl_lower_contract_test.o: \
 	$(BE_VHO_DIR)/tests/dsl_lower_contract_test.cxx
+	$(cxx) -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+dsl_wopt_bridge_test: $(OBJECTS) controls.o dsl_wopt_bridge_test.o \
+		opt_dsl_wopt_test.o opt_dsl_semantic_wopt_test.o
+	$(link.c++f) -o $@ dsl_wopt_bridge_test.o opt_dsl_wopt_test.o \
+		opt_dsl_semantic_wopt_test.o controls.o $(OBJECTS) $(LDFLAGS)
+
+dsl_wopt_bridge_test.o: \
+	$(BE_OPT_DIR)/tests/dsl_wopt_bridge_test.cxx
+	$(cxx) -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+opt_dsl_wopt_test.o: $(BE_OPT_DIR)/opt_dsl.cxx
+	$(cxx) -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+
+opt_dsl_semantic_wopt_test.o: $(BE_OPT_DIR)/opt_dsl_semantic.cxx
 	$(cxx) -c $(CPPFLAGS) $(CXXFLAGS) $< -o $@
 
 uwasm_nwrap: $(OBJECTS) uwasm_nwrap.o


### PR DESCRIPTION
## Summary

Completes the M5 vertical slice for admitting logical DSL WHIRL expressions into WOPT while preserving the physical OPR_DSL escape abstraction and existing CODEREP layout.

- carries logical DSL operator, version, attributes, tensor descriptor identity, effects, and compact tensor constants through CODEREP
- imports and emits DSL expressions through the public logical APIs and repairs mapped-image records
- runs the optional DSL WOPT pass before final DSL lowering with `-DSL:wopt=on|off`
- reuses the traditional `wn_simp_code.h` CODEREP simplifier for tensor factorization proof
- implements bounded same-BB factorization for pure, single-use, unique-ownership integer tensor results
- preserves strict floating-point expressions unless Open64 reassociation is explicitly enabled
- recovers DSL result symbols through authoritative STMTREP/OPT_STAB state during import and emission

## Behavior

The initial opportunity-forming rewrite is:

```text
t0 = common.mul(x, y)
t1 = common.mul(x, z)
r  = common.add(t0, t1)

=>

t0 = common.add(y, z)
r  = common.mul(x, t0)
```

The rewrite requires matching TensorDescriptorIR identity, a registered factor relation, pure operators, unique no-alias result stores, one basic block, and single-use producer values. General DSL copy propagation remains disabled.

Strict FP is a non-error legality decision. `WOPT_DSL_Algebraic_Safety_Allows()` declines the rewrite before entering the simplifier when reassociation is disabled.

## Compatibility

- no CODEREP size increase on x86-64
- no binary WHIRL layout or opcode encoding change
- physical OPR_DSL remains private in logical dumps and diagnostics
- native DSL result STIDs and mapped-image value relationships remain intact
- unsupported or marker-only lowering remains rejected at the established gate

## Validation

- Linux/amd64 WOPT build and link
- `dsl_wopt_semantic_info_test.sh`
- `dsl_builder_simplifier_control_test.sh`
- native `dsl_wopt_bridge_test` import/fold/emission/gatekeeper contract
- backend `-DSL:wopt=on|off` A/B artifacts
- `-WOPT:cr_simp=off` preservation
- positive integer factorization
- no-common-factor rejection
- strict-FP and reassociation-enabled semantic-policy test
- `ir_b2a -st -src` retained artifact generation
- `git diff --check`, shell syntax, and no-tab checks

## Deferred

Native `common.sub` cancellation, MPY/DIV cancellation, broad CSE/PRE admission, and projectable tensor DIVREM remain staged for later milestones.