### PR TITLE
Enforce FHE entry value PU ownership

### DIFF
--- a/doc/FHE-CONSOLIDATED-IMPLEMENTATION-PLAN.md
+++ b/doc/FHE-CONSOLIDATED-IMPLEMENTATION-PLAN.md
@@ -219,6 +219,15 @@ Status: active.  The merged SYNC-1 opaque APIs are available.  The FHE task
 owns ResNet-20 capture and artifact production while the main task audits the
 shared operator, type, source-position, side-file, and printer evidence.
 
+The first full trace exposed a PU-scope correctness gap in shared
+infrastructure: FHE entry values carried valid PU-relative `ST_IDX` values,
+but the global FHE printer resolved them through the last selected local symbol
+table.  SYNC-2 therefore remains active while common/com enforces the existing
+managed `owner_pu` relation during insertion and mapped-image validation and
+prints stable stored value identity.  The frontend concurrently assigns source
+positions to external and implicit parameter symbols.  Neither correction
+changes the FHE image layout or operator contracts.
+
 Main-side readiness at SYNC-2 entry:
 
 | Capture requirement | Merged infrastructure evidence | Ownership now |

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1666,6 +1666,26 @@ full-sequence causal prompt evaluation with no KV cache.
    definitions when a REGION result feeds a later expression.  No frontend
    lowering workaround or FHE image change is part of this repair.
 
+33. [ ] Certify FHE SYNC-2 entry-value ownership and artifact evidence.
+
+   FHE entry contracts are owned by a global PU symbol, while their DSL values
+   commonly reference PU-relative local `ST_IDX` values.  Insertion and mapped
+   image validation must confirm that every entry value's existing
+   `owner_pu=<name>` metadata agrees with the entry contract owner.  Reject a
+   value from another PU even when its numeric local `ST_IDX` matches.
+
+   Global FHE table printing must use the value record's stored name and the
+   entry contract's PU identity.  It must not dereference a PU-relative symbol
+   through whichever local symbol table happens to be selected when `ir_b2a`
+   prints the tables.  Source and constant detail remain available in their
+   owning PU's standard symbol/value evidence.  This correction changes no
+   mapped-image row, record size, opcode, version, or ELF section contract.
+
+   Close this item only after the ResNet-20 frontend assigns source positions
+   to source-derived external and implicit parameter symbols, regenerates the
+   artifact family, and the main task reviews `secure_resnet20.T`.  Evidence
+   must distinguish reusable ReLU node definitions from source-context uses.
+
 ### Deferred work TODO
 
 Deferred work remains tracked but does not block the active native DSL bring-up

--- a/osprey/common/com/dsl_fhe.cxx
+++ b/osprey/common/com/dsl_fhe.cxx
@@ -111,6 +111,23 @@ DSL_FHE_PU_ST_Valid (ST_IDX st)
 }
 
 static BOOL
+DSL_FHE_Value_Belongs_To_PU
+        (const DSL_IR_VALUE_RECORD &value, ST_IDX owner_pu_st)
+{
+    DSL_IR_VALUE_RECORD owned_value;
+    const char *owner_pu_name;
+
+    if (!DSL_FHE_PU_ST_Valid(owner_pu_st) ||
+        value.name == STR_IDX_ZERO)
+        return FALSE;
+    owner_pu_name = ST_name(St_Table[owner_pu_st]);
+    return DSL_IR_Image_Find_PU_Value
+               (value.st, Index_To_Str(value.name), owner_pu_name,
+                &owned_value) &&
+           owned_value.id == value.id;
+}
+
+static BOOL
 DSL_FHE_Config_Valid (const DSL_FHE_COMPILATION_CONFIG_RECORD &record)
 {
     return record.scheme == DSL_FHE_SCHEME_CKKS &&
@@ -224,10 +241,16 @@ DSL_FHE_View_Validate (const DSL_FHE_IMAGE_VIEW *view, FILE *diagnostic)
     for (UINT32 i = 0; i < header.entry_value_count; ++i) {
         const DSL_FHE_ENTRY_VALUE_RECORD &record = view->entry_values[i];
         DSL_IR_VALUE_RECORD value;
+        const DSL_FHE_ENTRY_CONTRACT_RECORD *entry =
+            record.entry_contract_id == 0 ||
+            record.entry_contract_id > header.entry_contract_count ? NULL :
+            &view->entry_contracts[record.entry_contract_id - 1];
         if (record.id != i + 1 || record.entry_contract_id == 0 ||
             record.entry_contract_id > header.entry_contract_count ||
             record.value_id == 0 ||
             !DSL_IR_Image_Get_Value(record.value_id, &value) ||
+            entry == NULL ||
+            !DSL_FHE_Value_Belongs_To_PU(value, entry->owner_pu_st) ||
             record.role < DSL_FHE_ENTRY_VALUE_INPUT ||
             record.role > DSL_FHE_ENTRY_VALUE_PARAMETER ||
             record.value_class < DSL_FHE_VALUE_CLASS_CIPHERTEXT ||
@@ -619,10 +642,16 @@ DSL_FHE_ENTRY_VALUE_ID
 DSL_FHE_Add_Entry_Value (const DSL_FHE_ENTRY_VALUE_RECORD *record)
 {
     DSL_IR_VALUE_RECORD value;
+    const DSL_FHE_ENTRY_CONTRACT_RECORD *entry =
+        record == NULL || record->entry_contract_id == 0 ||
+        record->entry_contract_id > DSL_fhe_entry_contract_table.Size() ?
+        NULL : &DSL_fhe_entry_contract_table[record->entry_contract_id - 1];
     if (record == NULL || record->entry_contract_id == 0 ||
         record->entry_contract_id > DSL_fhe_entry_contract_table.Size() ||
         record->value_id == 0 ||
         !DSL_IR_Image_Get_Value(record->value_id, &value) ||
+        entry == NULL ||
+        !DSL_FHE_Value_Belongs_To_PU(value, entry->owner_pu_st) ||
         record->role < DSL_FHE_ENTRY_VALUE_INPUT ||
         record->role > DSL_FHE_ENTRY_VALUE_PARAMETER ||
         record->value_class < DSL_FHE_VALUE_CLASS_CIPHERTEXT ||

--- a/osprey/common/com/dsl_fhe_print.cxx
+++ b/osprey/common/com/dsl_fhe_print.cxx
@@ -3,8 +3,6 @@
  */
 
 #include "dsl_fhe.h"
-#include "dsl_tensor_fold.h"
-#include "ir_reader.h"
 #include "strtab.h"
 #include "symtab.h"
 
@@ -67,34 +65,20 @@ DSL_FHE_Key_Class_Name (UINT32 value)
 }
 
 static void
-DSL_FHE_Print_Value_Symbol (FILE *file, const DSL_IR_VALUE_RECORD &value)
+DSL_FHE_Print_Value_Symbol
+        (FILE *file, const DSL_IR_VALUE_RECORD &value,
+         const char *owner_pu_name)
 {
     fprintf(file, " value=value%u", value.id);
     if (value.name != STR_IDX_ZERO)
         fprintf(file, " name=%s", Index_To_Str(value.name));
-    if (ST_IDX_index(value.st) == 0 ||
-        ST_IDX_level(value.st) > CURRENT_SYMTAB ||
-        Scope_tab[ST_IDX_level(value.st)].st_tab == NULL ||
-        ST_IDX_index(value.st) >= ST_Table_Size(ST_IDX_level(value.st)))
-        return;
-    ST &st = St_Table[value.st];
-    fprintf(file, " st=<%u,%u,%s>", ST_IDX_level(value.st),
-            ST_IDX_index(value.st), ST_name(st));
-    SRCPOS source_position = ST_Srcpos(st);
-    if (SRCPOS_linenum(source_position) != 0) {
-        const char *file_name = NULL;
-        const char *directory_name = NULL;
-        IR_Srcpos_Filename(source_position, &file_name, &directory_name);
-        if (file_name != NULL)
-            fprintf(file, " source=%s:%u", file_name,
-                    SRCPOS_linenum(source_position));
-        else
-            fprintf(file, " source_line=%u", SRCPOS_linenum(source_position));
-    }
-    if (ST_class(st) == CLASS_CONST) {
-        fputs(" ", file);
-        DSL_Tensor_TCON_Print(file, ST_tcon(st));
-    }
+    if (ST_IDX_index(value.st) != 0)
+        fprintf(file, " st=<%u,%u,%s>", ST_IDX_level(value.st),
+                ST_IDX_index(value.st),
+                value.name == STR_IDX_ZERO ? "" :
+                    Index_To_Str(value.name));
+    if (owner_pu_name != NULL)
+        fprintf(file, " owner_pu=%s", owner_pu_name);
 }
 
 void
@@ -139,14 +123,18 @@ DSL_FHE_Image_Print (FILE *file)
     for (UINT32 i = 1; i <= header.entry_value_count; ++i) {
         DSL_FHE_ENTRY_VALUE_RECORD record;
         DSL_IR_VALUE_RECORD value;
+        DSL_FHE_ENTRY_CONTRACT_RECORD entry;
+        const char *owner_pu_name;
         DSL_FHE_Get_Entry_Value(i, &record);
         DSL_IR_Image_Get_Value(record.value_id, &value);
+        DSL_FHE_Get_Entry_Contract(record.entry_contract_id, &entry);
+        owner_pu_name = ST_name(St_Table[entry.owner_pu_st]);
         fprintf(file, "  [%u] entry=%u role=%s ordinal=%u class=%s "
                 "encryption=%u", record.id, record.entry_contract_id,
                 DSL_FHE_Entry_Role_Name(record.role), record.ordinal,
                 DSL_FHE_Value_Class_Name(record.value_class),
                 record.encryption_descriptor_id);
-        DSL_FHE_Print_Value_Symbol(file, value);
+        DSL_FHE_Print_Value_Symbol(file, value, owner_pu_name);
         fprintf(file, " flags=0x%x\n", record.flags);
     }
 

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -4396,7 +4396,9 @@ Check_FHE_SYNC1_Mapped_Image(void)
     DSL_BUILDER_SOURCE_POSITION source_position;
     DSL_BUILDER_MAPPED_IMAGE_REQUEST request;
     DSL_BUILDER_PROGRAM_UNIT pu;
+    DSL_BUILDER_PROGRAM_UNIT foreign_pu;
     DSL_BUILDER_VALUE input;
+    DSL_BUILDER_VALUE foreign_input;
     DSL_BUILDER_VALUE weight;
     DSL_BUILDER_VALUE result;
     DSL_BUILDER_VALUE kids[2];
@@ -4418,6 +4420,7 @@ Check_FHE_SYNC1_Mapped_Image(void)
     DSL_FHE_ENCRYPTION_DESCRIPTOR_ID ciphertext_id;
     DSL_FHE_ENCRYPTION_DESCRIPTOR_ID plaintext_id;
     DSL_FHE_ENTRY_CONTRACT_ID entry_id;
+    BOOL foreign_value_rejected;
     const char checksum[] =
         "0123456789abcdef0123456789abcdef"
         "0123456789abcdef0123456789abcdef";
@@ -4561,6 +4564,20 @@ Check_FHE_SYNC1_Mapped_Image(void)
     memset(&value_info, 0, sizeof(value_info));
     value_info.encryption_descriptor_id = ciphertext_id;
     value_info.value_class = DSL_FHE_VALUE_CLASS_CIPHERTEXT;
+    foreign_pu = DSL_Builder_Create_Minimal_PU("fhe_sync1_foreign");
+    foreign_input = DSL_Builder_Create_Model_Input
+                        ("foreign_input", tensor_ty, 0);
+    foreign_value_rejected =
+        foreign_pu != NULL && foreign_input != NULL &&
+        DSL_Builder_Append_PU_Value(foreign_pu, foreign_input) &&
+        DSL_Builder_Declare_FHE_Entry_Value
+            (entry_id, foreign_input, 0, DSL_FHE_ENTRY_VALUE_INPUT,
+             &value_info) == DSL_FHE_ENTRY_VALUE_INVALID_ID;
+    FHE_SYNC1_CHECK
+        (foreign_value_rejected,
+         "reject an entry value owned by another program unit");
+    FHE_SYNC1_CHECK
+        (DSL_Builder_Select_PU(pu), "restore entry program unit");
     FHE_SYNC1_CHECK
         (entry_id != 0 &&
          DSL_Builder_Declare_FHE_Entry_Value
@@ -4705,6 +4722,11 @@ Check_FHE_SYNC1_Mapped_Image(void)
     FHE_SYNC1_CHECK
         (!DSL_FHE_Image_Load_Mapped(image_bytes, image_size, NULL),
          "reject invalid owner-PU symbol reference");
+    mapped_entry->owner_pu_st = saved_owner_pu_st;
+    mapped_entry->owner_pu_st = PU_Info_proc_sym(foreign_pu);
+    FHE_SYNC1_CHECK
+        (!DSL_FHE_Image_Load_Mapped(image_bytes, image_size, NULL),
+         "reject an entry contract whose values belong to another PU");
     mapped_entry->owner_pu_st = saved_owner_pu_st;
     DSL_FHE_ENTRY_VALUE_RECORD *mapped_value =
         (DSL_FHE_ENTRY_VALUE_RECORD *)

--- a/osprey/common/com/tests/dsl_fhe_sync1_image_test.sh
+++ b/osprey/common/com/tests/dsl_fhe_sync1_image_test.sh
@@ -50,8 +50,11 @@ for evidence in \
   'pu=fhe_sync1_add config=1' \
   'FHE Entry Value Table:' \
   'role=input ordinal=0 class=ciphertext' \
+  'name=encrypted_input st=<2,1,encrypted_input> owner_pu=fhe_sync1_add' \
   'role=parameter ordinal=0 class=encoded_plaintext' \
+  'name=plaintext_weight st=<2,2,plaintext_weight> owner_pu=fhe_sync1_add' \
   'role=output ordinal=0 class=ciphertext' \
+  'name=encrypted_result st=<2,3,encrypted_result> owner_pu=fhe_sync1_add' \
   'FHE Encryption Descriptor Table:' \
   'FHE Tensor Binding Table:' \
   'FHE Key Requirement Table:' \


### PR DESCRIPTION
## Summary

- validate every FHE entry value against the owning PU recorded by the entry contract
- reject cross-PU local-symbol collisions during construction and mapped-image reopen
- make `ir_b2a -st -src` print stored value names and explicit PU ownership without dereferencing an unrelated active local symbol table
- record the SYNC-2 artifact review gate in the infrastructure and consolidated FHE plans

No mapped-image row, record size, opcode, version, or ELF section contract changes.

## Validation

- focused Linux build of `dsl_fhe.cxx`, `dsl_fhe_print.cxx`, `dsl_builder_contract_test`, and `ir_b2a`
- full `dsl_builder_contract_test`
- `dsl_fhe_sync1_image_test.sh`, including producer, mapped-image reopen, `ir_b2a -st -src`, and retained `.B`/`.T` evidence
- `git diff --check` and no-tab scan

## Coordination

This is the main/common prerequisite for completing FHE SYNC-2. After merge, the FHE frontend branch will rebase, add source positions for external and implicit ResNet-20 parameters, and regenerate the full `secure_resnet20.B`/`.T` artifact family.