### PR TITLE
Persist and inspect FHE conversion planning images

### DIFF
--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1744,6 +1744,26 @@ full-sequence causal prompt evaluation with no KV cache.
    VHO conversion driver. Stage 2b owns that reader/writer/printer wiring and
    must preserve the version-1 `.WHIRL.dsl_fhe` image unchanged.
 
+   Stage 2b adds optional `WT_DSL_FHE_PLAN` (`0x24`) section emission and
+   discovery under `.WHIRL.dsl_fhe_plan`. The mapped reader validates the
+   exact section size and every cross-table reference before resetting live
+   state, then copies the accepted fixed rows into managed tables; it never
+   adopts mapped ELF storage as mutable compiler state. An absent section
+   resets to an empty valid plan so pre-SYNC-3 files remain readable.
+   `ir_b2a -st -src` prints stable logical conversion-disposition,
+   approximation, CKKS value-state, and BatchNorm-fold tables. The focused
+   producer rejects truncated, trailing, reserved-field, and invalid-reference
+   images, then writes and reopens a retained `.B`/`.T` pair through the normal
+   ELF path. The existing `.WHIRL.dsl_fhe` version and all earlier image rows
+   remain unchanged.
+
+   Stage 2c remains responsible for opaque builder attachment/rewrite APIs and
+   the common stable-definition/update services consumed by conversion. The
+   later VHO stage owns `VHO_FHE_Convert_Driver()`, its independent option
+   control, semantic gatekeeper, and before/after conversion artifacts. Keep
+   the FHE task blocked from conversion implementation until those reviewed
+   hooks land; do not let it reach into WN, ST, TY, or mapped-image internals.
+
 ### Deferred work TODO
 
 Deferred work remains tracked but does not block the active native DSL bring-up

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -3886,6 +3886,10 @@ DSL_Builder_Verify_Program (DSL_BUILDER_VERIFY_RESULT *result)
         valid = FALSE;
         ++gatekeeper_result.error_count;
     }
+    if (!DSL_FHE_Plan_Image_Validate(diagnostic)) {
+        valid = FALSE;
+        ++gatekeeper_result.error_count;
+    }
     if (gatekeeper_result.native_node_count != DSL_IR_Image_Node_Count()) {
         if (diagnostic != NULL)
             fprintf(diagnostic,

--- a/osprey/common/com/dsl_fhe_plan.cxx
+++ b/osprey/common/com/dsl_fhe_plan.cxx
@@ -28,6 +28,14 @@ static DSL_FHE_APPROXIMATION_TABLE DSL_fhe_approximation_table;
 static DSL_FHE_CKKS_STATE_TABLE DSL_fhe_ckks_state_table;
 static DSL_FHE_BN_FOLD_TABLE DSL_fhe_bn_fold_table;
 
+typedef struct {
+    const DSL_FHE_PLAN_IMAGE_HEADER *header;
+    const DSL_FHE_CONVERSION_DISPOSITION_RECORD *dispositions;
+    const DSL_FHE_APPROXIMATION_CONTRACT_RECORD *approximations;
+    const DSL_FHE_CKKS_VALUE_STATE_RECORD *ckks_states;
+    const DSL_FHE_BN_FOLD_PROVENANCE_RECORD *bn_folds;
+} DSL_FHE_PLAN_IMAGE_VIEW;
+
 typedef char DSL_FHE_Plan_TY_IDX_Width_Check
     [sizeof(TY_IDX) == 4 ? 1 : -1];
 typedef char DSL_FHE_Plan_ST_IDX_Width_Check
@@ -129,6 +137,66 @@ DSL_FHE_Plan_Range_Valid (UINT32 first, UINT32 count, UINT32 limit)
     if (count == 0)
         return first == 0;
     return first != 0 && count <= limit && first <= limit - count + 1;
+}
+
+static UINT32
+DSL_FHE_Plan_View_Disposition_Count (const DSL_FHE_PLAN_IMAGE_VIEW *view)
+{
+    return view == NULL ? DSL_fhe_disposition_table.Size() :
+                          view->header->disposition_count;
+}
+
+static UINT32
+DSL_FHE_Plan_View_Approximation_Count (const DSL_FHE_PLAN_IMAGE_VIEW *view)
+{
+    return view == NULL ? DSL_fhe_approximation_table.Size() :
+                          view->header->approximation_count;
+}
+
+static UINT32
+DSL_FHE_Plan_View_CKKS_State_Count (const DSL_FHE_PLAN_IMAGE_VIEW *view)
+{
+    return view == NULL ? DSL_fhe_ckks_state_table.Size() :
+                          view->header->ckks_value_state_count;
+}
+
+static UINT32
+DSL_FHE_Plan_View_BN_Fold_Count (const DSL_FHE_PLAN_IMAGE_VIEW *view)
+{
+    return view == NULL ? DSL_fhe_bn_fold_table.Size() :
+                          view->header->bn_fold_count;
+}
+
+static const DSL_FHE_CONVERSION_DISPOSITION_RECORD &
+DSL_FHE_Plan_View_Disposition
+        (const DSL_FHE_PLAN_IMAGE_VIEW *view, UINT32 ordinal)
+{
+    return view == NULL ? DSL_fhe_disposition_table[ordinal] :
+                          view->dispositions[ordinal];
+}
+
+static const DSL_FHE_APPROXIMATION_CONTRACT_RECORD &
+DSL_FHE_Plan_View_Approximation
+        (const DSL_FHE_PLAN_IMAGE_VIEW *view, UINT32 ordinal)
+{
+    return view == NULL ? DSL_fhe_approximation_table[ordinal] :
+                          view->approximations[ordinal];
+}
+
+static const DSL_FHE_CKKS_VALUE_STATE_RECORD &
+DSL_FHE_Plan_View_CKKS_State
+        (const DSL_FHE_PLAN_IMAGE_VIEW *view, UINT32 ordinal)
+{
+    return view == NULL ? DSL_fhe_ckks_state_table[ordinal] :
+                          view->ckks_states[ordinal];
+}
+
+static const DSL_FHE_BN_FOLD_PROVENANCE_RECORD &
+DSL_FHE_Plan_View_BN_Fold
+        (const DSL_FHE_PLAN_IMAGE_VIEW *view, UINT32 ordinal)
+{
+    return view == NULL ? DSL_fhe_bn_fold_table[ordinal] :
+                          view->bn_folds[ordinal];
 }
 
 static BOOL
@@ -328,7 +396,8 @@ DSL_FHE_Plan_Wrapper_Valid
 
 static BOOL
 DSL_FHE_Plan_Disposition_Valid
-        (const DSL_FHE_CONVERSION_DISPOSITION_RECORD &record)
+        (const DSL_FHE_CONVERSION_DISPOSITION_RECORD &record,
+         const DSL_FHE_PLAN_IMAGE_VIEW *view)
 {
     DSL_IR_NODE_RECORD node;
     DSL_IR_VALUE_RECORD value;
@@ -350,7 +419,7 @@ DSL_FHE_Plan_Disposition_Valid
         (record.flags & ~known_flags) != 0 || record.reserved != 0 ||
         !DSL_FHE_Plan_Range_Valid
             (record.first_bn_fold_id, record.bn_fold_count,
-             DSL_fhe_bn_fold_table.Size()))
+             DSL_FHE_Plan_View_BN_Fold_Count(view)))
         return FALSE;
 
     if (record.disposition == DSL_FHE_DISPOSITION_DOMAIN_WRAPPER) {
@@ -364,22 +433,24 @@ DSL_FHE_Plan_Disposition_Valid
     if (record.disposition == DSL_FHE_DISPOSITION_REQUIRE_APPROXIMATION) {
         if (record.approximation_contract_id == 0 ||
             record.approximation_contract_id >
-                DSL_fhe_approximation_table.Size())
+                DSL_FHE_Plan_View_Approximation_Count(view))
             return FALSE;
     } else if (record.approximation_contract_id != 0) {
         return FALSE;
     }
 
     if (record.result_ckks_value_state_id == 0 ||
-        record.result_ckks_value_state_id > DSL_fhe_ckks_state_table.Size() ||
-        DSL_fhe_ckks_state_table
-            [record.result_ckks_value_state_id - 1].value_id !=
+        record.result_ckks_value_state_id >
+            DSL_FHE_Plan_View_CKKS_State_Count(view) ||
+        DSL_FHE_Plan_View_CKKS_State
+            (view, record.result_ckks_value_state_id - 1).value_id !=
                 record.result_value_id)
         return FALSE;
 
     for (UINT32 i = 0; i < record.bn_fold_count; ++i) {
         const DSL_FHE_BN_FOLD_PROVENANCE_RECORD &fold =
-            DSL_fhe_bn_fold_table[record.first_bn_fold_id - 1 + i];
+            DSL_FHE_Plan_View_BN_Fold
+                (view, record.first_bn_fold_id - 1 + i);
         if (fold.conv_node_id != record.source_node_id ||
             fold.owner_pu_st != record.owner_pu_st)
             return FALSE;
@@ -475,11 +546,15 @@ DSL_FHE_Plan_Image_Has_Records (void)
            DSL_fhe_bn_fold_table.Size() != 0;
 }
 
-BOOL
-DSL_FHE_Plan_Image_Validate (FILE *diagnostic)
+static BOOL
+DSL_FHE_Plan_View_Validate
+        (const DSL_FHE_PLAN_IMAGE_VIEW *view, FILE *diagnostic)
 {
     DSL_FHE_PLAN_IMAGE_HEADER header;
-    DSL_FHE_Plan_Image_Get_Header(&header);
+    if (view == NULL)
+        DSL_FHE_Plan_Image_Get_Header(&header);
+    else
+        header = *view->header;
     const UINT32 capabilities = DSL_FHE_PLAN_CAP_DISPOSITION |
                                 DSL_FHE_PLAN_CAP_APPROXIMATION |
                                 DSL_FHE_PLAN_CAP_CKKS_VALUE_STATE |
@@ -494,38 +569,42 @@ DSL_FHE_Plan_Image_Validate (FILE *diagnostic)
         header.reserved4 != 0 || header.reserved5 != 0)
         return DSL_FHE_Plan_Report(diagnostic, "invalid header", 0);
 
-    for (UINT32 i = 0; i < DSL_fhe_approximation_table.Size(); ++i) {
+    for (UINT32 i = 0;
+         i < DSL_FHE_Plan_View_Approximation_Count(view); ++i) {
         const DSL_FHE_APPROXIMATION_CONTRACT_RECORD &record =
-            DSL_fhe_approximation_table[i];
+            DSL_FHE_Plan_View_Approximation(view, i);
         if (record.id != i + 1 ||
             !DSL_FHE_Plan_Approximation_Valid(record))
             return DSL_FHE_Plan_Report
                        (diagnostic, "invalid approximation", i + 1);
     }
-    for (UINT32 i = 0; i < DSL_fhe_ckks_state_table.Size(); ++i) {
+    for (UINT32 i = 0;
+         i < DSL_FHE_Plan_View_CKKS_State_Count(view); ++i) {
         const DSL_FHE_CKKS_VALUE_STATE_RECORD &record =
-            DSL_fhe_ckks_state_table[i];
+            DSL_FHE_Plan_View_CKKS_State(view, i);
         if (record.id != i + 1 || !DSL_FHE_Plan_CKKS_State_Valid(record))
             return DSL_FHE_Plan_Report
                        (diagnostic, "invalid CKKS value state", i + 1);
         UINT32 expected_version = 1;
         for (UINT32 j = 0; j < i; ++j) {
-            if (DSL_fhe_ckks_state_table[j].value_id == record.value_id)
+            if (DSL_FHE_Plan_View_CKKS_State(view, j).value_id ==
+                record.value_id)
                 ++expected_version;
         }
         if (record.state_version != expected_version)
             return DSL_FHE_Plan_Report
                        (diagnostic, "noncontiguous CKKS state version", i + 1);
     }
-    for (UINT32 i = 0; i < DSL_fhe_bn_fold_table.Size(); ++i) {
+    for (UINT32 i = 0;
+         i < DSL_FHE_Plan_View_BN_Fold_Count(view); ++i) {
         const DSL_FHE_BN_FOLD_PROVENANCE_RECORD &record =
-            DSL_fhe_bn_fold_table[i];
+            DSL_FHE_Plan_View_BN_Fold(view, i);
         if (record.id != i + 1 || !DSL_FHE_Plan_BN_Fold_Valid(record))
             return DSL_FHE_Plan_Report
                        (diagnostic, "invalid BatchNorm fold", i + 1);
         for (UINT32 j = 0; j < i; ++j) {
             const DSL_FHE_BN_FOLD_PROVENANCE_RECORD &prior =
-                DSL_fhe_bn_fold_table[j];
+                DSL_FHE_Plan_View_BN_Fold(view, j);
             if (prior.conv_node_id == record.conv_node_id &&
                 prior.batch_norm_node_id == record.batch_norm_node_id &&
                 prior.context_pu_identity_id ==
@@ -535,24 +614,28 @@ DSL_FHE_Plan_Image_Validate (FILE *diagnostic)
                            (diagnostic, "duplicate BatchNorm fold", i + 1);
         }
     }
-    for (UINT32 i = 0; i < DSL_fhe_disposition_table.Size(); ++i) {
+    for (UINT32 i = 0;
+         i < DSL_FHE_Plan_View_Disposition_Count(view); ++i) {
         const DSL_FHE_CONVERSION_DISPOSITION_RECORD &record =
-            DSL_fhe_disposition_table[i];
-        if (record.id != i + 1 || !DSL_FHE_Plan_Disposition_Valid(record))
+            DSL_FHE_Plan_View_Disposition(view, i);
+        if (record.id != i + 1 ||
+            !DSL_FHE_Plan_Disposition_Valid(record, view))
             return DSL_FHE_Plan_Report
                        (diagnostic, "invalid disposition", i + 1);
         for (UINT32 j = 0; j < i; ++j) {
-            if (DSL_fhe_disposition_table[j].source_node_id ==
+            if (DSL_FHE_Plan_View_Disposition(view, j).source_node_id ==
                     record.source_node_id)
                 return DSL_FHE_Plan_Report
                            (diagnostic, "duplicate disposition", i + 1);
         }
     }
-    for (UINT32 i = 0; i < DSL_fhe_bn_fold_table.Size(); ++i) {
+    for (UINT32 i = 0;
+         i < DSL_FHE_Plan_View_BN_Fold_Count(view); ++i) {
         UINT32 owners = 0;
-        for (UINT32 j = 0; j < DSL_fhe_disposition_table.Size(); ++j) {
+        for (UINT32 j = 0;
+             j < DSL_FHE_Plan_View_Disposition_Count(view); ++j) {
             const DSL_FHE_CONVERSION_DISPOSITION_RECORD &disposition =
-                DSL_fhe_disposition_table[j];
+                DSL_FHE_Plan_View_Disposition(view, j);
             if (disposition.bn_fold_count != 0 &&
                 i + 1 >= disposition.first_bn_fold_id &&
                 i + 1 < disposition.first_bn_fold_id +
@@ -563,6 +646,83 @@ DSL_FHE_Plan_Image_Validate (FILE *diagnostic)
             return DSL_FHE_Plan_Report
                        (diagnostic, "unowned BatchNorm fold", i + 1);
     }
+    return TRUE;
+}
+
+BOOL
+DSL_FHE_Plan_Image_Validate (FILE *diagnostic)
+{
+    return DSL_FHE_Plan_View_Validate(NULL, diagnostic);
+}
+
+static BOOL
+DSL_FHE_Plan_Add_Section_Size
+        (UINT64 *size, UINT32 count, UINT32 record_size)
+{
+    const UINT64 max_size = (UINT64)-1;
+    if (count != 0 && count > (max_size - *size) / record_size)
+        return FALSE;
+    *size += (UINT64)count * record_size;
+    return TRUE;
+}
+
+BOOL
+DSL_FHE_Plan_Image_Load_Mapped
+        (const void *section_base, UINT64 section_size, FILE *diagnostic)
+{
+    if (section_base == NULL || section_size < DSL_FHE_PLAN_IMAGE_HEADER_SIZE)
+        return DSL_FHE_Plan_Report(diagnostic, "section is truncated", 0);
+    const char *cursor = (const char *)section_base;
+    const DSL_FHE_PLAN_IMAGE_HEADER *header =
+        (const DSL_FHE_PLAN_IMAGE_HEADER *)cursor;
+    UINT64 expected_size = DSL_FHE_PLAN_IMAGE_HEADER_SIZE;
+    if (!DSL_FHE_Plan_Add_Section_Size
+             (&expected_size, header->disposition_count,
+              DSL_FHE_PLAN_DISPOSITION_RECORD_SIZE) ||
+        !DSL_FHE_Plan_Add_Section_Size
+             (&expected_size, header->approximation_count,
+              DSL_FHE_PLAN_APPROXIMATION_RECORD_SIZE) ||
+        !DSL_FHE_Plan_Add_Section_Size
+             (&expected_size, header->ckks_value_state_count,
+              DSL_FHE_PLAN_CKKS_STATE_RECORD_SIZE) ||
+        !DSL_FHE_Plan_Add_Section_Size
+             (&expected_size, header->bn_fold_count,
+              DSL_FHE_PLAN_BN_FOLD_RECORD_SIZE) ||
+        expected_size != section_size)
+        return DSL_FHE_Plan_Report
+                   (diagnostic, "section size mismatch", 0);
+
+    DSL_FHE_PLAN_IMAGE_VIEW view;
+    view.header = header;
+    cursor += DSL_FHE_PLAN_IMAGE_HEADER_SIZE;
+    view.dispositions =
+        (const DSL_FHE_CONVERSION_DISPOSITION_RECORD *)cursor;
+    cursor += (UINT64)header->disposition_count *
+              DSL_FHE_PLAN_DISPOSITION_RECORD_SIZE;
+    view.approximations =
+        (const DSL_FHE_APPROXIMATION_CONTRACT_RECORD *)cursor;
+    cursor += (UINT64)header->approximation_count *
+              DSL_FHE_PLAN_APPROXIMATION_RECORD_SIZE;
+    view.ckks_states = (const DSL_FHE_CKKS_VALUE_STATE_RECORD *)cursor;
+    cursor += (UINT64)header->ckks_value_state_count *
+              DSL_FHE_PLAN_CKKS_STATE_RECORD_SIZE;
+    view.bn_folds = (const DSL_FHE_BN_FOLD_PROVENANCE_RECORD *)cursor;
+
+    if (!DSL_FHE_Plan_View_Validate(&view, diagnostic))
+        return FALSE;
+
+    DSL_FHE_Plan_Image_Reset();
+    if (header->disposition_count != 0)
+        DSL_fhe_disposition_table.Insert
+            (view.dispositions, header->disposition_count);
+    if (header->approximation_count != 0)
+        DSL_fhe_approximation_table.Insert
+            (view.approximations, header->approximation_count);
+    if (header->ckks_value_state_count != 0)
+        DSL_fhe_ckks_state_table.Insert
+            (view.ckks_states, header->ckks_value_state_count);
+    if (header->bn_fold_count != 0)
+        DSL_fhe_bn_fold_table.Insert(view.bn_folds, header->bn_fold_count);
     return TRUE;
 }
 
@@ -644,7 +804,7 @@ DSL_FHE_CONVERSION_DISPOSITION_ID
 DSL_FHE_Plan_Add_Conversion_Disposition
         (const DSL_FHE_CONVERSION_DISPOSITION_RECORD *record)
 {
-    if (record == NULL || !DSL_FHE_Plan_Disposition_Valid(*record))
+    if (record == NULL || !DSL_FHE_Plan_Disposition_Valid(*record, NULL))
         return DSL_FHE_CONVERSION_DISPOSITION_INVALID_ID;
     for (UINT32 i = 0; i < DSL_fhe_disposition_table.Size(); ++i) {
         if (DSL_fhe_disposition_table[i].source_node_id ==

--- a/osprey/common/com/dsl_fhe_plan.h
+++ b/osprey/common/com/dsl_fhe_plan.h
@@ -201,6 +201,10 @@ extern void DSL_FHE_Plan_Image_Get_Header
                                 (DSL_FHE_PLAN_IMAGE_HEADER *header);
 extern BOOL DSL_FHE_Plan_Image_Has_Records (void);
 extern BOOL DSL_FHE_Plan_Image_Validate (FILE *diagnostic);
+extern BOOL DSL_FHE_Plan_Image_Load_Mapped (const void *section_base,
+                                            UINT64 section_size,
+                                            FILE *diagnostic);
+extern void DSL_FHE_Plan_Image_Print (FILE *file);
 
 extern void DSL_FHE_Conversion_Disposition_Record_Init
                                 (DSL_FHE_CONVERSION_DISPOSITION_RECORD *record);

--- a/osprey/common/com/dsl_fhe_plan_print.cxx
+++ b/osprey/common/com/dsl_fhe_plan_print.cxx
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2026 Open64 Project
+ */
+
+#include "dsl_fhe_plan.h"
+#include "dsl_opcode.h"
+#include "strtab.h"
+#include "symtab.h"
+
+static const char *
+DSL_FHE_Plan_Name (UINT32 value, const char *const *names, UINT32 count)
+{
+    return value < count ? names[value] : names[0];
+}
+
+static const char *
+DSL_FHE_Plan_Disposition_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "preserve", "domain_wrapper", "fold_into_producer",
+        "layout_reinterpret", "require_approximation"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Plan_Approximation_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "minimax", "chebyshev", "taylor"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Plan_Scale_Policy_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "inherit", "preserve", "explicit"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Plan_Bootstrap_Reason_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "none", "pre_relu_refresh", "depth_exhaustion",
+        "manual_boundary_required"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Plan_Value_Name (DSL_IR_VALUE_ID value_id)
+{
+    DSL_IR_VALUE_RECORD value;
+    if (!DSL_IR_Image_Get_Value(value_id, &value) ||
+        value.name == STR_IDX_ZERO)
+        return "";
+    return Index_To_Str(value.name);
+}
+
+static const char *
+DSL_FHE_Plan_Node_Operator_Name (DSL_IR_NODE_ID node_id)
+{
+    DSL_IR_NODE_RECORD node;
+    DSL_IR_OPCODE_DESCRIPTOR_RECORD descriptor;
+    if (!DSL_IR_Image_Get_Node(node_id, &node) ||
+        !DSL_IR_Image_Get_Opcode_Descriptor
+            (node.opcode_descriptor_id, &descriptor))
+        return "OPR_DSLUNKNOWN";
+    return DSL_OPERATOR_name((DSL_OPERATOR)descriptor.logical_operator);
+}
+
+static void
+DSL_FHE_Plan_Print_Pending_Integer (FILE *file, const char *name, INT32 value)
+{
+    if (value == -1)
+        fprintf(file, " %s=<pending>", name);
+    else
+        fprintf(file, " %s=%d", name, value);
+}
+
+void
+DSL_FHE_Plan_Image_Print (FILE *file)
+{
+    if (file == NULL || !DSL_FHE_Plan_Image_Has_Records())
+        return;
+    DSL_FHE_PLAN_IMAGE_HEADER header;
+    DSL_FHE_Plan_Image_Get_Header(&header);
+    fprintf(file, "\nFHE Plan Image: version=%u capabilities=0x%08x\n",
+            header.version, header.capabilities);
+
+    fprintf(file, "FHE Conversion Disposition Table:\n");
+    for (UINT32 i = 1; i <= header.disposition_count; ++i) {
+        DSL_FHE_CONVERSION_DISPOSITION_RECORD record;
+        DSL_FHE_Plan_Get_Conversion_Disposition(i, &record);
+        fprintf(file, "  [%u] source_node=node%u source_operator=%s "
+                "result=value%u(%s) owner_pu=%s disposition=%s",
+                record.id, record.source_node_id,
+                DSL_FHE_Plan_Node_Operator_Name(record.source_node_id),
+                record.result_value_id,
+                DSL_FHE_Plan_Value_Name(record.result_value_id),
+                ST_name(St_Table[record.owner_pu_st]),
+                DSL_FHE_Plan_Disposition_Name(record.disposition));
+        if (record.wrapper_name != STR_IDX_ZERO)
+            fprintf(file, " wrapper=%s.v%u",
+                    Index_To_Str(record.wrapper_name),
+                    record.wrapper_version);
+        if (record.approximation_contract_id != 0)
+            fprintf(file, " approximation=%u",
+                    record.approximation_contract_id);
+        fprintf(file, " ckks_state=%u bn_folds=[%u,%u] flags=0x%x\n",
+                record.result_ckks_value_state_id,
+                record.first_bn_fold_id, record.bn_fold_count, record.flags);
+    }
+
+    fprintf(file, "FHE Approximation Contract Table:\n");
+    for (UINT32 i = 1; i <= header.approximation_count; ++i) {
+        DSL_FHE_APPROXIMATION_CONTRACT_RECORD record;
+        DSL_FHE_Plan_Get_Approximation_Contract(i, &record);
+        fprintf(file, "  [%u] config=%u polynomial=%s.v%u family=%s "
+                "degree=%u coefficients=tcon%u range=[tcon%u,tcon%u] "
+                "max_abs_error=tcon%u scale_policy=%s depth=%u "
+                "bootstrap=%u pre_refresh=%u flags=0x%x\n", record.id,
+                record.config_id, Index_To_Str(record.polynomial_name),
+                record.polynomial_version,
+                DSL_FHE_Plan_Approximation_Name
+                    (record.approximation_family),
+                record.degree, (UINT32)record.coefficient_tensor_tcon,
+                (UINT32)record.valid_range_min_tcon,
+                (UINT32)record.valid_range_max_tcon,
+                (UINT32)record.max_abs_error_tcon,
+                DSL_FHE_Plan_Scale_Policy_Name(record.scale_policy),
+                record.required_multiplicative_depth,
+                record.bootstrap_policy, record.requires_pre_refresh,
+                record.flags);
+    }
+
+    fprintf(file, "FHE CKKS Value State Table:\n");
+    for (UINT32 i = 1; i <= header.ckks_value_state_count; ++i) {
+        DSL_FHE_CKKS_VALUE_STATE_RECORD record;
+        DSL_FHE_Plan_Get_CKKS_Value_State(i, &record);
+        fprintf(file, "  [%u] value=value%u(%s) state_version=%u "
+                "encryption=%u scheme=%u class=%u", record.id,
+                record.value_id, DSL_FHE_Plan_Value_Name(record.value_id),
+                record.state_version, record.encryption_descriptor_id,
+                record.scheme, record.value_class);
+        DSL_FHE_Plan_Print_Pending_Integer(file, "level", record.level);
+        DSL_FHE_Plan_Print_Pending_Integer
+            (file, "scale_bits", record.scale_bits);
+        DSL_FHE_Plan_Print_Pending_Integer
+            (file, "components", record.component_count);
+        DSL_FHE_Plan_Print_Pending_Integer
+            (file, "precision_bits", record.precision_bits);
+        fprintf(file, " slots=%u alignment_group=%u layout=%s "
+                "pending=0x%x bootstrap_reason=%s\n", record.slot_count,
+                record.alignment_group,
+                record.encrypted_layout_name == STR_IDX_ZERO ? "<pending>" :
+                    Index_To_Str(record.encrypted_layout_name),
+                record.pending_actions,
+                DSL_FHE_Plan_Bootstrap_Reason_Name
+                    (record.pending_bootstrap_reason));
+    }
+
+    fprintf(file, "FHE BatchNorm Fold Provenance Table:\n");
+    for (UINT32 i = 1; i <= header.bn_fold_count; ++i) {
+        DSL_FHE_BN_FOLD_PROVENANCE_RECORD record;
+        DSL_PU_SOURCE_IDENTITY_RECORD identity;
+        DSL_FHE_Plan_Get_BN_Fold_Provenance(i, &record);
+        DSL_Call_Image_Get_PU_Identity
+            (record.context_pu_identity_id, &identity);
+        fprintf(file, "  [%u] owner_pu=%s conv=node%u batch_norm=node%u "
+                "context=%s callsite=%u conv_weight=%s conv_bias=%s "
+                "bn_scale=%s bn_bias=%s bn_mean=%s bn_variance=%s "
+                "folded_weight=tcon%u folded_bias=tcon%u flags=0x%x\n",
+                record.id, ST_name(St_Table[record.owner_pu_st]),
+                record.conv_node_id, record.batch_norm_node_id,
+                Index_To_Str(identity.canonical_definition_name),
+                record.context_callsite_id,
+                DSL_FHE_Plan_Value_Name
+                    (record.source_conv_weight_value_id),
+                DSL_FHE_Plan_Value_Name
+                    (record.source_conv_bias_value_id),
+                DSL_FHE_Plan_Value_Name(record.source_bn_scale_value_id),
+                DSL_FHE_Plan_Value_Name(record.source_bn_bias_value_id),
+                DSL_FHE_Plan_Value_Name(record.source_bn_mean_value_id),
+                DSL_FHE_Plan_Value_Name
+                    (record.source_bn_variance_value_id),
+                (UINT32)record.folded_weight_tcon,
+                (UINT32)record.folded_bias_tcon, record.flags);
+    }
+}

--- a/osprey/common/com/dsl_ir_print.cxx
+++ b/osprey/common/com/dsl_ir_print.cxx
@@ -4,6 +4,7 @@
 
 #include "dsl_ir_image.h"
 #include "dsl_fhe.h"
+#include "dsl_fhe_plan.h"
 #include "dsl_opcode.h"
 #include "strtab.h"
 #include "symtab.h"
@@ -257,4 +258,5 @@ DSL_IR_Image_Print (FILE *file)
                 record.source_call_ordinal, record.flags);
     }
     DSL_FHE_Image_Print(file);
+    DSL_FHE_Plan_Image_Print(file);
 }

--- a/osprey/common/com/ir_bread.cxx
+++ b/osprey/common/com/ir_bread.cxx
@@ -100,6 +100,7 @@
 #include "ir_bread.h"
 #include "dsl_ir_image.h"
 #include "dsl_fhe.h"
+#include "dsl_fhe_plan.h"
 #include "dsl_region.h"
 #include "config_opt.h"
 
@@ -497,6 +498,21 @@ WN_get_dsl_fhe_image (void *handle)
     }
     const void *section_base = (const char *)handle + shdr.offset;
     return DSL_FHE_Image_Load_Mapped
+               (section_base, shdr.size, stderr) ? 0 : -1;
+}
+
+INT
+WN_get_dsl_fhe_plan_image (void *handle)
+{
+    OFFSET_AND_SIZE shdr = get_section
+                               (handle, SHT_MIPS_WHIRL,
+                                WT_DSL_FHE_PLAN);
+    if (shdr.offset == 0) {
+        DSL_FHE_Plan_Image_Reset();
+        return 0;
+    }
+    const void *section_base = (const char *)handle + shdr.offset;
+    return DSL_FHE_Plan_Image_Load_Mapped
                (section_base, shdr.size, stderr) ? 0 : -1;
 }
 
@@ -1656,6 +1672,9 @@ Read_Global_Info (INT32 *p_num_PUs)
     }
     if (WN_get_dsl_fhe_image(global_fhandle) == -1) {
         ErrMsg (EC_IR_Scn_Read, "DSL FHE image", global_ir_file);
+    }
+    if (WN_get_dsl_fhe_plan_image(global_fhandle) == -1) {
+        ErrMsg (EC_IR_Scn_Read, "DSL FHE plan image", global_ir_file);
     }
 
 #if defined(KEY) && defined(BACK_END)

--- a/osprey/common/com/ir_bread.h
+++ b/osprey/common/com/ir_bread.h
@@ -130,6 +130,7 @@ extern INT WN_get_strtab (void *handle);
 extern INT WN_get_dsl_ir_image (void *handle);
 extern INT WN_get_dsl_effect_image (void *handle);
 extern INT WN_get_dsl_fhe_image (void *handle);
+extern INT WN_get_dsl_fhe_plan_image (void *handle);
 
 
 extern INT WN_get_dst (void *handle);

--- a/osprey/common/com/ir_bwrite.cxx
+++ b/osprey/common/com/ir_bwrite.cxx
@@ -101,6 +101,7 @@
 #include "ir_bcom.h"
 #include "dsl_ir_image.h"
 #include "dsl_fhe.h"
+#include "dsl_fhe_plan.h"
 #include "dsl_region.h"
 #include "ir_bread.h"
 #include "tracing.h"                /* TEMPORARY FOR ROBERT'S DEBUGGING */
@@ -973,6 +974,52 @@ WN_write_dsl_fhe_image (Output_File *fl)
     cur_section->shdr.sh_addralign = sizeof(mINT64);
 }
 
+void
+WN_write_dsl_fhe_plan_image (Output_File *fl)
+{
+    if (!DSL_FHE_Plan_Image_Has_Records())
+        return;
+
+    FmtAssert(DSL_FHE_Plan_Image_Validate(stderr),
+              ("invalid FHE plan image tables"));
+    Section *cur_section = get_section
+                               (WT_DSL_FHE_PLAN,
+                                MIPS_WHIRL_DSL_FHE_PLAN, fl);
+    fl->file_size = ir_b_align(fl->file_size, sizeof(mINT64), 0);
+    cur_section->shdr.sh_offset = fl->file_size;
+
+    DSL_FHE_PLAN_IMAGE_HEADER header;
+    DSL_FHE_Plan_Image_Get_Header(&header);
+    ir_b_save_buf(&header, sizeof(header), sizeof(mINT64), 0, fl);
+    for (UINT32 i = 1; i <= header.disposition_count; ++i) {
+        DSL_FHE_CONVERSION_DISPOSITION_RECORD record;
+        FmtAssert(DSL_FHE_Plan_Get_Conversion_Disposition(i, &record),
+                  ("missing FHE conversion disposition %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    for (UINT32 i = 1; i <= header.approximation_count; ++i) {
+        DSL_FHE_APPROXIMATION_CONTRACT_RECORD record;
+        FmtAssert(DSL_FHE_Plan_Get_Approximation_Contract(i, &record),
+                  ("missing FHE approximation contract %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    for (UINT32 i = 1; i <= header.ckks_value_state_count; ++i) {
+        DSL_FHE_CKKS_VALUE_STATE_RECORD record;
+        FmtAssert(DSL_FHE_Plan_Get_CKKS_Value_State(i, &record),
+                  ("missing FHE CKKS value state %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    for (UINT32 i = 1; i <= header.bn_fold_count; ++i) {
+        DSL_FHE_BN_FOLD_PROVENANCE_RECORD record;
+        FmtAssert(DSL_FHE_Plan_Get_BN_Fold_Provenance(i, &record),
+                  ("missing FHE BatchNorm fold provenance %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+
+    cur_section->shdr.sh_size = fl->file_size - cur_section->shdr.sh_offset;
+    cur_section->shdr.sh_addralign = sizeof(mINT64);
+}
+
 
 /*
  * Write out the debug symbol table (dst).  The DST gets its own Elf
@@ -1798,6 +1845,7 @@ Write_Global_Info (PU_Info *pu_tree)
     WN_write_dsl_effect_image(ir_output);
     WN_write_dsl_callsite_image(ir_output);
     WN_write_dsl_fhe_image(ir_output);
+    WN_write_dsl_fhe_plan_image(ir_output);
 
     WN_write_strtab(Index_To_Str (0), STR_Table_Size (), ir_output);
 

--- a/osprey/common/com/ir_bwrite.h
+++ b/osprey/common/com/ir_bwrite.h
@@ -114,6 +114,7 @@ extern void WN_write_strtab (const void *strtab, UINT64 size, Output_File *fl);
 extern void WN_write_dsl_ir_image (Output_File *fl);
 extern void WN_write_dsl_effect_image (Output_File *fl);
 extern void WN_write_dsl_fhe_image (Output_File *fl);
+extern void WN_write_dsl_fhe_plan_image (Output_File *fl);
 extern void WN_write_localmap (void *localmap, Output_File *fl);
 extern void IPA_write_summary (void (*IPA_irb_write_summary) (Output_File*),
 			      Output_File *fl);

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -4804,17 +4804,40 @@ Check_FHE_SYNC1_Mapped_Image(void)
 static int
 Check_FHE_SYNC3_Plan_Image(void)
 {
+    const char *artifact = getenv("OPEN64_DSL_FHE_SYNC3_ARTIFACT");
+    BOOL retain_artifact = artifact != NULL && artifact[0] != '\0';
     DSL_BUILDER_TENSOR_DESCRIPTOR descriptor;
     DSL_BUILDER_TENSOR_TYPE_CORE coefficient_core;
     DSL_BUILDER_PU_SOURCE_IDENTITY source_identity;
+    DSL_BUILDER_SOURCE_POSITION source_position;
+    DSL_BUILDER_MAPPED_IMAGE_REQUEST request;
+    DSL_BUILDER_VERIFY_RESULT verify;
     DSL_BUILDER_PROGRAM_UNIT pu;
     DSL_BUILDER_VALUE input;
+    DSL_BUILDER_VALUE conv_weight;
+    DSL_BUILDER_VALUE channel_parameter;
     DSL_BUILDER_VALUE conv;
     DSL_BUILDER_VALUE batch_norm;
     DSL_BUILDER_VALUE relu;
     DSL_BUILDER_VALUE conv_kids[3];
     DSL_BUILDER_VALUE bn_kids[5];
     DSL_BUILDER_VALUE unary_kid[1];
+    DSL_BUILDER_OPERATOR_ATTRIBUTE conv_attributes[8] = {
+        { "attr.kernel_shape", "1,1" },
+        { "attr.stride", "1,1" },
+        { "attr.padding", "0,0" },
+        { "attr.dilation", "1,1" },
+        { "attr.groups", "1" },
+        { "attr.input_layout", "NCHW" },
+        { "attr.weight_layout", "OIHW" },
+        { "attr.output_layout", "NCHW" }
+    };
+    DSL_BUILDER_OPERATOR_ATTRIBUTE batch_norm_attributes[4] = {
+        { "attr.epsilon", "0.00001" },
+        { "attr.training", "false" },
+        { "attr.input_layout", "NCHW" },
+        { "attr.channel_axis", "1" }
+    };
     DSL_IR_VALUE_RECORD conv_value;
     DSL_IR_VALUE_RECORD bn_value;
     DSL_IR_VALUE_RECORD relu_value;
@@ -4840,8 +4863,12 @@ Check_FHE_SYNC3_Plan_Image(void)
     TCON_IDX range_max_tcon;
     TCON_IDX max_error_tcon;
     TY_IDX tensor_ty;
+    TY_IDX conv_weight_ty;
+    TY_IDX channel_parameter_ty;
     TY_IDX coefficient_ty;
     DSL_DOMAIN_ID cnn_id;
+    UINT32 file_id;
+    BOOL positions_set;
     int failed = 0;
 #define FHE_SYNC3_CHECK(condition, message) \
     do { \
@@ -4851,6 +4878,8 @@ Check_FHE_SYNC3_Plan_Image(void)
         } \
     } while (0)
 
+    if (!retain_artifact)
+        artifact = "fhe_sync3_plan_contract.B";
     FHE_SYNC3_CHECK
         (sizeof(DSL_FHE_PLAN_IMAGE_HEADER) == 64 &&
          sizeof(DSL_FHE_CONVERSION_DISPOSITION_RECORD) == 56 &&
@@ -4877,6 +4906,16 @@ Check_FHE_SYNC3_Plan_Image(void)
     tensor_ty = DSL_Builder_Intern_Tensor_Type
                     ("fhe_sync3_f32_1x4x4x4", MTYPE_To_TY(MTYPE_F4),
                      &descriptor);
+    descriptor.type_core.logical_shape = "[4,4,1,1]";
+    descriptor.traits.traits = "parameter";
+    conv_weight_ty = DSL_Builder_Intern_Tensor_Type
+                         ("fhe_sync3_conv_weight_f32_4x4x1x1",
+                          MTYPE_To_TY(MTYPE_F4), &descriptor);
+    descriptor.type_core.rank = 1;
+    descriptor.type_core.logical_shape = "[4]";
+    channel_parameter_ty = DSL_Builder_Intern_Tensor_Type
+                               ("fhe_sync3_channel_parameter_f32_4",
+                                MTYPE_To_TY(MTYPE_F4), &descriptor);
     memset(&coefficient_core, 0, sizeof(coefficient_core));
     coefficient_core.kind = "tensor";
     coefficient_core.dtype = "float32";
@@ -4886,38 +4925,84 @@ Check_FHE_SYNC3_Plan_Image(void)
                          ("fhe_sync3_coeff_f32_4", MTYPE_To_TY(MTYPE_F4),
                           &coefficient_core);
     pu = DSL_Builder_Create_Minimal_PU("fhe_sync3_plan");
+    file_id = DSL_Builder_Register_Source_File(pu, __FILE__);
     memset(&source_identity, 0, sizeof(source_identity));
     source_identity.canonical_definition_name = "FHEResNet.forward";
     source_identity.defining_module = "fhe_resnet";
-    source_identity.defining_file = "fhe_resnet.py";
+    source_identity.defining_file = __FILE__;
     source_identity.defining_line = 1;
     FHE_SYNC3_CHECK
-        (tensor_ty != TY_IDX_ZERO && coefficient_ty != TY_IDX_ZERO &&
+        (tensor_ty != TY_IDX_ZERO && conv_weight_ty != TY_IDX_ZERO &&
+         channel_parameter_ty != TY_IDX_ZERO &&
+         coefficient_ty != TY_IDX_ZERO &&
          TY_tensor_seal(coefficient_ty) &&
-         pu != NULL && cnn_id != DSL_DOMAIN_INVALID_ID &&
+         pu != NULL && file_id != 0 && cnn_id != DSL_DOMAIN_INVALID_ID &&
          DSL_Builder_Set_PU_Source_Identity(pu, &source_identity),
          "program, tensor types, and source identity");
 
     input = DSL_Builder_Create_Model_Input("encrypted_input", tensor_ty, 0);
+    conv_weight = DSL_Builder_Create_Model_Input
+                      ("conv_weight", conv_weight_ty, 1);
+    channel_parameter = DSL_Builder_Create_Model_Input
+                            ("channel_parameter", channel_parameter_ty, 2);
     conv_kids[0] = input;
-    conv_kids[1] = input;
-    conv_kids[2] = input;
+    conv_kids[1] = conv_weight;
+    conv_kids[2] = channel_parameter;
     conv = DSL_Builder_Create_Operator_With_Result
                (DSL_Opcode_Find(cnn_id, "cnn.conv2d", 2), 2,
-                conv_kids, 3, NULL, 0, "conv_result", tensor_ty);
-    for (UINT32 i = 0; i < 5; ++i)
-        bn_kids[i] = i == 0 ? conv : input;
+                conv_kids, 3, conv_attributes, 8,
+                "conv_result", tensor_ty);
+    bn_kids[0] = conv;
+    for (UINT32 i = 1; i < 5; ++i)
+        bn_kids[i] = channel_parameter;
     batch_norm = DSL_Builder_Create_Operator_With_Result
                      (DSL_Opcode_Find(cnn_id, "cnn.batch_norm_infer", 2), 2,
-                      bn_kids, 5, NULL, 0, "batch_norm_result", tensor_ty);
+                      bn_kids, 5, batch_norm_attributes, 4,
+                      "batch_norm_result", tensor_ty);
     unary_kid[0] = batch_norm;
     relu = DSL_Builder_Create_Operator_With_Result
                (DSL_Opcode_Find(DSL_Domain_Find("common"),
                                 "common.relu", 2),
                 2, unary_kid, 1, NULL, 0, "relu_result", tensor_ty);
+    memset(&source_position, 0, sizeof(source_position));
+    source_position.file_id = file_id;
+    source_position.line = __LINE__ + 1;
+    source_position.column = 5;
+    source_position.statement_begin = 1;
+    positions_set = input != NULL && conv_weight != NULL &&
+                    channel_parameter != NULL && conv != NULL &&
+                    batch_norm != NULL && relu != NULL;
+    if (positions_set) {
+        positions_set = DSL_Builder_Set_Value_Source_Position
+                            (input, &source_position);
+        ++source_position.line;
+        positions_set = positions_set &&
+                        DSL_Builder_Set_Value_Source_Position
+                            (conv_weight, &source_position);
+        ++source_position.line;
+        positions_set = positions_set &&
+                        DSL_Builder_Set_Value_Source_Position
+                            (channel_parameter, &source_position);
+        ++source_position.line;
+        positions_set = positions_set &&
+                        DSL_Builder_Set_Value_Source_Position
+                            (conv, &source_position);
+        ++source_position.line;
+        positions_set = positions_set &&
+                        DSL_Builder_Set_Value_Source_Position
+                            (batch_norm, &source_position);
+        ++source_position.line;
+        positions_set = positions_set &&
+                        DSL_Builder_Set_Value_Source_Position
+                            (relu, &source_position);
+    }
     FHE_SYNC3_CHECK
-        (input != NULL && conv != NULL && batch_norm != NULL && relu != NULL &&
+        (input != NULL && conv_weight != NULL && channel_parameter != NULL &&
+         conv != NULL && batch_norm != NULL && relu != NULL &&
+         positions_set &&
          DSL_Builder_Append_PU_Value(pu, input) &&
+         DSL_Builder_Append_PU_Value(pu, conv_weight) &&
+         DSL_Builder_Append_PU_Value(pu, channel_parameter) &&
          DSL_Builder_Append_PU_Value(pu, conv) &&
          DSL_Builder_Append_PU_Value(pu, batch_norm) &&
          DSL_Builder_Append_PU_Value(pu, relu),
@@ -5028,15 +5113,15 @@ Check_FHE_SYNC3_Plan_Image(void)
     bn_fold.batch_norm_node_id = bn_value.producer_node_id;
     bn_fold.context_pu_identity_id = pu_identity.id;
     bn_fold.source_conv_weight_value_id =
-        DSL_Builder_Get_Value_Image_Id(input);
+        DSL_Builder_Get_Value_Image_Id(conv_weight);
     bn_fold.source_bn_scale_value_id =
-        DSL_Builder_Get_Value_Image_Id(input);
+        DSL_Builder_Get_Value_Image_Id(channel_parameter);
     bn_fold.source_bn_bias_value_id =
-        DSL_Builder_Get_Value_Image_Id(input);
+        DSL_Builder_Get_Value_Image_Id(channel_parameter);
     bn_fold.source_bn_mean_value_id =
-        DSL_Builder_Get_Value_Image_Id(input);
+        DSL_Builder_Get_Value_Image_Id(channel_parameter);
     bn_fold.source_bn_variance_value_id =
-        DSL_Builder_Get_Value_Image_Id(input);
+        DSL_Builder_Get_Value_Image_Id(channel_parameter);
     bn_fold.folded_weight_tcon = folded_weight_tcon;
     bn_fold.folded_bias_tcon = folded_bias_tcon;
     bn_fold.flags = DSL_FHE_BN_FOLD_IMPLICIT_ZERO_BIAS;
@@ -5094,12 +5179,97 @@ Check_FHE_SYNC3_Plan_Image(void)
     FHE_SYNC3_CHECK
         (DSL_FHE_Plan_Add_CKKS_Value_State(&ckks_state) == 0,
          "unknown CKKS pending action rejected");
+
+    UINT64 image_size = DSL_FHE_PLAN_IMAGE_HEADER_SIZE +
+        (UINT64)header.disposition_count *
+            DSL_FHE_PLAN_DISPOSITION_RECORD_SIZE +
+        (UINT64)header.approximation_count *
+            DSL_FHE_PLAN_APPROXIMATION_RECORD_SIZE +
+        (UINT64)header.ckks_value_state_count *
+            DSL_FHE_PLAN_CKKS_STATE_RECORD_SIZE +
+        (UINT64)header.bn_fold_count * DSL_FHE_PLAN_BN_FOLD_RECORD_SIZE;
+    unsigned char *image_bytes = new unsigned char[image_size];
+    unsigned char *cursor = image_bytes;
+    memcpy(cursor, &header, sizeof(header));
+    cursor += sizeof(header);
+    for (UINT32 i = 1; i <= header.disposition_count; ++i) {
+        DSL_FHE_Plan_Get_Conversion_Disposition(i, &disposition);
+        memcpy(cursor, &disposition, sizeof(disposition));
+        cursor += sizeof(disposition);
+    }
+    for (UINT32 i = 1; i <= header.approximation_count; ++i) {
+        DSL_FHE_Plan_Get_Approximation_Contract(i, &approximation);
+        memcpy(cursor, &approximation, sizeof(approximation));
+        cursor += sizeof(approximation);
+    }
+    for (UINT32 i = 1; i <= header.ckks_value_state_count; ++i) {
+        DSL_FHE_Plan_Get_CKKS_Value_State(i, &ckks_state);
+        memcpy(cursor, &ckks_state, sizeof(ckks_state));
+        cursor += sizeof(ckks_state);
+    }
+    for (UINT32 i = 1; i <= header.bn_fold_count; ++i) {
+        DSL_FHE_Plan_Get_BN_Fold_Provenance(i, &bn_fold);
+        memcpy(cursor, &bn_fold, sizeof(bn_fold));
+        cursor += sizeof(bn_fold);
+    }
+    FHE_SYNC3_CHECK
+        (!DSL_FHE_Plan_Image_Load_Mapped
+             (image_bytes, image_size - 1, NULL) &&
+         !DSL_FHE_Plan_Image_Load_Mapped
+             (image_bytes, image_size + 1, NULL),
+         "truncated and trailing mapped images rejected");
+    DSL_FHE_PLAN_IMAGE_HEADER *mapped_header =
+        (DSL_FHE_PLAN_IMAGE_HEADER *)image_bytes;
+    mapped_header->reserved0 = 1;
+    FHE_SYNC3_CHECK
+        (!DSL_FHE_Plan_Image_Load_Mapped(image_bytes, image_size, NULL),
+         "nonzero mapped header reserved field rejected");
+    mapped_header->reserved0 = 0;
+    DSL_FHE_CONVERSION_DISPOSITION_RECORD *mapped_disposition =
+        (DSL_FHE_CONVERSION_DISPOSITION_RECORD *)
+            (image_bytes + DSL_FHE_PLAN_IMAGE_HEADER_SIZE);
+    DSL_IR_VALUE_ID saved_result_value_id =
+        mapped_disposition->result_value_id;
+    mapped_disposition->result_value_id = DSL_IR_Image_Value_Count() + 1;
+    FHE_SYNC3_CHECK
+        (!DSL_FHE_Plan_Image_Load_Mapped(image_bytes, image_size, NULL),
+         "invalid mapped DSL value reference rejected");
+    mapped_disposition->result_value_id = saved_result_value_id;
+    FHE_SYNC3_CHECK
+        (DSL_FHE_Plan_Image_Load_Mapped(image_bytes, image_size, stderr) &&
+         DSL_FHE_Plan_Conversion_Disposition_Count() == 2 &&
+         DSL_FHE_Plan_Approximation_Contract_Count() == 1 &&
+         DSL_FHE_Plan_CKKS_Value_State_Count() == 2 &&
+         DSL_FHE_Plan_BN_Fold_Provenance_Count() == 1,
+         "mapped planning image copied into managed tables");
+    delete [] image_bytes;
+
+    char diagnostic[4096];
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    FHE_SYNC3_CHECK
+        (DSL_Builder_Verify_Program(&verify),
+         diagnostic[0] == '\0' ? "program verification" : diagnostic);
+
+    request.path = artifact;
+    request.flags = 0;
+    (void) unlink(request.path);
+    FHE_SYNC3_CHECK
+        (DSL_Builder_Finalize_Mapped_Image(&request) &&
+         access(request.path, F_OK) == 0,
+         "mapped-image artifact finalization");
     DSL_FHE_Plan_Image_Reset();
     FHE_SYNC3_CHECK
         (!DSL_FHE_Plan_Image_Has_Records() &&
          DSL_FHE_Plan_Conversion_Disposition_Count() == 0 &&
          DSL_FHE_Plan_Image_Validate(NULL),
          "planning image reset");
+    if (!retain_artifact)
+        (void) unlink(request.path);
+    if (!failed)
+        printf("FHE SYNC-3 planning-image contract passed\n");
 
 #undef FHE_SYNC3_CHECK
     return failed;

--- a/osprey/common/com/tests/dsl_fhe_sync3_plan_image_test.sh
+++ b/osprey/common/com/tests/dsl_fhe_sync3_plan_image_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Preserve and inspect the SYNC-3 FHE conversion-planning image contract.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+contract_test="${OPEN64_DSL_CONTRACT_TEST:-$repo_root/build/osprey/targdir/ir_tools/dsl_builder_contract_test}"
+ir_b2a="${OPEN64_IR_B2A:-$repo_root/build/osprey/targdir/ir_tools/ir_b2a}"
+artifact_dir="${OPEN64_DSL_FHE_SYNC3_ARTIFACT_DIR:-$repo_root/artifacts/fhe/sync3-plan}"
+image="$artifact_dir/fhe_sync3_plan_contract.B"
+trace="$artifact_dir/fhe_sync3_plan_contract.T"
+command_log="$artifact_dir/commands.txt"
+validation_log="$artifact_dir/validation.log"
+
+for executable in "$contract_test" "$ir_b2a"; do
+  if [[ ! -x "$executable" ]]; then
+    echo "missing executable: $executable" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$artifact_dir"
+find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -delete
+
+printf '%s\n' \
+  "OPEN64_DSL_FHE_SYNC3_PLAN_ONLY=1 OPEN64_DSL_FHE_SYNC3_ARTIFACT=$image $contract_test" \
+  "$ir_b2a -st -src $image $trace" >"$command_log"
+
+if ! (cd "$repo_root" && \
+  OPEN64_DSL_FHE_SYNC3_PLAN_ONLY=1 \
+  OPEN64_DSL_FHE_SYNC3_ARTIFACT="$image" \
+    "$contract_test") >"$validation_log" 2>&1; then
+  cat "$validation_log" >&2
+  exit 1
+fi
+if ! (cd "$repo_root" && \
+  "$ir_b2a" -st -src "$image" "$trace") >>"$validation_log" 2>&1; then
+  cat "$validation_log" >&2
+  exit 1
+fi
+
+for evidence in \
+  'FHE Plan Image: version=1 capabilities=0x0000000f' \
+  'FHE Conversion Disposition Table:' \
+  'source_operator=OPR_DSLCONV2D' \
+  'wrapper=fhe.cnn.conv2d.v1' \
+  'source_operator=OPR_DSLRELU' \
+  'disposition=require_approximation' \
+  'FHE Approximation Contract Table:' \
+  'polynomial=relu_minimax_degree3.v1' \
+  'FHE CKKS Value State Table:' \
+  'level=<pending>' \
+  'bootstrap_reason=pre_relu_refresh' \
+  'FHE BatchNorm Fold Provenance Table:' \
+  'context=FHEResNet.forward' \
+  'dsl_builder_contract_test.cxx'; do
+  if ! grep -Fq "$evidence" "$trace"; then
+    echo "missing FHE SYNC-3 evidence '$evidence' in $trace" >&2
+    exit 1
+  fi
+done
+
+if grep -Fq 'OPR_DSL ' "$trace"; then
+  echo "physical DSL escape tag leaked into $trace" >&2
+  exit 1
+fi
+
+echo "FHE SYNC-3 planning-image fixture passed"
+echo "review image: $image"
+echo "review trace: $trace"
+echo "review commands: $command_log"
+echo "review diagnostics: $validation_log"

--- a/osprey/common/com/tests/dsl_native_syntax_test.sh
+++ b/osprey/common/com/tests/dsl_native_syntax_test.sh
@@ -53,6 +53,7 @@ sources=(
   "osprey/common/com/dsl_builder.cxx"
   "osprey/common/com/dsl_fhe.cxx"
   "osprey/common/com/dsl_fhe_plan.cxx"
+  "osprey/common/com/dsl_fhe_plan_print.cxx"
   "osprey/common/com/dsl_fhe_print.cxx"
   "osprey/common/com/dsl_gatekeeper.cxx"
   "osprey/common/com/dsl_ir_image.cxx"

--- a/osprey/include/sys/elf_whirl.h
+++ b/osprey/include/sys/elf_whirl.h
@@ -84,6 +84,7 @@
 #define WT_DSL_EFFECT_IMAGE 0x21
 #define WT_DSL_CALLSITE_IMAGE 0x22
 #define WT_DSL_FHE_IMAGE 0x23
+#define WT_DSL_FHE_PLAN 0x24
 
 /*
  * Special WHIRL section names.
@@ -101,6 +102,7 @@
 #define MIPS_WHIRL_DSL_EFFECT_IMAGE ".WHIRL.dsl_effects"
 #define MIPS_WHIRL_DSL_CALLSITE_IMAGE ".WHIRL.dsl_calls"
 #define MIPS_WHIRL_DSL_FHE_IMAGE ".WHIRL.dsl_fhe"
+#define MIPS_WHIRL_DSL_FHE_PLAN ".WHIRL.dsl_fhe_plan"
 #if defined(TARG_SL)
 #define MIPS_WHIRL_CALLGRAPH    ".WHIRL.callgraph"
 #endif

--- a/osprey/ir_tools/Makefile.gbase
+++ b/osprey/ir_tools/Makefile.gbase
@@ -189,6 +189,7 @@ COMMON_COM_CXX_SRC =	\
         dsl_domain.cxx	\
         dsl_fhe.cxx \
         dsl_fhe_plan.cxx \
+        dsl_fhe_plan_print.cxx \
         dsl_fhe_print.cxx \
         dsl_ir_image.cxx \
         dsl_ir_print.cxx \


### PR DESCRIPTION
## Summary

- add optional `WT_DSL_FHE_PLAN` / `.WHIRL.dsl_fhe_plan` ELF mapped-image write and read support on top of #108
- validate exact size and cross-table references before copying mapped rows into managed compiler tables
- expose stable logical FHE disposition, approximation, CKKS value-state, and BatchNorm-fold evidence through `ir_b2a -st -src`
- preserve pre-SYNC-3 and non-plan image behavior when the optional section is absent
- retain a focused `.B`/`.T` producer fixture with malformed-image checks and source cross-reference evidence

## Compatibility

The existing `.WHIRL.dsl_fhe` version and all earlier WN, TY, ST, opcode, and mapped-image layouts are unchanged. The new section is optional, uses the reviewed `0x24` section tag and 8-byte alignment, and is omitted when no planning rows exist.

## Validation

- linked `dsl_builder_contract_test`: passed
- `dsl_fhe_sync3_plan_image_test.sh`: passed through separate producer and `ir_b2a -st -src` processes
- legacy SYNC-1 FHE image reopen: passed with no plan table output
- `.WHIRL.dsl_fhe_plan` section: 8-byte aligned, 432-byte expected payload
- Linux `dsl_native_syntax_test.sh`: passed, including target layout matrix
- torch2whirl `python_native_test`: 148 tests passed
- `git diff --check` and added-line no-tab scan: passed

## Deferred

Opaque conversion attachment/rewrite APIs and `VHO_FHE_Convert_Driver()` remain Stage 2c/later work. This PR does not allocate FHE arithmetic opcodes, insert bootstrap, or lower to runtime calls.