### PR TITLE
Publish backend-safe tensor type interning

### DIFF
--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1813,6 +1813,24 @@ full-sequence causal prompt evaluation with no KV cache.
    linking. Existing builder, FHE planning-image, native-rewrite, and VHO
    conversion contract tests must then pass.
 
+36. [x] Publish backend-safe canonical tensor type interning.
+
+   Canonical TensorDescriptorIR identity belongs to the common `TY` service,
+   not to the frontend builder registry. Publish `TY_Intern_Tensor_Type()`
+   with a canonical descriptor input that includes kind, dtype, rank, logical
+   shape, semantic traits, layout, sharding, placement, memory, and
+   quantization. Runtime state and lineage remain value context and do not
+   participate in canonical `TY_IDX` equivalence.
+
+   Keep `DSL_Builder_Intern_Tensor_Type()` as a source-producer compatibility
+   wrapper over the common service. Backend FHE conversion, WOPT, IPA, VHO,
+   and later LNO transformations may use the common service without linking or
+   calling `DSL_Builder_*`. A regression test must prove that builder and
+   common callers deduplicate the same descriptor to the same canonical
+   `TY_IDX`; the `be.so` and `lw_inline` no-builder-symbol gates remain in
+   force. This introduces no new type kind, binary row, ELF section, or WHIRL
+   image revision.
+
 ### Deferred work TODO
 
 Deferred work remains tracked but does not block the active native DSL bring-up

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -2115,41 +2115,22 @@ DSL_Builder_Intern_Tensor_Type
          TY_IDX element_ty,
          const DSL_BUILDER_TENSOR_DESCRIPTOR *descriptor)
 {
-    DSL_BUILDER_TENSOR_DESCRIPTOR type_descriptor;
-    TY_IDX tensor_ty;
-
-    if (descriptor == NULL || TY_IDX_index(element_ty) == 0 ||
-        descriptor->type_core.kind == NULL ||
-        descriptor->type_core.kind[0] == '\0' ||
-        descriptor->type_core.dtype == NULL ||
-        descriptor->type_core.dtype[0] == '\0' ||
-        descriptor->type_core.rank < 0 ||
-        descriptor->type_core.logical_shape == NULL ||
-        descriptor->type_core.logical_shape[0] == '\0')
+    if (descriptor == NULL)
         return TY_IDX_ZERO;
 
-    type_descriptor = *descriptor;
-    type_descriptor.representation.runtime_state = NULL;
-    type_descriptor.lineage.lineage = NULL;
-    tensor_ty = DSL_Builder_Create_Tensor_Type_Core
-                    (name, element_ty, &type_descriptor.type_core);
-    if (!DSL_Builder_Attach_Tensor_Descriptor(tensor_ty, &type_descriptor) ||
-        !TY_tensor_seal(tensor_ty))
-        return TY_IDX_ZERO;
-
-    for (UINT32 index = 1; index < Ty_tab.Size(); ++index) {
-        TY_IDX candidate = TY_IDX_ZERO;
-        TY_TENSOR_EXTENSION_INFO candidate_info;
-        Set_TY_IDX_index(candidate, index);
-        if (!TY_Get_Tensor_Extension_Info(candidate, &candidate_info))
-            continue;
-        candidate = candidate_info.ty;
-        if (candidate != tensor_ty &&
-            TY_tensor_is_canonical(candidate) &&
-            TY_are_equivalent(candidate, tensor_ty, TY_EQUIV_IGNORE_NAMES))
-            return candidate;
-    }
-    return tensor_ty;
+    TY_TENSOR_CANONICAL_DESCRIPTOR canonical = {
+        descriptor->type_core.kind,
+        descriptor->type_core.dtype,
+        descriptor->type_core.rank,
+        descriptor->type_core.logical_shape,
+        descriptor->traits.traits,
+        descriptor->representation.layout,
+        descriptor->representation.sharding,
+        descriptor->representation.placement,
+        descriptor->representation.memory,
+        descriptor->representation.quantization
+    };
+    return TY_Intern_Tensor_Type(name, element_ty, &canonical);
 }
 
 BOOL

--- a/osprey/common/com/symtab.cxx
+++ b/osprey/common/com/symtab.cxx
@@ -686,6 +686,69 @@ TY_tensor_seal (TY_IDX ty)
     return TRUE;
 }
 
+static void
+TY_Tensor_Bind_Attribute_If_Present
+        (TY_IDX ty, TY_TENSOR_SCHEMA_KEY key, const char *value)
+{
+    if (value != NULL && value[0] != '\0')
+        TY_tensor_bind_attribute(ty, key, value);
+}
+
+TY_IDX
+TY_Intern_Tensor_Type
+        (const char *name,
+         TY_IDX element_ty,
+         const TY_TENSOR_CANONICAL_DESCRIPTOR *descriptor)
+{
+    char rank_buf[32];
+
+    if (descriptor == NULL || TY_IDX_index(element_ty) == 0 ||
+        descriptor->kind == NULL || descriptor->kind[0] == '\0' ||
+        descriptor->dtype == NULL || descriptor->dtype[0] == '\0' ||
+        descriptor->rank < 0 || descriptor->logical_shape == NULL ||
+        descriptor->logical_shape[0] == '\0')
+        return TY_IDX_ZERO;
+
+    TY_IDX tensor_ty = TY_Create_Tensor_Type
+                           (name, element_ty, descriptor->rank);
+    snprintf(rank_buf, sizeof(rank_buf), "%d", descriptor->rank);
+    TY_tensor_bind_attribute
+        (tensor_ty, TY_TENSOR_SCHEMA_KIND, descriptor->kind);
+    TY_tensor_bind_attribute
+        (tensor_ty, TY_TENSOR_SCHEMA_DTYPE, descriptor->dtype);
+    TY_tensor_bind_attribute
+        (tensor_ty, TY_TENSOR_SCHEMA_RANK, rank_buf);
+    TY_tensor_bind_attribute
+        (tensor_ty, TY_TENSOR_SCHEMA_SHAPE, descriptor->logical_shape);
+    TY_Tensor_Bind_Attribute_If_Present
+        (tensor_ty, TY_TENSOR_SCHEMA_TRAITS, descriptor->traits);
+    TY_Tensor_Bind_Attribute_If_Present
+        (tensor_ty, TY_TENSOR_SCHEMA_LAYOUT, descriptor->layout);
+    TY_Tensor_Bind_Attribute_If_Present
+        (tensor_ty, TY_TENSOR_SCHEMA_SHARDING, descriptor->sharding);
+    TY_Tensor_Bind_Attribute_If_Present
+        (tensor_ty, TY_TENSOR_SCHEMA_PLACEMENT, descriptor->placement);
+    TY_Tensor_Bind_Attribute_If_Present
+        (tensor_ty, TY_TENSOR_SCHEMA_MEMORY, descriptor->memory);
+    TY_Tensor_Bind_Attribute_If_Present
+        (tensor_ty, TY_TENSOR_SCHEMA_QUANTIZATION, descriptor->quantization);
+    if (!TY_tensor_seal(tensor_ty))
+        return TY_IDX_ZERO;
+
+    for (UINT32 index = 1; index < Ty_tab.Size(); ++index) {
+        TY_IDX candidate = TY_IDX_ZERO;
+        TY_TENSOR_EXTENSION_INFO candidate_info;
+        Set_TY_IDX_index(candidate, index);
+        if (!TY_Get_Tensor_Extension_Info(candidate, &candidate_info))
+            continue;
+        candidate = candidate_info.ty;
+        if (candidate != tensor_ty && TY_tensor_is_canonical(candidate) &&
+            TY_are_equivalent(candidate, tensor_ty, TY_EQUIV_IGNORE_NAMES))
+            return candidate;
+    }
+    return tensor_ty;
+}
+
 UINT32
 TY_tensor_unbound_required_attribute_count
         (TY_IDX ty, const TY_TENSOR_SCHEMA_KEY *required, UINT32 required_count)

--- a/osprey/common/com/symtab.h
+++ b/osprey/common/com/symtab.h
@@ -512,6 +512,24 @@ struct TY_TENSOR_EXTENSION_INFO {
 };
 
 /*
+ * Canonical TensorDescriptorIR input for type-system clients. Runtime state
+ * and lineage are value context and are deliberately excluded from canonical
+ * TY identity.
+ */
+struct TY_TENSOR_CANONICAL_DESCRIPTOR {
+    const char *kind;
+    const char *dtype;
+    INT32 rank;
+    const char *logical_shape;
+    const char *traits;
+    const char *layout;
+    const char *sharding;
+    const char *placement;
+    const char *memory;
+    const char *quantization;
+};
+
+/*
  * Source-level TensorDescriptorIR probe.
  *
  * These IDs and records describe the future fixed descriptor shape, but they do
@@ -599,6 +617,10 @@ extern BOOL TY_tensor_attribute_at (TY_IDX ty, UINT32 ordinal,
 extern BOOL TY_tensor_attributes_are_equivalent (TY_IDX ty1, TY_IDX ty2);
 extern BOOL TY_tensor_is_canonical (TY_IDX ty);
 extern BOOL TY_tensor_seal (TY_IDX ty);
+extern TY_IDX TY_Intern_Tensor_Type
+                            (const char *name,
+                             TY_IDX element_ty,
+                             const TY_TENSOR_CANONICAL_DESCRIPTOR *descriptor);
 extern UINT32 TY_tensor_unbound_required_attribute_count
 				    (TY_IDX ty,
 				     const TY_TENSOR_SCHEMA_KEY *required,

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -75,13 +75,17 @@ Check_Tensor_Type_And_Descriptor(void)
 {
     DSL_BUILDER_TENSOR_TYPE_CORE type_core;
     DSL_BUILDER_TENSOR_DESCRIPTOR descriptor;
+    TY_TENSOR_CANONICAL_DESCRIPTOR canonical_descriptor;
     TY_IDX tensor_ty;
     TY_IDX extension_ty;
+    TY_IDX common_service_ty;
+    TY_IDX builder_service_ty;
     TENSOR_DESCRIPTOR_RECORD record;
     int failed = 0;
 
     memset(&type_core, 0, sizeof(type_core));
     memset(&descriptor, 0, sizeof(descriptor));
+    memset(&canonical_descriptor, 0, sizeof(canonical_descriptor));
 
     type_core.kind = "tensor";
     type_core.dtype = "int32";
@@ -145,6 +149,31 @@ Check_Tensor_Type_And_Descriptor(void)
         record.rank != 2 ||
         record.attribute_count != TY_tensor_attribute_count(tensor_ty)) {
         fprintf(stderr, "builder tensor descriptor record is inconsistent\n");
+        failed = 1;
+    }
+
+    canonical_descriptor.kind = descriptor.type_core.kind;
+    canonical_descriptor.dtype = descriptor.type_core.dtype;
+    canonical_descriptor.rank = descriptor.type_core.rank;
+    canonical_descriptor.logical_shape = descriptor.type_core.logical_shape;
+    canonical_descriptor.traits = descriptor.traits.traits;
+    canonical_descriptor.layout = descriptor.representation.layout;
+    canonical_descriptor.sharding = descriptor.representation.sharding;
+    canonical_descriptor.placement = descriptor.representation.placement;
+    canonical_descriptor.memory = descriptor.representation.memory;
+    canonical_descriptor.quantization =
+        descriptor.representation.quantization;
+    common_service_ty = TY_Intern_Tensor_Type
+                            ("common_tensor_intern_contract",
+                             MTYPE_To_TY(MTYPE_I4),
+                             &canonical_descriptor);
+    builder_service_ty = DSL_Builder_Intern_Tensor_Type
+                             ("builder_tensor_intern_contract",
+                              MTYPE_To_TY(MTYPE_I4), &descriptor);
+    if (common_service_ty == TY_IDX_ZERO ||
+        builder_service_ty != common_service_ty ||
+        !TY_tensor_is_canonical(common_service_ty)) {
+        fprintf(stderr, "common and builder tensor interning diverged\n");
         failed = 1;
     }
 


### PR DESCRIPTION
## Summary

- add a backend-safe TY_Intern_Tensor_Type service for canonical TensorDescriptorIR construction
- keep DSL_Builder_Intern_Tensor_Type as a producer compatibility wrapper
- preserve canonical equivalence: runtime state and lineage remain value context
- prove common and builder callers deduplicate to the same TY_IDX
- document the service as the FHE SYNC-3 backend boundary

No type kind, opcode, mapped-image row, ELF section, or WHIRL image revision changes.

## Motivation

The FHE semantic conversion pass needs a small rank-1 float32 coefficient tensor for the common.relu polynomial approximation contract. Calling DSL_Builder_Intern_Tensor_Type from be.so violates the producer/backend boundary enforced by PR #112. Direct TY table mutation from the pass would violate the reviewed common-service boundary.

## Validation

- Linux DSL syntax and physical operator-layout matrix passed
- focused tensor descriptor/interning contract passed
- be.so rebuilt and contains no DSL_Builder symbols
- lw_inline rebuilt and passed its no-DSL_Builder symbol gate
- git diff --check passed
- no tabs introduced

This PR is the prerequisite for completing the FHE-owned SYNC-3 ResNet-20 conversion evidence.