### PR TITLE
Admit ResNet linear in FHE wrapper plan

### DIFF
--- a/doc/FHE-SYNC3-NATIVE-PLAN-CONTRACT.md
+++ b/doc/FHE-SYNC3-NATIVE-PLAN-CONTRACT.md
@@ -67,6 +67,14 @@ future operation with genuinely new expression semantics, including
 
 On image load, a nonempty wrapper name must resolve through the domain-wrapper
 registry, and its wrapper target must match the source node's logical operator.
+
+`fhe.cnn.linear` has two append-only wrapper identities. The original
+`fhe.cnn.linear.v1` continues to target the two-kid rank-generic
+`common.linear.v3` contract. `fhe.cnn.linear.v2` targets the three-kid
+`common.linear.v2` contract used by the certified ResNet capture. Conversion
+selects the wrapper version from the source logical operator version; the two
+wrapper versions may coexist in one program and neither reinterprets the
+other's persisted planning-image rows.
 The mapped image stores the stable name and version, never the runtime-assigned
 `DSL_OPCODE_ID`.
 

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1831,6 +1831,15 @@ full-sequence causal prompt evaluation with no KV cache.
    force. This introduces no new type kind, binary row, ELF section, or WHIRL
    image revision.
 
+37. [x] Admit both published `common.linear` contracts in FHE conversion.
+
+   Preserve `fhe.cnn.linear.v1` as the wrapper for `common.linear.v3`. Add the
+   append-only `fhe.cnn.linear.v2` wrapper for the three-kid
+   `common.linear.v2` contract used by the certified ResNet capture. Publish
+   named wrapper-version constants and prove both mappings coexist with their
+   original logical targets. This changes no WN encoding, planning-image row,
+   ELF section, or image revision.
+
 ### Deferred work TODO
 
 Deferred work remains tracked but does not block the active native DSL bring-up

--- a/osprey/common/com/dsl_fhe_plan.cxx
+++ b/osprey/common/com/dsl_fhe_plan.cxx
@@ -463,20 +463,25 @@ DSL_FHE_Plan_Register_Domain_Wrappers (void)
 {
     typedef struct {
         const char *wrapper_name;
+        UINT16 wrapper_version;
         const char *target_domain;
         const char *target_name;
         UINT16 target_version;
         const char *diagnostic_prefix;
     } DSL_FHE_WRAPPER_SEED;
     static const DSL_FHE_WRAPPER_SEED seeds[] = {
-        { DSL_FHE_WRAPPER_CNN_CONV2D, "cnn", "cnn.conv2d", 2,
+        { DSL_FHE_WRAPPER_CNN_CONV2D, 1, "cnn", "cnn.conv2d", 2,
           "CFHECNN_CONV2D" },
-        { DSL_FHE_WRAPPER_CNN_RESIDUAL_ADD, "common",
+        { DSL_FHE_WRAPPER_CNN_RESIDUAL_ADD, 1, "common",
           "common.residual_add", 2, "CFHECNN_RESIDUAL_ADD" },
-        { DSL_FHE_WRAPPER_CNN_GLOBAL_AVG_POOL2D, "cnn",
+        { DSL_FHE_WRAPPER_CNN_GLOBAL_AVG_POOL2D, 1, "cnn",
           "cnn.global_avg_pool2d", 2, "CFHECNN_GLOBAL_AVG_POOL2D" },
-        { DSL_FHE_WRAPPER_CNN_LINEAR, "common", "common.linear", 3,
-          "CFHECNN_LINEAR" }
+        { DSL_FHE_WRAPPER_CNN_LINEAR,
+          DSL_FHE_WRAPPER_CNN_LINEAR_COMMON_V3_VERSION,
+          "common", "common.linear", 3, "CFHECNN_LINEAR" },
+        { DSL_FHE_WRAPPER_CNN_LINEAR,
+          DSL_FHE_WRAPPER_CNN_LINEAR_COMMON_V2_VERSION,
+          "common", "common.linear", 2, "CFHECNN_LINEAR_V2" }
     };
     UINT32 registered = 0;
 
@@ -500,7 +505,8 @@ DSL_FHE_Plan_Register_Domain_Wrappers (void)
                                    (target_domain, seeds[i].target_name,
                                     seeds[i].target_version);
         DSL_OPCODE_ID wrapper = DSL_Opcode_Register_Domain_Wrapper
-                                    (fhe_cnn_id, seeds[i].wrapper_name, 1,
+                                    (fhe_cnn_id, seeds[i].wrapper_name,
+                                     seeds[i].wrapper_version,
                                      target, seeds[i].diagnostic_prefix, 0);
         if (wrapper != DSL_OPCODE_INVALID_ID)
             ++registered;

--- a/osprey/common/com/dsl_fhe_plan.h
+++ b/osprey/common/com/dsl_fhe_plan.h
@@ -30,6 +30,14 @@
 #define DSL_FHE_WRAPPER_CNN_LINEAR \
     "fhe.cnn.linear"
 
+/*
+ * Wrapper versions are append-only compatibility identities. Version 1 was
+ * published for common.linear.v3; version 2 admits the earlier three-kid
+ * common.linear.v2 contract used by the certified ResNet capture.
+ */
+#define DSL_FHE_WRAPPER_CNN_LINEAR_COMMON_V3_VERSION 1
+#define DSL_FHE_WRAPPER_CNN_LINEAR_COMMON_V2_VERSION 2
+
 typedef UINT32 DSL_FHE_CONVERSION_DISPOSITION_ID;
 typedef UINT32 DSL_FHE_APPROXIMATION_CONTRACT_ID;
 typedef UINT32 DSL_FHE_BN_FOLD_PROVENANCE_ID;

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -5158,6 +5158,13 @@ Check_FHE_SYNC3_Plan_Image(void)
     TY_IDX channel_parameter_ty;
     TY_IDX coefficient_ty;
     DSL_DOMAIN_ID cnn_id;
+    DSL_DOMAIN_ID common_id;
+    DSL_DOMAIN_ID fhe_cnn_id;
+    DSL_OPCODE_ID common_linear_v2;
+    DSL_OPCODE_ID common_linear_v3;
+    DSL_OPCODE_ID fhe_linear_v1;
+    DSL_OPCODE_ID fhe_linear_v2;
+    DSL_OPCODE_INFO wrapper_info;
     UINT32 file_id;
     BOOL positions_set;
     int failed = 0;
@@ -5182,6 +5189,33 @@ Check_FHE_SYNC3_Plan_Image(void)
         return 1;
     DSL_Opcode_Register_Domain_Wrapper_Examples();
     cnn_id = DSL_Domain_Find("cnn");
+    common_id = DSL_Domain_Find("common");
+    FHE_SYNC3_CHECK
+        (DSL_FHE_Plan_Register_Domain_Wrappers() == 5,
+         "FHE domain-wrapper registration");
+    fhe_cnn_id = DSL_Domain_Find("fhe.cnn");
+    common_linear_v2 = DSL_Opcode_Find
+                           (common_id, "common.linear", 2);
+    common_linear_v3 = DSL_Opcode_Find
+                           (common_id, "common.linear", 3);
+    fhe_linear_v1 = DSL_Opcode_Find
+                        (fhe_cnn_id, DSL_FHE_WRAPPER_CNN_LINEAR,
+                         DSL_FHE_WRAPPER_CNN_LINEAR_COMMON_V3_VERSION);
+    fhe_linear_v2 = DSL_Opcode_Find
+                        (fhe_cnn_id, DSL_FHE_WRAPPER_CNN_LINEAR,
+                         DSL_FHE_WRAPPER_CNN_LINEAR_COMMON_V2_VERSION);
+    FHE_SYNC3_CHECK
+        (common_linear_v2 != DSL_OPCODE_INVALID_ID &&
+         common_linear_v3 != DSL_OPCODE_INVALID_ID &&
+         fhe_linear_v1 != DSL_OPCODE_INVALID_ID &&
+         fhe_linear_v2 != DSL_OPCODE_INVALID_ID &&
+         DSL_Opcode_Get_Info(fhe_linear_v1, &wrapper_info) &&
+         wrapper_info.wrapper_target_id == common_linear_v3,
+         "fhe.cnn.linear.v1 preserves common.linear.v3 target");
+    FHE_SYNC3_CHECK
+        (DSL_Opcode_Get_Info(fhe_linear_v2, &wrapper_info) &&
+         wrapper_info.wrapper_target_id == common_linear_v2,
+         "fhe.cnn.linear.v2 targets common.linear.v2");
 
     memset(&descriptor, 0, sizeof(descriptor));
     descriptor.type_core.kind = "tensor";


### PR DESCRIPTION
## Summary

- preserve the published `fhe.cnn.linear.v1 -> common.linear.v3` mapping
- add append-only `fhe.cnn.linear.v2 -> common.linear.v2` support for the certified ResNet capture
- publish named wrapper-version constants and make wrapper seed versions explicit
- prove both wrapper identities coexist and resolve to their intended logical operators
- document the compatibility contract and completed infrastructure item

## Motivation

SYNC-3 ResNet conversion reached the registered semantic pass but failed closed at node 173 because the capture contains three-kid `common.linear.v2`, while the only published FHE wrapper targeted two-kid `common.linear.v3`.

Changing v1 would reinterpret existing planning-image rows. This PR keeps v1 unchanged and allocates v2 for the earlier source contract. Persisted rows already carry `(wrapper_name, wrapper_version)`, so no binary layout or image revision is required.

## Compatibility

No WN encoding, DSL operator encoding, mapped-image row, ELF section, or image revision changes.

The FHE consumer task reviewed and accepted this contract. Unsupported future `common.linear` versions continue to fail closed.

## Validation

- Linux native DSL syntax matrix passed
- x8664, MIPS, MIPS little-endian, KEY generic, Loongson, and baseline operator-layout checks passed
- WOPT DSL semantic-info contract passed
- linked FHE SYNC-3 planning-image contract passed
- generated binary WHIRL reopened through `ir_b2a -st -src`
- `git diff --check` and no-tab checks passed

Retained local evidence:

- `/private/tmp/open64-fhe-linear-v2-wrapper/artifacts/fhe/linear-v2-wrapper/fhe_sync3_plan_contract.B`
- `/private/tmp/open64-fhe-linear-v2-wrapper/artifacts/fhe/linear-v2-wrapper/fhe_sync3_plan_contract.T`
- `/private/tmp/open64-fhe-linear-v2-wrapper/artifacts/fhe/linear-v2-wrapper/validation.log`
- `/private/tmp/open64-fhe-linear-v2-wrapper/artifacts/fhe/linear-v2-wrapper/commands.txt`
