### PR TITLE
Add all-PU FHE conversion checkpoint

### DIFF
--- a/doc/FHE-CONSOLIDATED-IMPLEMENTATION-PLAN.md
+++ b/doc/FHE-CONSOLIDATED-IMPLEMENTATION-PLAN.md
@@ -346,12 +346,22 @@ Required phase output:
 secure_resnet20.B
   -> ordinary DSL/common gatekeeper
   -> FHE semantic gatekeeper
-  -> VHO_FHE_Convert_Driver()
+  -> -FHE:checkpoint=secure_resnet20.fhe.B
+  -> VHO_FHE_Convert_Driver_Try() for every selected PU
   -> FHE semantic gatekeeper, converted form
+  -> complete managed-image validation
+  -> standard Write_PU_Info()/Write_Global_Info() binary WHIRL path
   -> secure_resnet20.fhe.B
   -> ir_b2a -st -src secure_resnet20.fhe.B secure_resnet20.fhe.T
   -> secure_resnet20.fhe.conversion-report.txt
 ```
+
+The checkpoint is conversion-only. It deliberately returns before ordinary
+DSL and language VHO lowering and before WOPT/LNO/CG. Each converted PU is
+written while its own local symbol table is active; the requested final path
+is published atomically only after all PUs and complete managed images pass.
+This main/backend-owned service prevents the FHE task from duplicating raw
+PU traversal, symbol-table lifetime, mapped-image, or writer orchestration.
 
 Acceptance checks:
 

--- a/doc/FHE-SYNC3-NATIVE-PLAN-CONTRACT.md
+++ b/doc/FHE-SYNC3-NATIVE-PLAN-CONTRACT.md
@@ -1,6 +1,7 @@
 # Open64 FHE SYNC-3 Native Planning-Image Contract
 
-Status: Stage 3 VHO phase substrate implemented after PR #110, pending review
+Status: Stage 3 VHO phase and all-PU conversion-checkpoint substrate
+implemented, pending review
 
 Semantic authority:
 
@@ -631,6 +632,10 @@ ciphertext bytes, or backend object state.
    `VHO_DSL_Lower_Driver()`.
 6. Hand the merged APIs to the FHE task for semantic gatekeeper, BatchNorm
    folding, conversion reports, and retained ResNet-20 artifacts.
+7. Add a backend-owned all-PU conversion checkpoint that writes each converted
+   PU while its local symbol table is active, validates the complete managed
+   image after traversal, and atomically publishes a binary WHIRL artifact
+   before ordinary DSL or language lowering.
 
 Stage 5 is implemented by the Stage 3 infrastructure PR. The public option
 surface is:
@@ -640,7 +645,9 @@ surface is:
 - `-FHE:strict_o0=on|off`, enabled by default so the conversion pass can
   distinguish mandatory semantic adaptation from optional optimization;
 - `-FHE:dump_before=on|off`; and
-- `-FHE:dump_after=on|off`.
+- `-FHE:dump_after=on|off`;
+- `-FHE:checkpoint=<path>`, which selects conversion-only certification and
+  names the binary WHIRL output.
 
 `VHO_FHE_Convert_Program_Unit()` performs the structural DSL/FHE/FHE-plan
 gate, invokes the registered semantic gatekeeper, invokes the registered
@@ -656,6 +663,51 @@ Until the FHE semantic implementation is linked, enabling conversion for an
 artifact that contains FHE records fails with `CFHE-CONVERT-001` instead of
 silently lowering away FHE semantics. Non-FHE and legacy artifacts remain
 unchanged even though the option defaults to enabled.
+
+### All-PU Conversion Checkpoint
+
+`-FHE:checkpoint=<path>` is an explicit file-level certification mode. It may
+run the option-controlled DSL WOPT/Preopt preparation, then invokes
+`VHO_FHE_Convert_Driver_Try()` exactly once for every PU. It does not
+run `VHO_DSL_Lower_Driver()`, language VHO lowering, WOPT/LNO/CG, whirl2c, or
+whirl2f after conversion. Unrelated phase options continue to be accepted and
+are silently ignored in this mode according to the Open64 phase-option
+convention.
+
+`VHO_FHE_Convert_Driver_With_Result()` remains the public ordinary-pipeline
+helper that returns the per-PU counters and preserves the established
+fail-closed assertion. `VHO_FHE_Convert_Driver()` remains its source-compatible
+wrapper for callers that do not need the result.
+
+The backend owns traversal and file construction. While each PU and its local
+symbol table are selected, it verifies the tree and symbol table and calls the
+standard `Write_PU_Info()` service. After all PUs have succeeded, it aggregates
+the `VHO_FHE_CONVERT_RESULT` counters and calls
+`VHO_FHE_Convert_Checkpoint_Validate()` to prove that every expected PU was
+converted without an error and that the complete DSL, effect, call, FHE, and
+FHE-plan images are valid. It then calls the standard `Write_Global_Info()`
+and closes the binary WHIRL image.
+
+The writer initially uses `<path>.tmp` in the destination directory. Only a
+fully converted, validated, and closed file is atomically renamed to `<path>`.
+A failed run removes the temporary file and never publishes a partial artifact
+under the requested checkpoint name. The FHE semantic task consumes this
+mode; it must not reproduce PU selection, local-symbol-table lifetime, managed
+image validation, or binary writer orchestration.
+
+The retained integration fixture is
+`osprey/common/com/tests/dsl_fhe_conversion_checkpoint_test.sh`. It requires a
+reviewed multi-PU input, reopens the checkpoint with `ir_b2a -st -src`, checks
+the expected `FUNC_ENTRY` count, and stages the source named by
+`OPEN64_FHE_CHECKPOINT_SOURCE` beside the artifact for source-interleaved
+inspection. It may also prove fail-closed behavior with an FHE-bearing input
+when semantic conversion support is intentionally absent.
+
+Stable checkpoint diagnostics are `CFHE-CHECKPOINT-001` for incomplete PU
+coverage, `CFHE-CHECKPOINT-002` for aggregated conversion errors, and
+`CFHE-CHECKPOINT-003` for an invalid complete managed image. A successful run
+reports PU, semantic-gate, pass, disposition, rewrite, BatchNorm-fold,
+approximation, and error counts.
 
 No bootstrap insertion, SIHE/CKKS arithmetic opcode allocation,
 `fhe.cnn.poly_activation` emission, OpenFHE/runtime lowering, or generated-C

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1840,6 +1840,25 @@ full-sequence causal prompt evaluation with no KV cache.
    original logical targets. This changes no WN encoding, planning-image row,
    ELF section, or image revision.
 
+38. [x] Add an all-PU FHE conversion-only binary WHIRL checkpoint.
+
+   The per-PU backend pipeline cannot publish a complete converted artifact by
+   stopping after the first `VHO_FHE_Convert_Driver()` call: local symbol
+   tables are selected and released one PU at a time, and ordinary DSL lowering
+   immediately follows conversion. Add `-FHE:checkpoint=<path>` as an explicit
+   certification mode. It preserves optional DSL WOPT/Preopt, converts every
+   PU, writes each PU through `Write_PU_Info()` while its local symbol table is
+   active, aggregates conversion results, and validates the complete managed
+   DSL/effect/call/FHE/FHE-plan images.
+
+   Only after all-PU success may the driver call `Write_Global_Info()`, close
+   the standard binary WHIRL output, and atomically rename `<path>.tmp` to the
+   requested path. The mode returns before `VHO_DSL_Lower_Driver()`, language
+   VHO lowering, WOPT/LNO/CG, and source translation. Failed conversion must
+   not publish a partial `.fhe.B`. This is backend orchestration; FHE semantic
+   code must continue to use the registered gatekeeper/pass APIs and must not
+   reproduce PU, symbol-table, or writer management.
+
 ### Deferred work TODO
 
 Deferred work remains tracked but does not block the active native DSL bring-up

--- a/osprey/be/be/driver.cxx
+++ b/osprey/be/be/driver.cxx
@@ -71,6 +71,9 @@
 #endif /* ! defined(BUILD_OS_DARWIN) */
 #include <cmplrs/rcodes.h>
 #include <dirent.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
 #ifndef __MINGW32__
 #include <libgen.h>
 #endif
@@ -420,7 +423,11 @@ static INT total_pu_count;
 static BOOL need_wopt_output = FALSE;
 static BOOL need_lno_output = FALSE;
 static BOOL need_ipl_output = FALSE;
+static BOOL need_fhe_checkpoint_output = FALSE;
 static Output_File *ir_output = 0;
+static char *fhe_checkpoint_temp_name = NULL;
+static UINT32 fhe_checkpoint_pu_count;
+static VHO_FHE_CONVERT_RESULT fhe_checkpoint_result;
 
 // options stack for PU and region level pragmas
 static OPTIONS_STACK *Options_Stack;
@@ -443,15 +450,50 @@ FILE *DFile = stderr;
 
 extern char *Processor_Name;
 
+static BOOL
+FHE_Conversion_Checkpoint_Enabled (void)
+{
+  return VHO_FHE_Conversion_Checkpoint_Output != NULL &&
+         VHO_FHE_Conversion_Checkpoint_Output[0] != '\0';
+}
+
+static void
+Open_FHE_Conversion_Checkpoint (void)
+{
+  const char *output = VHO_FHE_Conversion_Checkpoint_Output;
+  size_t length = strlen(output) + sizeof(".tmp");
+
+  fhe_checkpoint_temp_name = (char *)malloc(length);
+  FmtAssert(fhe_checkpoint_temp_name != NULL,
+            ("could not allocate FHE checkpoint pathname"));
+  snprintf(fhe_checkpoint_temp_name, length, "%s.tmp", output);
+  remove(fhe_checkpoint_temp_name);
+
+  VHO_FHE_Convert_Result_Init(&fhe_checkpoint_result);
+  fhe_checkpoint_pu_count = 0;
+  need_fhe_checkpoint_output = TRUE;
+  ir_output = Open_Output_Info(fhe_checkpoint_temp_name);
+  FmtAssert(ir_output != NULL,
+            ("could not open FHE checkpoint output %s",
+             fhe_checkpoint_temp_name));
+}
+
 static void
 load_components (INT argc, char **argv)
 {
     INT phase_argc;
     char **phase_argv;
 
+    if (FHE_Conversion_Checkpoint_Enabled()) {
+      Run_lno = Run_autopar = Run_Distr_Array = FALSE;
+      Run_preopt = Run_wopt = Run_vsaopt = Run_ipsaopt = FALSE;
+      Run_cg = Run_w2c = Run_w2f = Run_w2fc_early = Run_ipl = FALSE;
+    }
+
     if (!(Run_lno || (Run_wopt || (Run_vsaopt || Run_ipsaopt))
 	  || Run_preopt || Run_cg || Run_w2c || Run_w2f
-          || Run_w2fc_early || Run_ipl))
+          || Run_w2fc_early || Run_ipl) &&
+        !FHE_Conversion_Checkpoint_Enabled())
       Run_cg = TRUE;		    /* if nothing is set, run CG */
 
     if (Run_cg || Run_lno || Run_autopar) {
@@ -594,7 +636,11 @@ Phase_Init (void)
 	    output_file_name = Irb_File_Name;
     }
 
-    if (need_lno_output) {
+    if (FHE_Conversion_Checkpoint_Enabled()) {
+        Write_BE_Maps = FALSE;
+        Open_FHE_Conversion_Checkpoint();
+    }
+    if (!need_fhe_checkpoint_output && need_lno_output) {
 	Write_BE_Maps = TRUE;
 	// Output IR after preopt to .P file, and IR after LNO to .N file.
 	if (Run_lno)
@@ -602,18 +648,18 @@ Phase_Init (void)
 	else
 	    ir_output = Open_Output_Info(New_Extension(output_file_name,".P"));
     }
-    if (need_wopt_output) {
+    if (!need_fhe_checkpoint_output && need_wopt_output) {
 	Write_ALIAS_CLASS_Map = TRUE;
 	Write_BE_Maps = TRUE;
 	ir_output = Open_Output_Info(New_Extension(output_file_name,".O"));
     }
-    if (need_ipl_output) {
+    if (!need_fhe_checkpoint_output && need_ipl_output) {
 	Write_BE_Maps = FALSE;
 	ir_output = Open_Output_Info (Obj_File_Name ?
 				      Obj_File_Name :
 				      New_Extension(output_file_name, ".o"));
     }
-    if (Emit_Global_Data) {
+    if (!need_fhe_checkpoint_output && Emit_Global_Data) {
 	Write_BE_Maps = FALSE;
 	ir_output = Open_Output_Info (Global_File_Name);
     }
@@ -1835,10 +1881,36 @@ Preprocess_PU (PU_Info *current_pu)
   }
 
   if (!w2c_only) {
+    VHO_FHE_CONVERT_RESULT convert_result;
     Set_Error_Phase ( "FHE VHO Conversion" );
-    pu = VHO_FHE_Convert_Driver (current_pu, pu);
+    if (need_fhe_checkpoint_output) {
+      BOOL converted = VHO_FHE_Convert_Driver_Try
+                           (current_pu, &pu, &convert_result);
+      VHO_FHE_Convert_Result_Accumulate
+          (&fhe_checkpoint_result, &convert_result);
+      if (!converted) {
+        fprintf(stderr,
+                "CFHE-CHECKPOINT-002: conversion failed before all-PU "
+                "checkpoint completion\n");
+        Close_Output_Info();
+        remove(fhe_checkpoint_temp_name);
+        FmtAssert(FALSE, ("FHE conversion checkpoint failed"));
+      }
+      ++fhe_checkpoint_pu_count;
+    }
+    else {
+      pu = VHO_FHE_Convert_Driver_With_Result
+               (current_pu, pu, &convert_result);
+    }
     Set_PU_Info_tree_ptr(current_pu, pu);
     Check_for_IR_Dump(TP_GLOBOPT, pu, "FHE_CONVERT");
+
+    if (need_fhe_checkpoint_output) {
+      if (wopt_loaded)
+        Create_Restricted_Map(MEM_pu_nz_pool_ptr);
+      REGION_Initialize(pu, PU_has_region(Get_Current_PU()));
+      return pu;
+    }
 
     Set_Error_Phase ( "DSL VHO Processing" );
     pu = VHO_DSL_Lower_Driver (current_pu, pu);
@@ -1960,28 +2032,34 @@ Preorder_Process_PUs (PU_Info *current_pu)
 
   Verify_SYMTAB (CURRENT_SYMTAB);
 
-  if (!PU_mp (Get_Current_PU ()) &&
-      (Run_Dsm_Cloner || Run_Dsm_Common_Check || Run_Dsm_Check))
-    DRA_Processing(current_pu, pu, Cur_PU_Feedback != NULL);
-
-  /* If SYMTAB_IPA_on is set then we have run ipl,
-   * and therefore already done OMP_prelowering.
-   * So don't do it again.
-   */
-  if (PU_has_mp (Get_Current_PU ()) && !FILE_INFO_ipa (File_info)) {
-    Set_Error_Phase("OMP Pre-lowering");
-    WB_OMP_Initialize(pu);
-    pu = OMP_Prelower(current_pu, pu);
-    WB_OMP_Terminate(); 
-  }
-
-  if (Run_ipl) {
-    Ipl_Processing (current_pu, pu);
-    Verify_SYMTAB (CURRENT_SYMTAB);
+  if (need_fhe_checkpoint_output) {
+    Set_PU_Info_tree_ptr(current_pu, pu);
+    Write_PU_Info(current_pu);
   }
   else {
-    Backend_Processing (current_pu, pu);
-    Verify_SYMTAB (CURRENT_SYMTAB);
+    if (!PU_mp (Get_Current_PU ()) &&
+        (Run_Dsm_Cloner || Run_Dsm_Common_Check || Run_Dsm_Check))
+      DRA_Processing(current_pu, pu, Cur_PU_Feedback != NULL);
+
+    /* If SYMTAB_IPA_on is set then we have run ipl,
+     * and therefore already done OMP_prelowering.
+     * So don't do it again.
+     */
+    if (PU_has_mp (Get_Current_PU ()) && !FILE_INFO_ipa (File_info)) {
+      Set_Error_Phase("OMP Pre-lowering");
+      WB_OMP_Initialize(pu);
+      pu = OMP_Prelower(current_pu, pu);
+      WB_OMP_Terminate();
+    }
+
+    if (Run_ipl) {
+      Ipl_Processing (current_pu, pu);
+      Verify_SYMTAB (CURRENT_SYMTAB);
+    }
+    else {
+      Backend_Processing (current_pu, pu);
+      Verify_SYMTAB (CURRENT_SYMTAB);
+    }
   }
   if (reset_opt_level) {
     Opt_Level = orig_opt_level;
@@ -2286,7 +2364,7 @@ main (INT argc, char **argv)
   }
   BOOL needs_lno = FILE_INFO_needs_lno (File_info);
 
-  if (needs_lno && !Run_ipl) {
+  if (needs_lno && !Run_ipl && !FHE_Conversion_Checkpoint_Enabled()) {
     Run_Distr_Array = TRUE;
     if (!Run_lno && !Run_autopar) {
       /* ipl is not running, and LNO has not been loaded */
@@ -2421,7 +2499,45 @@ main (INT argc, char **argv)
   BE_symtab_free_be_scopes();
 
   
-  if (need_wopt_output || need_lno_output || need_ipl_output) {
+  if (need_fhe_checkpoint_output) {
+    BOOL valid = VHO_FHE_Convert_Checkpoint_Validate
+                     (total_pu_count, fhe_checkpoint_pu_count,
+                      &fhe_checkpoint_result, stderr);
+    if (!valid) {
+      Close_Output_Info();
+      remove(fhe_checkpoint_temp_name);
+      FmtAssert(FALSE, ("FHE conversion checkpoint validation failed"));
+    }
+
+    Write_Global_Info(pu_tree);
+    Close_Output_Info();
+    if (rename(fhe_checkpoint_temp_name,
+               VHO_FHE_Conversion_Checkpoint_Output) != 0) {
+      INT rename_error = errno;
+      remove(fhe_checkpoint_temp_name);
+      FmtAssert(FALSE,
+                ("could not publish FHE conversion checkpoint %s: %s",
+                 VHO_FHE_Conversion_Checkpoint_Output,
+                 strerror(rename_error)));
+    }
+    fprintf(stderr,
+            "FHE conversion checkpoint: output=%s pu=%u "
+            "semantic_gates=%u passes=%u source=%u converted=%u "
+            "rewritten=%u batch_norm=%u approximations=%u errors=%u\n",
+            VHO_FHE_Conversion_Checkpoint_Output,
+            fhe_checkpoint_pu_count,
+            fhe_checkpoint_result.semantic_gatekeeper_count,
+            fhe_checkpoint_result.conversion_pass_count,
+            fhe_checkpoint_result.source_disposition_count,
+            fhe_checkpoint_result.converted_disposition_count,
+            fhe_checkpoint_result.rewritten_value_count,
+            fhe_checkpoint_result.folded_batch_norm_count,
+            fhe_checkpoint_result.approximation_contract_count,
+            fhe_checkpoint_result.error_count);
+    free(fhe_checkpoint_temp_name);
+    fhe_checkpoint_temp_name = NULL;
+  }
+  else if (need_wopt_output || need_lno_output || need_ipl_output) {
     Write_Global_Info (pu_tree);
     if (need_ipl_output)
       Ipl_Extra_Output (ir_output);

--- a/osprey/be/vho/fhe_convert.cxx
+++ b/osprey/be/vho/fhe_convert.cxx
@@ -9,6 +9,7 @@
 #include "dsl_fhe.h"
 #include "dsl_fhe_plan.h"
 #include "dsl_gatekeeper.h"
+#include "dsl_ir_image.h"
 #include "errors.h"
 #include "ir_reader.h"
 #include "pu_info.h"
@@ -17,6 +18,70 @@
 
 static VHO_FHE_SEMANTIC_GATEKEEPER VHO_FHE_semantic_gatekeeper;
 static VHO_FHE_CONVERSION_PASS VHO_FHE_conversion_pass;
+
+void
+VHO_FHE_Convert_Result_Init (VHO_FHE_CONVERT_RESULT *result)
+{
+    if (result != NULL)
+        memset(result, 0, sizeof(*result));
+}
+
+void
+VHO_FHE_Convert_Result_Accumulate
+        (VHO_FHE_CONVERT_RESULT *aggregate,
+         const VHO_FHE_CONVERT_RESULT *result)
+{
+    if (aggregate == NULL || result == NULL)
+        return;
+    aggregate->semantic_gatekeeper_count += result->semantic_gatekeeper_count;
+    aggregate->conversion_pass_count += result->conversion_pass_count;
+    aggregate->source_disposition_count += result->source_disposition_count;
+    aggregate->converted_disposition_count +=
+        result->converted_disposition_count;
+    aggregate->rewritten_value_count += result->rewritten_value_count;
+    aggregate->folded_batch_norm_count += result->folded_batch_norm_count;
+    aggregate->approximation_contract_count +=
+        result->approximation_contract_count;
+    aggregate->error_count += result->error_count;
+}
+
+BOOL
+VHO_FHE_Convert_Checkpoint_Validate
+        (UINT32 expected_pu_count,
+         UINT32 converted_pu_count,
+         const VHO_FHE_CONVERT_RESULT *aggregate,
+         FILE *diagnostic)
+{
+    BOOL valid = TRUE;
+
+    if (aggregate == NULL || expected_pu_count == 0 ||
+        converted_pu_count != expected_pu_count) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "CFHE-CHECKPOINT-001: converted PU count %u does not "
+                    "match expected count %u\n",
+                    converted_pu_count, expected_pu_count);
+        valid = FALSE;
+    } else if (aggregate->error_count != 0) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "CFHE-CHECKPOINT-002: conversion reported %u errors\n",
+                    aggregate->error_count);
+        valid = FALSE;
+    }
+
+    if (!DSL_IR_Image_Validate(diagnostic) ||
+        !DSL_Effect_Image_Validate(diagnostic) ||
+        !DSL_Call_Image_Validate(diagnostic) ||
+        !DSL_FHE_Image_Validate(diagnostic) ||
+        !DSL_FHE_Plan_Image_Validate(diagnostic)) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "CFHE-CHECKPOINT-003: complete managed image is invalid\n");
+        valid = FALSE;
+    }
+    return valid;
+}
 
 static BOOL
 VHO_FHE_Convert_Report
@@ -166,30 +231,52 @@ VHO_FHE_Convert_Program_Unit
     return TRUE;
 }
 
+BOOL
+VHO_FHE_Convert_Driver_Try
+        (struct pu_info *pu_info,
+         WN **tree,
+         VHO_FHE_CONVERT_RESULT *result)
+{
+    if (tree != NULL && *tree != NULL &&
+        VHO_FHE_Dump_Before_Conversion && TFile != NULL) {
+        fprintf(TFile,
+                "\n\n========== WHIRL before VHO FHE Conversion "
+                "==========\n");
+        fdump_tree(TFile, *tree);
+        fflush(TFile);
+    }
+
+    VHO_FHE_CONVERT_RESULT local_result;
+    BOOL valid = VHO_FHE_Convert_Program_Unit
+                     (pu_info, tree, stderr, &local_result);
+    if (result != NULL)
+        *result = local_result;
+
+    if (valid && VHO_FHE_Dump_After_Conversion && TFile != NULL) {
+        fprintf(TFile,
+                "\n\n========== WHIRL after VHO FHE Conversion "
+                "==========\n");
+        fdump_tree(TFile, *tree);
+        fflush(TFile);
+    }
+    return valid;
+}
+
+WN *
+VHO_FHE_Convert_Driver_With_Result
+        (struct pu_info *pu_info,
+         WN *tree,
+         VHO_FHE_CONVERT_RESULT *result)
+{
+    BOOL valid = VHO_FHE_Convert_Driver_Try(pu_info, &tree, result);
+    FmtAssert(valid, ("FHE VHO conversion failed"));
+    return tree;
+}
+
 WN *
 VHO_FHE_Convert_Driver
         (struct pu_info *pu_info,
          WN *tree)
 {
-    if (VHO_FHE_Dump_Before_Conversion && TFile != NULL) {
-        fprintf(TFile,
-                "\n\n========== WHIRL before VHO FHE Conversion "
-                "==========\n");
-        fdump_tree(TFile, tree);
-        fflush(TFile);
-    }
-
-    VHO_FHE_CONVERT_RESULT result;
-    BOOL valid = VHO_FHE_Convert_Program_Unit
-                     (pu_info, &tree, stderr, &result);
-    FmtAssert(valid, ("FHE VHO conversion failed"));
-
-    if (VHO_FHE_Dump_After_Conversion && TFile != NULL) {
-        fprintf(TFile,
-                "\n\n========== WHIRL after VHO FHE Conversion "
-                "==========\n");
-        fdump_tree(TFile, tree);
-        fflush(TFile);
-    }
-    return tree;
+    return VHO_FHE_Convert_Driver_With_Result(pu_info, tree, NULL);
 }

--- a/osprey/be/vho/fhe_convert.h
+++ b/osprey/be/vho/fhe_convert.h
@@ -50,6 +50,24 @@ extern BOOL VHO_FHE_Convert_Program_Unit
                                  WN **tree,
                                  FILE *diagnostic,
                                  VHO_FHE_CONVERT_RESULT *result);
+extern void VHO_FHE_Convert_Result_Init
+                                (VHO_FHE_CONVERT_RESULT *result);
+extern void VHO_FHE_Convert_Result_Accumulate
+                                (VHO_FHE_CONVERT_RESULT *aggregate,
+                                 const VHO_FHE_CONVERT_RESULT *result);
+extern BOOL VHO_FHE_Convert_Checkpoint_Validate
+                                (UINT32 expected_pu_count,
+                                 UINT32 converted_pu_count,
+                                 const VHO_FHE_CONVERT_RESULT *aggregate,
+                                 FILE *diagnostic);
+extern BOOL VHO_FHE_Convert_Driver_Try
+                                (struct pu_info *pu_info,
+                                 WN **tree,
+                                 VHO_FHE_CONVERT_RESULT *result);
+extern WN *VHO_FHE_Convert_Driver_With_Result
+                                (struct pu_info *pu_info,
+                                 WN *tree,
+                                 VHO_FHE_CONVERT_RESULT *result);
 extern WN *VHO_FHE_Convert_Driver (struct pu_info *pu_info, WN *tree);
 
 #endif /* fhe_convert_INCLUDED */

--- a/osprey/be/vho/tests/fhe_convert_contract_test.cxx
+++ b/osprey/be/vho/tests/fhe_convert_contract_test.cxx
@@ -165,6 +165,20 @@ main(void)
         return 1;
     }
 
+    VHO_FHE_CONVERT_RESULT aggregate;
+    VHO_FHE_Convert_Result_Init(&aggregate);
+    VHO_FHE_Convert_Result_Accumulate(&aggregate, &result);
+    if (aggregate.semantic_gatekeeper_count != 2 ||
+        aggregate.conversion_pass_count != 1 ||
+        aggregate.source_disposition_count != 1 ||
+        aggregate.converted_disposition_count != 1 ||
+        aggregate.error_count != 0 ||
+        !VHO_FHE_Convert_Checkpoint_Validate(1, 1, &aggregate, stderr) ||
+        VHO_FHE_Convert_Checkpoint_Validate(2, 1, &aggregate, NULL)) {
+        fprintf(stderr, "FHE checkpoint aggregation contract changed\n");
+        return 1;
+    }
+
     const char *trace = getenv("OPEN64_FHE_CONVERT_TRACE");
     if (trace != NULL) {
         FILE *trace_file = fopen(trace, "w");
@@ -173,7 +187,13 @@ main(void)
         Set_Trace_File_internal(trace_file);
         VHO_FHE_Dump_Before_Conversion = TRUE;
         VHO_FHE_Dump_After_Conversion = TRUE;
-        tree = VHO_FHE_Convert_Driver(pu, tree);
+        VHO_FHE_CONVERT_RESULT driver_result;
+        tree = VHO_FHE_Convert_Driver_With_Result
+                   (pu, tree, &driver_result);
+        if (driver_result.semantic_gatekeeper_count != 2 ||
+            driver_result.conversion_pass_count != 1 ||
+            driver_result.error_count != 0)
+            return 1;
         fclose(trace_file);
         Set_Trace_File_internal(stderr);
     }

--- a/osprey/common/com/config_fhe.cxx
+++ b/osprey/common/com/config_fhe.cxx
@@ -15,6 +15,7 @@ BOOL VHO_FHE_Dump_Before_Conversion = FALSE;
 BOOL VHO_FHE_Dump_Before_Conversion_Set = FALSE;
 BOOL VHO_FHE_Dump_After_Conversion = FALSE;
 BOOL VHO_FHE_Dump_After_Conversion_Set = FALSE;
+char *VHO_FHE_Conversion_Checkpoint_Output = NULL;
 
 static OPTION_DESC Options_FHE[] = {
   { OVK_BOOL, OV_VISIBLE, TRUE, "convert", "convert",
@@ -29,5 +30,7 @@ static OPTION_DESC Options_FHE[] = {
   { OVK_BOOL, OV_VISIBLE, TRUE, "dump_after", "dump_after",
     FALSE, 0, 0, &VHO_FHE_Dump_After_Conversion,
     &VHO_FHE_Dump_After_Conversion_Set },
+  { OVK_NAME, OV_VISIBLE, FALSE, "checkpoint", "checkpoint",
+    0, 0, 0, &VHO_FHE_Conversion_Checkpoint_Output, NULL },
   { OVK_COUNT }
 };

--- a/osprey/common/com/config_fhe.h
+++ b/osprey/common/com/config_fhe.h
@@ -13,5 +13,6 @@ extern BOOL VHO_FHE_Dump_Before_Conversion;
 extern BOOL VHO_FHE_Dump_Before_Conversion_Set;
 extern BOOL VHO_FHE_Dump_After_Conversion;
 extern BOOL VHO_FHE_Dump_After_Conversion_Set;
+extern char *VHO_FHE_Conversion_Checkpoint_Output;
 
 #endif /* config_fhe_INCLUDED */

--- a/osprey/common/com/tests/dsl_fhe_conversion_checkpoint_test.sh
+++ b/osprey/common/com/tests/dsl_fhe_conversion_checkpoint_test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Exercise the backend-owned all-PU FHE conversion checkpoint and retain the
+# binary WHIRL, ir_b2a -st -src trace, commands, and diagnostics for review.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+be="${OPEN64_FHE_CHECKPOINT_BE:-$repo_root/build/osprey/targdir/be/be}"
+ir_b2a="${OPEN64_FHE_CHECKPOINT_IR_B2A:-$repo_root/build/osprey/targdir/ir_tools/ir_b2a}"
+input="${OPEN64_FHE_CHECKPOINT_INPUT:-}"
+source_file="${OPEN64_FHE_CHECKPOINT_SOURCE:-}"
+reject_input="${OPEN64_FHE_CHECKPOINT_REJECT_INPUT:-}"
+expected_pus="${OPEN64_FHE_CHECKPOINT_EXPECTED_PUS:-2}"
+artifact_dir="${OPEN64_FHE_CHECKPOINT_ARTIFACT_DIR:-$repo_root/artifacts/fhe/conversion-checkpoint-driver}"
+
+if [[ ! -x "$be" ]]; then
+  echo "missing backend executable: $be" >&2
+  exit 1
+fi
+if [[ ! -x "$ir_b2a" ]]; then
+  echo "missing ir_b2a executable: $ir_b2a" >&2
+  exit 1
+fi
+if [[ -z "$input" || ! -f "$input" ]]; then
+  echo "set OPEN64_FHE_CHECKPOINT_INPUT to a binary WHIRL fixture" >&2
+  exit 1
+fi
+
+mkdir -p "$artifact_dir"
+find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -delete
+
+input_name="$(basename "$input")"
+input_stem="${input_name%.B}"
+output="$artifact_dir/$input_stem.fhe.B"
+trace="$artifact_dir/$input_stem.fhe.T"
+validation_log="$artifact_dir/validation.log"
+failure_log="$artifact_dir/failure.log"
+command_log="$artifact_dir/commands.txt"
+
+printf '%s\n' \
+  "$be -FHE:checkpoint=$output $input" \
+  "$ir_b2a -st -src $output $trace" >"$command_log"
+
+if [[ -n "$source_file" ]]; then
+  if [[ ! -f "$source_file" ]]; then
+    echo "missing checkpoint source file: $source_file" >&2
+    exit 1
+  fi
+  cp "$source_file" "$artifact_dir/$(basename "$source_file")"
+fi
+
+if ! "$be" -FHE:checkpoint="$output" "$input" \
+    >"$validation_log" 2>&1; then
+  cat "$validation_log" >&2
+  exit 1
+fi
+
+(
+  cd "$artifact_dir"
+  "$ir_b2a" -st -src "$(basename "$output")" "$(basename "$trace")"
+)
+
+actual_pus="$(grep -c '^FUNC_ENTRY' "$trace")"
+if [[ "$actual_pus" != "$expected_pus" ]]; then
+  echo "expected $expected_pus PUs, found $actual_pus in $trace" >&2
+  exit 1
+fi
+if ! grep -Fq 'FHE conversion checkpoint: output=' "$validation_log"; then
+  echo "missing successful checkpoint summary in $validation_log" >&2
+  exit 1
+fi
+
+if [[ -n "$reject_input" ]]; then
+  rejected_output="$artifact_dir/must_not_exist.fhe.B"
+  if "$be" -FHE:checkpoint="$rejected_output" "$reject_input" \
+      >"$failure_log" 2>&1; then
+    echo "unsupported FHE conversion unexpectedly succeeded" >&2
+    exit 1
+  fi
+  if [[ -e "$rejected_output" || -e "$rejected_output.tmp" ]]; then
+    echo "failed conversion published a checkpoint artifact" >&2
+    exit 1
+  fi
+  if ! grep -Fq 'CFHE-CHECKPOINT-002' "$failure_log"; then
+    echo "missing stable checkpoint failure diagnostic" >&2
+    exit 1
+  fi
+fi
+
+echo "FHE all-PU conversion checkpoint fixture passed"
+echo "review binary: $output"
+echo "review trace: $trace"
+echo "review commands: $command_log"
+echo "review diagnostics: $validation_log"
+if [[ -f "$failure_log" ]]; then
+  echo "review rejected-run diagnostics: $failure_log"
+fi

--- a/osprey/common/com/tests/dsl_fhe_sync3_vho_driver_test.sh
+++ b/osprey/common/com/tests/dsl_fhe_sync3_vho_driver_test.sh
@@ -11,6 +11,8 @@ artifact_dir="${OPEN64_DSL_FHE_SYNC3_VHO_ARTIFACT_DIR:-$repo_root/artifacts/fhe/
 trace="$artifact_dir/fhe_sync3_vho_conversion.T"
 command_log="$artifact_dir/commands.txt"
 validation_log="$artifact_dir/validation.log"
+driver_source="$repo_root/osprey/be/be/driver.cxx"
+config_source="$repo_root/osprey/common/com/config_fhe.cxx"
 
 if [[ ! -x "$contract_test" ]]; then
   echo "missing executable: $contract_test" >&2
@@ -38,6 +40,23 @@ for evidence in \
     exit 1
   fi
 done
+
+for evidence in \
+  'VHO_FHE_Convert_Driver_With_Result' \
+  'VHO_FHE_Convert_Checkpoint_Validate' \
+  'Write_PU_Info(current_pu)' \
+  'Write_Global_Info(pu_tree)' \
+  'rename(fhe_checkpoint_temp_name'; do
+  if ! grep -Fq "$evidence" "$driver_source"; then
+    echo "missing all-PU checkpoint evidence '$evidence' in $driver_source" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Fq '"checkpoint", "checkpoint"' "$config_source"; then
+  echo "missing -FHE:checkpoint option in $config_source" >&2
+  exit 1
+fi
 
 echo "FHE SYNC-3 VHO conversion phase fixture passed"
 echo "review trace: $trace"


### PR DESCRIPTION
## Summary

- add `-FHE:checkpoint=<path>` as a conversion-only backend mode
- convert every PU while its local symbol table and map table are active
- aggregate FHE conversion results and validate complete DSL/effect/call/FHE/FHE-plan images
- write through the standard binary WHIRL PU/global services and atomically publish only after all-PU success
- preserve the ordinary fail-closed FHE driver API and add a non-asserting backend orchestration entry point
- document the SYNC-3 ownership boundary and add retained positive/negative checkpoint fixtures

## Flow

```text
input.B
  -> optional DSL WOPT/Preopt
  -> VHO_FHE_Convert_Driver_Try() for each selected PU
  -> Write_PU_Info() while each local symtab is active
  -> aggregate result and complete managed-image validation
  -> Write_Global_Info() / Close_Output_Info()
  -> atomic <path>.tmp -> <path> publication
```

Checkpoint mode returns before ordinary DSL/language VHO lowering and before WOPT/LNO/CG/source translation. Unrelated later-phase options remain accepted and are silently ignored.

## Compatibility

- no WN, TY, ST, opcode, mapped-image row, ELF section, or WHIRL revision change
- existing `VHO_FHE_Convert_Driver()` behavior remains source compatible
- no `DSL_Builder_*` dependency enters `be.so`
- failed conversion publishes neither the requested output nor its temporary file

## Validation

- common/VHO syntax fixture and target operator-layout compatibility matrix passed
- full x86-64 `be.so` and `be` build passed; only the known pre-existing `comp_driver.h` return warning appeared
- focused FHE conversion phase contract passed
- six-PU Llama checkpoint reopened with `ir_b2a -st -src`; all six `FUNC_ENTRY`s, source lines, local symbols, and nine call edges are present
- encrypted ResNet negative run without registered semantic support produced `CFHE-CONVERT-001` and `CFHE-CHECKPOINT-002`, with no final or `.tmp` artifact
- `be.so` contains no defined or undefined `DSL_Builder_*` symbols
- `git diff --check` and added-line no-tab scan passed

The FHE task reviewed and accepted this contract. After merge it will provide the positive encrypted ResNet conversion, complete FHE-plan persistence/count evidence, and retained `.fhe.B`/`.fhe.T` artifacts.