### PR TITLE
Fix FHE checkpoint REGION and cleanup lifetime

### DIFF
--- a/doc/FHE-SYNC3-NATIVE-PLAN-CONTRACT.md
+++ b/doc/FHE-SYNC3-NATIVE-PLAN-CONTRACT.md
@@ -688,20 +688,33 @@ converted without an error and that the complete DSL, effect, call, FHE, and
 FHE-plan images are valid. It then calls the standard `Write_Global_Info()`
 and closes the binary WHIRL image.
 
+Checkpoint mode does not initialize the backend REGION optimization service
+after conversion, and its matching PU postprocessing does not finalize that
+service. The checkpoint only preserves and writes REGION WN nodes and their
+managed RID records; it does not consume, lower, or optimize them. Optional
+DSL WOPT preparation retains its own paired REGION initialization and
+finalization before FHE conversion.
+
 The writer initially uses `<path>.tmp` in the destination directory. Only a
 fully converted, validated, and closed file is atomically renamed to `<path>`.
 A failed run removes the temporary file and never publishes a partial artifact
-under the requested checkpoint name. The FHE semantic task consumes this
-mode; it must not reproduce PU selection, local-symbol-table lifetime, managed
-image validation, or binary writer orchestration.
+under the requested checkpoint name. The temporary output is registered with
+the backend's standard error and signal cleanup callback service so failures
+outside the conversion callback also remove it without introducing a shared
+library dependency on the backend driver executable. The FHE semantic task consumes this mode;
+it must not reproduce PU selection, local-symbol-table lifetime, managed image
+validation, or binary writer orchestration.
 
 The retained integration fixture is
 `osprey/common/com/tests/dsl_fhe_conversion_checkpoint_test.sh`. It requires a
 reviewed multi-PU input, reopens the checkpoint with `ir_b2a -st -src`, checks
 the expected `FUNC_ENTRY` count, and stages the source named by
 `OPEN64_FHE_CHECKPOINT_SOURCE` beside the artifact for source-interleaved
-inspection. It may also prove fail-closed behavior with an FHE-bearing input
-when semantic conversion support is intentionally absent.
+inspection. Optional REGION count and contract-name checks prove that legal DSL
+REGION metadata passes through checkpoint mode without invoking backend REGION
+optimization initialization. The fixture may also prove fail-closed behavior
+with an FHE-bearing input when semantic conversion support is intentionally
+absent.
 
 Stable checkpoint diagnostics are `CFHE-CHECKPOINT-001` for incomplete PU
 coverage, `CFHE-CHECKPOINT-002` for aggregated conversion errors, and

--- a/osprey/be/be/be.so.Exported
+++ b/osprey/be/be/be.so.Exported
@@ -99,6 +99,7 @@ Can_Do_Fast_Remainder
 Change_Base__19SYSTEM_OF_EQUATIONSGiT1P8mem_pool
 Check_for_IR_Dump__GiP2WNPc
 Cleanup_Files
+Register_Cleanup_Callback
 Clone_INITVs_For_EH__10IPO_SYMTABGUiT1
 Clone_Tree__9IPO_CLONEGP2WNP2ST
 Close_Output_Info

--- a/osprey/be/be/cleanup.cxx
+++ b/osprey/be/be/cleanup.cxx
@@ -84,6 +84,14 @@
 BOOL Whirl2f_loaded = FALSE;
 BOOL Whirl2c_loaded = FALSE;
 
+static CLEANUP_CALLBACK Cleanup_Callback = NULL;
+
+void
+Register_Cleanup_Callback (CLEANUP_CALLBACK callback)
+{
+    Cleanup_Callback = callback;
+}
+
 /* The subroutines we use from Whirl2c, and Whirl2f
  */
 
@@ -107,6 +115,12 @@ void
 Cleanup_Files (BOOL report,         /* Report errors during cleanup? */
                BOOL delete_dotofile /* remove .o file ? */)
 {
+    if (Cleanup_Callback != NULL) {
+        CLEANUP_CALLBACK callback = Cleanup_Callback;
+        Cleanup_Callback = NULL;
+        callback();
+    }
+
     /* No current line number for errors: */
     Set_Error_Line (ERROR_LINE_UNKNOWN);
 

--- a/osprey/be/be/driver.cxx
+++ b/osprey/be/be/driver.cxx
@@ -458,6 +458,37 @@ FHE_Conversion_Checkpoint_Enabled (void)
 }
 
 static void
+Close_FHE_Conversion_Checkpoint (void)
+{
+  if (ir_output != NULL) {
+    ir_output = NULL;
+    Close_Output_Info();
+  }
+}
+
+static void
+Release_FHE_Conversion_Checkpoint (void)
+{
+  Register_Cleanup_Callback(NULL);
+  free(fhe_checkpoint_temp_name);
+  fhe_checkpoint_temp_name = NULL;
+  need_fhe_checkpoint_output = FALSE;
+}
+
+static void
+Cleanup_FHE_Conversion_Checkpoint (void)
+{
+  if (!need_fhe_checkpoint_output && fhe_checkpoint_temp_name == NULL)
+    return;
+
+  Register_Cleanup_Callback(NULL);
+  Close_FHE_Conversion_Checkpoint();
+  if (fhe_checkpoint_temp_name != NULL)
+    remove(fhe_checkpoint_temp_name);
+  Release_FHE_Conversion_Checkpoint();
+}
+
+static void
 Open_FHE_Conversion_Checkpoint (void)
 {
   const char *output = VHO_FHE_Conversion_Checkpoint_Output;
@@ -472,6 +503,7 @@ Open_FHE_Conversion_Checkpoint (void)
   VHO_FHE_Convert_Result_Init(&fhe_checkpoint_result);
   fhe_checkpoint_pu_count = 0;
   need_fhe_checkpoint_output = TRUE;
+  Register_Cleanup_Callback(Cleanup_FHE_Conversion_Checkpoint);
   ir_output = Open_Output_Info(fhe_checkpoint_temp_name);
   FmtAssert(ir_output != NULL,
             ("could not open FHE checkpoint output %s",
@@ -1892,8 +1924,7 @@ Preprocess_PU (PU_Info *current_pu)
         fprintf(stderr,
                 "CFHE-CHECKPOINT-002: conversion failed before all-PU "
                 "checkpoint completion\n");
-        Close_Output_Info();
-        remove(fhe_checkpoint_temp_name);
+        Cleanup_FHE_Conversion_Checkpoint();
         FmtAssert(FALSE, ("FHE conversion checkpoint failed"));
       }
       ++fhe_checkpoint_pu_count;
@@ -1908,7 +1939,6 @@ Preprocess_PU (PU_Info *current_pu)
     if (need_fhe_checkpoint_output) {
       if (wopt_loaded)
         Create_Restricted_Map(MEM_pu_nz_pool_ptr);
-      REGION_Initialize(pu, PU_has_region(Get_Current_PU()));
       return pu;
     }
 
@@ -1953,8 +1983,10 @@ Postprocess_PU (PU_Info *current_pu)
 
   Current_Map_Tab = PU_Info_maptab(current_pu);
  
-  if (IPSA_insession && ! IPSA_insession()) REGION_Finalize();
-  else REGION_Finalize_wo_delete();
+  if (!need_fhe_checkpoint_output) {
+    if (IPSA_insession && ! IPSA_insession()) REGION_Finalize();
+    else REGION_Finalize_wo_delete();
+  }
 
   if ((Run_wopt || (Run_vsaopt || Run_ipsaopt)) || Run_cg) {
     // delete lowering map
@@ -2504,17 +2536,16 @@ main (INT argc, char **argv)
                      (total_pu_count, fhe_checkpoint_pu_count,
                       &fhe_checkpoint_result, stderr);
     if (!valid) {
-      Close_Output_Info();
-      remove(fhe_checkpoint_temp_name);
+      Cleanup_FHE_Conversion_Checkpoint();
       FmtAssert(FALSE, ("FHE conversion checkpoint validation failed"));
     }
 
     Write_Global_Info(pu_tree);
-    Close_Output_Info();
+    Close_FHE_Conversion_Checkpoint();
     if (rename(fhe_checkpoint_temp_name,
                VHO_FHE_Conversion_Checkpoint_Output) != 0) {
       INT rename_error = errno;
-      remove(fhe_checkpoint_temp_name);
+      Cleanup_FHE_Conversion_Checkpoint();
       FmtAssert(FALSE,
                 ("could not publish FHE conversion checkpoint %s: %s",
                  VHO_FHE_Conversion_Checkpoint_Output,
@@ -2534,8 +2565,7 @@ main (INT argc, char **argv)
             fhe_checkpoint_result.folded_batch_norm_count,
             fhe_checkpoint_result.approximation_contract_count,
             fhe_checkpoint_result.error_count);
-    free(fhe_checkpoint_temp_name);
-    fhe_checkpoint_temp_name = NULL;
+    Release_FHE_Conversion_Checkpoint();
   }
   else if (need_wopt_output || need_lno_output || need_ipl_output) {
     Write_Global_Info (pu_tree);

--- a/osprey/common/com/glob.h
+++ b/osprey/common/com/glob.h
@@ -202,6 +202,10 @@ extern BOOL Keep_Flag;             /* Keep intermediate files(-kp) */
 extern UINT32 File_Index;       /* File index for multiple files compilation */
 
 /* Clean up files after failure: */
+typedef void (*CLEANUP_CALLBACK)(void);
+
+extern void Register_Cleanup_Callback (CLEANUP_CALLBACK callback);
+
 extern void Cleanup_Files (
   BOOL report	/* Report errors which occur during file cleanup? */
 		/* This should generally be FALSE for failures.   */

--- a/osprey/common/com/tests/dsl_fhe_conversion_checkpoint_test.sh
+++ b/osprey/common/com/tests/dsl_fhe_conversion_checkpoint_test.sh
@@ -13,6 +13,8 @@ input="${OPEN64_FHE_CHECKPOINT_INPUT:-}"
 source_file="${OPEN64_FHE_CHECKPOINT_SOURCE:-}"
 reject_input="${OPEN64_FHE_CHECKPOINT_REJECT_INPUT:-}"
 expected_pus="${OPEN64_FHE_CHECKPOINT_EXPECTED_PUS:-2}"
+expected_regions="${OPEN64_FHE_CHECKPOINT_EXPECTED_REGIONS:-}"
+expected_region_contract="${OPEN64_FHE_CHECKPOINT_EXPECTED_REGION_CONTRACT:-}"
 artifact_dir="${OPEN64_FHE_CHECKPOINT_ARTIFACT_DIR:-$repo_root/artifacts/fhe/conversion-checkpoint-driver}"
 
 if [[ ! -x "$be" ]]; then
@@ -65,6 +67,18 @@ fi
 actual_pus="$(grep -c '^FUNC_ENTRY' "$trace")"
 if [[ "$actual_pus" != "$expected_pus" ]]; then
   echo "expected $expected_pus PUs, found $actual_pus in $trace" >&2
+  exit 1
+fi
+if [[ -n "$expected_regions" ]]; then
+  actual_regions="$(grep -c '^ REGION [0-9]' "$trace")"
+  if [[ "$actual_regions" != "$expected_regions" ]]; then
+    echo "expected $expected_regions REGIONs, found $actual_regions in $trace" >&2
+    exit 1
+  fi
+fi
+if [[ -n "$expected_region_contract" ]] &&
+   ! grep -Fq "contract=$expected_region_contract" "$trace"; then
+  echo "missing REGION contract $expected_region_contract in $trace" >&2
   exit 1
 fi
 if ! grep -Fq 'FHE conversion checkpoint: output=' "$validation_log"; then


### PR DESCRIPTION
## Summary

- skip backend REGION initialization/finalization in conversion-only FHE checkpoint mode while preserving the paired REGION lifetime used by optional DSL WOPT
- register the live checkpoint temporary output with the standard backend cleanup callback path
- centralize close, discard, release, validation-failure, and publication-failure handling
- extend the checkpoint fixture with optional REGION count and contract checks
- document the REGION and temporary-output ownership boundary

## Why

PR #116 introduced an all-PU conversion checkpoint. A real encrypted ResNet-20 run showed that its write-only path unnecessarily initialized backend REGION processing and asserted on legal DSL REGION metadata carriers. The assertion also left the temporary checkpoint file behind.

This patch keeps REGION nodes and managed RID records intact for writing without asking REGION optimization code to consume them. It also makes assertion and handled-signal cleanup remove the temporary output.

## Validation

- rebuilt `be.so`, `be`, and `lw_inline`
- verified zero `DSL_Builder_*` symbols in `be.so` and `lw_inline`
- verified no driver-only `Cleanup_FHE_Conversion_Checkpoint` dependency in shared consumers
- retained non-FHE ResNet checkpoint reopens with `ir_b2a -st -src`, preserving 2 REGION nodes and 2 `cnn.basic_block.v1` records
- rejected encrypted input leaves neither final nor `.tmp` output
- FHE task's six-PU encrypted ResNet checkpoint completes and reopens with the candidate
- complete candidate evidence: 6 PUs, 5 `cnn.basic_block.v1` REGIONs, 46 source and converted dispositions, 46 CKKS states, 13 BatchNorm rows, 11 ReLU approximation rows, and zero conversion errors
- controlled handled-signal cleanup leaves neither final nor `.tmp` output

## Coordination

Depends on merged PR #116 and removes the backend blocker for FHE SYNC-3 PR-E. Remaining BatchNorm payload transformation and ReLU coefficient work is FHE semantic implementation, not part of this infrastructure correction.
