### PR TITLE
Publish converted tensor payload APIs

### DIFF
--- a/doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md
+++ b/doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md
@@ -1,0 +1,134 @@
+# FHE SYNC-3 External Tensor Rewrite Contract
+
+## Purpose
+
+This contract closes the main/common payload boundary needed for real
+BatchNorm-to-Conv folding. It provides backend-safe typed access to existing
+external tensor constants and an owner-aware batch transaction for publishing
+converted side-file tensor values and redirecting call actuals.
+
+The service is generic DSL infrastructure. It does not depend on FHE semantic
+code, `DSL_Builder_*`, Python, torch2whirl, backend code generation, or a
+specific side-file implementation.
+
+## Published APIs
+
+```c++
+BOOL DSL_IR_Image_Get_External_Tensor_Reference(
+    ST_IDX owner_pu_st,
+    DSL_IR_VALUE_ID value_id,
+    DSL_IR_EXTERNAL_TENSOR_REFERENCE *reference);
+
+BOOL DSL_IR_Materialize_External_Tensor_Values(
+    ST_IDX owner_pu_st,
+    const DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST *requests,
+    UINT32 request_count,
+    DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_RESULT *results);
+```
+
+`DSL_IR_Image_Get_External_Tensor_Reference()` returns a borrowed typed view of
+the existing DSL value, ST metadata, and canonical tensor TY. It validates:
+
+- selected and owning PU identity;
+- `common.tensor_const.v1` and `external_data` semantics;
+- result value, result ST, and canonical `TY_IDX` consistency;
+- storage format, side-file path, tensor key, byte range, and checksum syntax;
+- dtype, rank, logical shape, layout, placement, and memory descriptor facts;
+- exact static tensor byte size and element-aligned byte offset; and
+- agreement between the structured fields and the logical storage URI.
+
+Callers receive structured fields and do not parse ST metadata or payload
+strings themselves. The returned strings remain owned by the existing Open64
+string and tensor tables. A caller must not retain those borrowed fields across
+owner-PU table mutation, mapped-image reset, or program reset.
+
+Checksum validation at this common/com boundary covers syntax and agreement
+between structured metadata and the logical storage URI. It does not read the
+side file or prove that the checksum describes its current payload bytes. The
+FHE producer and semantic gatekeeper own payload digest verification.
+
+## Batch Materialization
+
+`DSL_IR_Materialize_External_Tensor_Values()` preflights the complete request
+array before creating a symbol, WN, image row, or call replacement. Each
+request names an existing owner-PU external tensor source and creates one
+caller-owned `common.tensor_const.v1` value with:
+
+- the exact canonical tensor `TY_IDX`;
+- a side-file dense tensor TCON whose descriptor, path, range, and logical byte
+  size agree with the external tensor reference;
+- source position on the new STID and result symbol;
+- copied source/instance/context metadata where a source value exists;
+- `dsl.converted_from_value_id` provenance;
+- immutable original source payload and source value; and
+- stable logical `ir_b2a -st -src` evidence.
+
+When `call` is non-null, the request must identify one existing read-only,
+passed-not-saved, by-reference actual and its expected source value. Commit
+replaces that actual with the new same-`TY_IDX` value. When `call` is null, the
+new value is inserted at the supplied entry-owned anchor without inventing a
+fake callsite. This supports the ResNet stem Conv/BatchNorm context.
+
+Duplicate names and duplicate call-actual targets in one transaction are
+rejected. Invalid owner, type, range, checksum, TCON, insertion anchor, or
+expected actual rejects the entire array during preflight. The focused test
+proves that a failure in the second request leaves DSL node/value counts, the
+local ST table, and the earlier call actual unchanged.
+
+## Shared-PU Rule
+
+For the certified ResNet profile, BatchNorm folding changes payload bytes but
+does not change formal roles, formal order, `TY_IDX`, return convention, Conv
+attributes, or projection topology. Therefore:
+
+- rewrite each compatible shared callee body once;
+- materialize weight and bias payloads for each source call context;
+- redirect caller actuals while retaining the same callee signature; and
+- do not split a clone solely because payload keys, ranges, checksums,
+  instance metadata, call metadata, or CKKS value state differ.
+
+Retained BatchNorm formals and actuals are permitted as dead ABI inputs during
+this compatibility stage. The FHE verifier must prove that they have no
+remaining executable use and the conversion report must distinguish them from
+a surviving BatchNorm computation. Clone splitting remains fail-closed when
+the reviewed structural ABI/body clone key actually diverges.
+
+## Atomicity Boundary
+
+The request array is the in-PU preflight/commit unit. Weight and bias for a
+context must be submitted in the same batch. FHE body rewrite/retirement must
+be validated before committing caller payload requests. The existing all-PU
+FHE checkpoint remains the file publication transaction: a later semantic,
+body-rewrite, writer, or verification failure publishes neither the final
+`.fhe.B` nor a partial temporary artifact. The converted side payload must use
+the same temporary/publication discipline and may be renamed only after the
+final all-PU semantic and image gate succeeds.
+
+This is artifact atomicity, not general in-memory rollback for an arbitrary
+continued conversion. A failure after materialization is terminal for the
+conversion-only process: it must not retry or continue transforming the
+mutated in-memory image.
+
+No mapped-image row, ELF section, WHIRL opcode, TY encoding, or binary revision
+is added. New logical node/value/ST metadata records use the existing managed
+tables and mapped-image writer/reader path.
+
+## Focused Evidence
+
+`osprey/common/com/tests/dsl_external_tensor_rewrite_test.sh` retains:
+
+```text
+artifacts/fhe/external-tensor-rewrite/
+  external_tensor_rewrite.B
+  external_tensor_rewrite.T
+  commands.txt
+  validation.log
+```
+
+The trace contains two real PUs, distinct rank-4 weight and rank-1 bias types,
+two calls sharing one unchanged callee signature, per-context converted
+weight/bias actuals, entry-owned stem weight/bias values, source-link metadata,
+side-file tensor TCONs, and the rewritten `OPR_CALL` actuals. Negative checks
+cover failure in the second member of a weight/bias batch, duplicate names,
+duplicate call targets, invalid types, bad ranges, malformed checksums, wrong
+owners, and invalid tensor TCONs without partial table or call mutation.

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1859,6 +1859,36 @@ full-sequence causal prompt evaluation with no KV cache.
    code must continue to use the registered gatekeeper/pass APIs and must not
    reproduce PU, symbol-table, or writer management.
 
+39. [x] Publish typed external tensor lookup and batch payload materialization.
+
+   Add `DSL_IR_Image_Get_External_Tensor_Reference()` as a backend-safe,
+   owner-aware typed view over the existing DSL value row, ST metadata, and
+   canonical tensor TY. The service validates storage format, side-file path,
+   tensor key, aligned byte range, checksum syntax, dtype, rank, shape, layout,
+   placement, memory, and logical URI agreement. Compiler passes must use this
+   service instead of parsing tensor metadata strings.
+
+   Add `DSL_IR_Materialize_External_Tensor_Values()` as a complete-array
+   preflight/commit service. It creates same-`TY_IDX`, caller-owned external
+   tensor constants with side-file tensor TCON evidence, copied source/context
+   metadata, source-value provenance, and source positions. A request may
+   replace one existing read-only call actual or create an entry-owned value
+   without a fake callsite. Original source payloads remain immutable.
+
+   For the current ResNet profile, payload differences do not split shared
+   PUs because formal roles/order/types and the rewritten Conv body contract
+   remain equal. Rewrite a shared body once and materialize folded weight/bias
+   values per source context. Retained dead BatchNorm ABI inputs are permitted
+   only when the FHE verifier proves they have no executable uses. The exact
+   contract and retained evidence are in
+   `doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md`. This stage adds no ELF
+   section, mapped-image row, opcode, type kind, or binary revision.
+
+   This service guarantees complete request-array preflight in the active PU.
+   Whole-conversion artifact atomicity comes from the conversion-only
+   checkpoint: a later failure is terminal, publishes neither `.fhe.B` nor its
+   converted side payload, and does not continue on the mutated memory image.
+
 ### Deferred work TODO
 
 Deferred work remains tracked but does not block the active native DSL bring-up

--- a/osprey/common/com/dsl_ir_image.h
+++ b/osprey/common/com/dsl_ir_image.h
@@ -9,7 +9,9 @@
 
 #include "defs.h"
 #include "dsl_opcode.h"
+#include "srcpos.h"
 #include "symtab_idx.h"
+#include "targ_const.h"
 
 class WN;
 typedef INT32 WN_MAP;
@@ -210,6 +212,61 @@ typedef struct {
     STR_IDX metadata;
 } DSL_IR_VALUE_RECORD;
 
+/*
+ * Runtime-only borrowed view of one external tensor constant. The underlying
+ * facts remain in the existing DSL value, ST metadata, and canonical TY
+ * descriptor tables; this view does not add a mapped-image record. String
+ * fields must not be retained across owner-PU table mutation or image reset.
+ */
+typedef struct {
+    DSL_IR_VALUE_ID value_id;
+    DSL_IR_NODE_ID producer_node_id;
+    TY_IDX descriptor_ty;
+    ST_IDX st;
+    TY_IDX element_ty;
+    INT32 rank;
+    const char *storage_format;
+    const char *side_file;
+    const char *tensor_key;
+    UINT64 byte_offset;
+    UINT64 byte_length;
+    const char *checksum;
+    const char *dtype;
+    const char *logical_shape;
+    const char *layout;
+} DSL_IR_EXTERNAL_TENSOR_REFERENCE;
+
+/*
+ * Runtime-only request for materializing converted side-file tensor values.
+ * All requests are preflighted before any symbol, WN, or image table changes.
+ * source_value_id must name an existing external tensor in the owner PU. A
+ * null call creates an entry-owned value without rewriting a call actual.
+ */
+typedef struct {
+    const char *name;
+    TY_IDX descriptor_ty;
+    TCON_IDX tensor_tcon;
+    DSL_IR_VALUE_ID source_value_id;
+    WN *insertion_block;
+    WN *insert_before;
+    WN *call;
+    UINT32 actual_ordinal;
+    DSL_IR_VALUE_ID expected_actual_value_id;
+    SRCPOS source_position;
+    const char *storage_format;
+    const char *side_file;
+    const char *tensor_key;
+    UINT64 byte_offset;
+    UINT64 byte_length;
+    const char *checksum;
+} DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST;
+
+typedef struct {
+    DSL_IR_VALUE_ID value_id;
+    ST_IDX st;
+    WN *definition;
+} DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_RESULT;
+
 typedef struct {
     DSL_IR_VALUE_REFERENCE_ID id;
     DSL_IR_NODE_ID owner_node_id;
@@ -407,6 +464,17 @@ extern BOOL DSL_IR_Image_Find_Definition_Value
                                 (ST_IDX owner_pu_st,
                                  const WN *definition,
                                  DSL_IR_VALUE_RECORD *value_record);
+extern BOOL DSL_IR_Image_Get_External_Tensor_Reference
+                                (ST_IDX owner_pu_st,
+                                 DSL_IR_VALUE_ID value_id,
+                                 DSL_IR_EXTERNAL_TENSOR_REFERENCE *reference);
+extern BOOL DSL_IR_Materialize_External_Tensor_Values
+                                (ST_IDX owner_pu_st,
+                                 const DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST
+                                     *requests,
+                                 UINT32 request_count,
+                                 DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_RESULT
+                                     *results);
 extern BOOL DSL_IR_Rewrite_Native_Value
                                 (ST_IDX owner_pu_st,
                                  WN *definition,

--- a/osprey/common/com/dsl_ir_rewrite.cxx
+++ b/osprey/common/com/dsl_ir_rewrite.cxx
@@ -2,9 +2,15 @@
  * Copyright (C) 2026 Open64 Project
  */
 
+#include <ctype.h>
 #include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string>
 #include <vector>
 
+#include "dsl_memory_behavior.h"
+#include "dsl_tensor_fold.h"
 #include "dsl_ir_image.h"
 #include "strtab.h"
 #include "symtab.h"
@@ -71,6 +77,570 @@ DSL_IR_Image_Value_Belongs_To_PU
                (value.st, Index_To_Str(value.name),
                 ST_name(St_Table[owner_pu_st]), &owned_value) &&
            owned_value.id == value.id;
+}
+
+static BOOL
+DSL_IR_Parse_Unsigned (const char *text, UINT64 *value)
+{
+    char *end;
+    unsigned long long parsed;
+
+    if (text == NULL || text[0] == '\0' || value == NULL || text[0] == '-')
+        return FALSE;
+    errno = 0;
+    parsed = strtoull(text, &end, 10);
+    if (errno == ERANGE || end == text || *end != '\0')
+        return FALSE;
+    *value = (UINT64)parsed;
+    return TRUE;
+}
+
+static BOOL
+DSL_IR_Checksum_Valid (const char *checksum)
+{
+    if (checksum == NULL || checksum[0] == '\0')
+        return TRUE;
+    if (strlen(checksum) != 64)
+        return FALSE;
+    for (UINT32 i = 0; i < 64; ++i) {
+        if (!isxdigit((unsigned char)checksum[i]))
+            return FALSE;
+    }
+    return TRUE;
+}
+
+static UINT64
+DSL_IR_Tensor_Element_Size (const char *dtype)
+{
+    if (dtype == NULL)
+        return 0;
+    if (strcmp(dtype, "bool") == 0 || strcmp(dtype, "int8") == 0 ||
+        strcmp(dtype, "uint8") == 0)
+        return 1;
+    if (strcmp(dtype, "float16") == 0 || strcmp(dtype, "bfloat16") == 0 ||
+        strcmp(dtype, "int16") == 0 || strcmp(dtype, "uint16") == 0)
+        return 2;
+    if (strcmp(dtype, "float32") == 0 || strcmp(dtype, "int32") == 0 ||
+        strcmp(dtype, "uint32") == 0)
+        return 4;
+    if (strcmp(dtype, "float64") == 0 || strcmp(dtype, "int64") == 0 ||
+        strcmp(dtype, "uint64") == 0)
+        return 8;
+    return 0;
+}
+
+static BOOL
+DSL_IR_Static_Tensor_Byte_Size
+        (const TENSOR_DESCRIPTOR_RECORD &descriptor,
+         UINT64 *element_size,
+         UINT64 *byte_size)
+{
+    const char *dtype = descriptor.dtype == STR_IDX_ZERO ? NULL :
+                        Index_To_Str(descriptor.dtype);
+    const char *shape = descriptor.logical_shape == STR_IDX_ZERO ? NULL :
+                        Index_To_Str(descriptor.logical_shape);
+    UINT64 item_size = DSL_IR_Tensor_Element_Size(dtype);
+    if (item_size == 0 || descriptor.rank < 0 || shape == NULL ||
+        shape[0] != '[')
+        return FALSE;
+
+    const char *cursor = shape + 1;
+    UINT64 elements = 1;
+    INT32 dimension_count = 0;
+    while (TRUE) {
+        while (isspace((unsigned char)*cursor))
+            ++cursor;
+        if (*cursor == ']') {
+            ++cursor;
+            break;
+        }
+        if (!isdigit((unsigned char)*cursor))
+            return FALSE;
+        UINT64 dimension = 0;
+        while (isdigit((unsigned char)*cursor)) {
+            UINT64 digit = (UINT64)(*cursor - '0');
+            if (dimension > (~(UINT64)0 - digit) / 10)
+                return FALSE;
+            dimension = dimension * 10 + digit;
+            ++cursor;
+        }
+        if (dimension == 0 || elements > ~(UINT64)0 / dimension)
+            return FALSE;
+        elements *= dimension;
+        ++dimension_count;
+        while (isspace((unsigned char)*cursor))
+            ++cursor;
+        if (*cursor == ',') {
+            ++cursor;
+            continue;
+        }
+        if (*cursor != ']')
+            return FALSE;
+    }
+    while (isspace((unsigned char)*cursor))
+        ++cursor;
+    if (*cursor != '\0' || dimension_count != descriptor.rank ||
+        elements > ~(UINT64)0 / item_size)
+        return FALSE;
+    if (element_size != NULL)
+        *element_size = item_size;
+    if (byte_size != NULL)
+        *byte_size = elements * item_size;
+    return TRUE;
+}
+
+static BOOL
+DSL_IR_Node_Attribute
+        (const DSL_IR_NODE_RECORD &node,
+         const char *name,
+         const char **value)
+{
+    if (name == NULL || value == NULL)
+        return FALSE;
+    for (UINT32 i = 0; i < node.attribute_count; ++i) {
+        DSL_IR_ATTRIBUTE_RECORD attribute;
+        if (!DSL_IR_Image_Get_Attribute
+                 (node.first_attribute_id + i, &attribute) ||
+            attribute.name == STR_IDX_ZERO)
+            return FALSE;
+        if (strcmp(Index_To_Str(attribute.name), name) == 0) {
+            *value = attribute.value == STR_IDX_ZERO ? "" :
+                     Index_To_Str(attribute.value);
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_IR_Image_Get_External_Tensor_Reference
+        (ST_IDX owner_pu_st,
+         DSL_IR_VALUE_ID value_id,
+         DSL_IR_EXTERNAL_TENSOR_REFERENCE *reference)
+{
+    DSL_IR_VALUE_RECORD value;
+    DSL_IR_NODE_RECORD node;
+    DSL_IR_OPCODE_DESCRIPTOR_RECORD opcode;
+    TENSOR_DESCRIPTOR_RECORD descriptor;
+    const char *value_kind;
+    const char *uri;
+    const char *format;
+    const char *file;
+    const char *key;
+    const char *offset_text;
+    const char *length_text;
+    const char *checksum;
+    UINT64 offset;
+    UINT64 length;
+    UINT64 element_size;
+    UINT64 tensor_size;
+
+    if (reference == NULL)
+        return FALSE;
+    memset(reference, 0, sizeof(*reference));
+    if (!DSL_IR_Image_Current_PU_Is(owner_pu_st) ||
+        !DSL_IR_Image_Get_Value(value_id, &value) ||
+        value.value_kind != DSL_IR_VALUE_CONSTANT ||
+        !DSL_IR_Image_Value_Belongs_To_PU(value, owner_pu_st) ||
+        ST_IDX_level(value.st) != CURRENT_SYMTAB ||
+        ST_IDX_index(value.st) == 0 ||
+        ST_IDX_index(value.st) >= ST_Table_Size(CURRENT_SYMTAB) ||
+        ST_type(St_Table[value.st]) != value.ty ||
+        !DSL_IR_Image_Get_Node(value.producer_node_id, &node) ||
+        !DSL_IR_Image_Get_Opcode_Descriptor
+             (node.opcode_descriptor_id, &opcode) ||
+        opcode.logical_operator != OPR_DSLTENSORCONST ||
+        opcode.version != 1 || node.result_value_id != value.id ||
+        !DSL_IR_Node_Attribute(node, "value_kind", &value_kind) ||
+        strcmp(value_kind, "external_data") != 0 ||
+        !DSL_IR_Node_Attribute(node, "value", &uri) ||
+        !TY_get_tensor_descriptor_record(value.ty, &descriptor))
+        return FALSE;
+
+    format = ST_tensor_metadata(value.st, "storage_format");
+    file = ST_tensor_metadata(value.st, "storage_file");
+    key = ST_tensor_metadata(value.st, "storage_tensor_key");
+    offset_text = ST_tensor_metadata(value.st, "storage_byte_offset");
+    length_text = ST_tensor_metadata(value.st, "storage_byte_length");
+    checksum = ST_tensor_metadata(value.st, "storage_checksum");
+    if (format == NULL || format[0] == '\0' || file == NULL ||
+        file[0] == '\0' || key == NULL || key[0] == '\0' ||
+        !DSL_IR_Parse_Unsigned(offset_text, &offset) ||
+        !DSL_IR_Parse_Unsigned(length_text, &length) || length == 0 ||
+        offset + length < offset || !DSL_IR_Checksum_Valid(checksum) ||
+        !DSL_IR_Static_Tensor_Byte_Size
+             (descriptor, &element_size, &tensor_size) ||
+        offset % element_size != 0 || length != tensor_size)
+        return FALSE;
+
+    const char *placement = descriptor.placement == STR_IDX_ZERO ? NULL :
+                            Index_To_Str(descriptor.placement);
+    const char *memory = descriptor.memory == STR_IDX_ZERO ? NULL :
+                         Index_To_Str(descriptor.memory);
+    if (descriptor.layout == STR_IDX_ZERO || placement == NULL ||
+        strcmp(placement, "side_file") != 0 || memory == NULL ||
+        strcmp(memory, "external_data") != 0)
+        return FALSE;
+
+    size_t uri_size = strlen(format) + strlen(file) + strlen(key) +
+                      strlen(checksum == NULL ? "" : checksum) + 96;
+    char *expected = new char[uri_size];
+    snprintf(expected, uri_size,
+             "%s://%s#%s?offset=%llu&length=%llu&checksum=%s",
+             format, file, key, (unsigned long long)offset,
+             (unsigned long long)length, checksum == NULL ? "" : checksum);
+    BOOL matches = strcmp(uri, expected) == 0;
+    delete [] expected;
+    if (!matches)
+        return FALSE;
+
+    reference->value_id = value.id;
+    reference->producer_node_id = value.producer_node_id;
+    reference->descriptor_ty = value.ty;
+    reference->st = value.st;
+    reference->element_ty = descriptor.element_ty;
+    reference->rank = descriptor.rank;
+    reference->storage_format = format;
+    reference->side_file = file;
+    reference->tensor_key = key;
+    reference->byte_offset = offset;
+    reference->byte_length = length;
+    reference->checksum = checksum == NULL ? "" : checksum;
+    reference->dtype = Index_To_Str(descriptor.dtype);
+    reference->logical_shape = Index_To_Str(descriptor.logical_shape);
+    reference->layout = Index_To_Str(descriptor.layout);
+    return TRUE;
+}
+
+static BOOL
+DSL_IR_Block_Contains (const WN *block, const WN *statement)
+{
+    if (block == NULL || WN_operator(block) != OPR_BLOCK || statement == NULL)
+        return FALSE;
+    for (const WN *current = WN_first(block); current != NULL;
+         current = WN_next(current)) {
+        if (current == statement)
+            return TRUE;
+    }
+    return FALSE;
+}
+
+static BOOL
+DSL_IR_Value_From_Call_Actual
+        (ST_IDX owner_pu_st,
+         const WN *call,
+         UINT32 ordinal,
+         DSL_IR_VALUE_RECORD *value)
+{
+    DSL_CALLSITE_METADATA_RECORD callsite;
+    if (call == NULL || WN_operator(call) != OPR_CALL ||
+        ordinal >= (UINT32)WN_kid_count(call) ||
+        !DSL_Call_Image_Find_Callsite(call, &callsite) ||
+        callsite.owner_pu_st != owner_pu_st)
+        return FALSE;
+
+    const WN *parm = WN_kid(call, ordinal);
+    const WN *address = parm == NULL || WN_operator(parm) != OPR_PARM ?
+                        NULL : WN_kid0(parm);
+    ST_IDX actual_st = address == NULL ? ST_IDX_ZERO : WN_st_idx(address);
+    if (address == NULL || !WN_Parm_By_Reference(parm) ||
+        !WN_Parm_Read_Only(parm) || !WN_Parm_Passed_Not_Saved(parm) ||
+        WN_operator(address) != OPR_LDA ||
+        ST_IDX_level(actual_st) != CURRENT_SYMTAB ||
+        ST_IDX_index(actual_st) == 0 ||
+        ST_IDX_index(actual_st) >= ST_Table_Size(CURRENT_SYMTAB))
+        return FALSE;
+    return DSL_IR_Image_Find_PU_Value
+               (actual_st, ST_name(St_Table[actual_st]),
+                ST_name(St_Table[owner_pu_st]), value);
+}
+
+static BOOL
+DSL_IR_PU_Value_Name_Exists (ST_IDX owner_pu_st, const char *name)
+{
+    std::string owner = "owner_pu=";
+    owner += ST_name(St_Table[owner_pu_st]);
+    for (DSL_IR_VALUE_ID id = 1; id <= DSL_IR_Image_Value_Count(); ++id) {
+        DSL_IR_VALUE_RECORD value;
+        if (!DSL_IR_Image_Get_Value(id, &value) ||
+            value.name == STR_IDX_ZERO || value.metadata == STR_IDX_ZERO)
+            continue;
+        if (strcmp(Index_To_Str(value.name), name) == 0 &&
+            owner == Index_To_Str(value.metadata))
+            return TRUE;
+    }
+    return FALSE;
+}
+
+static BOOL
+DSL_IR_External_Tensor_Request_Valid
+        (ST_IDX owner_pu_st,
+         const DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST &request,
+         DSL_IR_VALUE_RECORD *source_value,
+         std::string *uri,
+         std::string *payload)
+{
+    TENSOR_DESCRIPTOR_RECORD descriptor;
+    DSL_TENSOR_TCON_RECORD tensor_tcon;
+    DSL_IR_EXTERNAL_TENSOR_REFERENCE source_reference;
+    DSL_IR_VALUE_RECORD actual_value;
+    const char *side_path;
+    UINT32 side_path_length;
+    UINT64 element_size;
+    UINT64 tensor_size;
+
+    if (source_value != NULL)
+        memset(source_value, 0, sizeof(*source_value));
+    if (request.name == NULL || request.name[0] == '\0' ||
+        request.descriptor_ty == TY_IDX_ZERO ||
+        request.tensor_tcon == TCON_IDX_ZERO ||
+        request.source_value_id == DSL_IR_VALUE_INVALID_ID ||
+        request.insertion_block == NULL || request.insert_before == NULL ||
+        !DSL_IR_Block_Contains
+             (request.insertion_block, request.insert_before) ||
+        request.source_position == 0 ||
+        request.storage_format == NULL ||
+        request.storage_format[0] == '\0' || request.side_file == NULL ||
+        request.side_file[0] == '\0' || request.tensor_key == NULL ||
+        request.tensor_key[0] == '\0' || request.byte_length == 0 ||
+        request.byte_offset + request.byte_length < request.byte_offset ||
+        !DSL_IR_Checksum_Valid(request.checksum) ||
+        !TY_get_tensor_descriptor_record(request.descriptor_ty, &descriptor) ||
+        !DSL_IR_Static_Tensor_Byte_Size
+             (descriptor, &element_size, &tensor_size) ||
+        request.byte_offset % element_size != 0 ||
+        request.byte_length != tensor_size ||
+        !DSL_Tensor_TCON_Get(request.tensor_tcon, &tensor_tcon) ||
+        tensor_tcon.storage_kind != DSL_TENSOR_TCON_STORAGE_SIDE_FILE_DENSE ||
+        tensor_tcon.descriptor_ty != request.descriptor_ty ||
+        tensor_tcon.element_mtype != TY_mtype(descriptor.element_ty) ||
+        tensor_tcon.element_size != element_size ||
+        tensor_tcon.logical_bytes != tensor_size ||
+        tensor_tcon.required_alignment < TY_align(request.descriptor_ty) ||
+        tensor_tcon.byte_offset != request.byte_offset ||
+        tensor_tcon.byte_length != request.byte_length ||
+        !DSL_Tensor_TCON_Get_Side_Path
+             (request.tensor_tcon, &side_path, &side_path_length) ||
+        strlen(request.side_file) != side_path_length ||
+        memcmp(request.side_file, side_path, side_path_length) != 0)
+        return FALSE;
+
+    const char *placement = descriptor.placement == STR_IDX_ZERO ? NULL :
+                            Index_To_Str(descriptor.placement);
+    const char *memory = descriptor.memory == STR_IDX_ZERO ? NULL :
+                         Index_To_Str(descriptor.memory);
+    if (descriptor.dtype == STR_IDX_ZERO ||
+        descriptor.logical_shape == STR_IDX_ZERO ||
+        descriptor.layout == STR_IDX_ZERO || placement == NULL ||
+        strcmp(placement, "side_file") != 0 || memory == NULL ||
+        strcmp(memory, "external_data") != 0)
+        return FALSE;
+
+    DSL_IR_VALUE_RECORD source;
+    if (!DSL_IR_Image_Get_External_Tensor_Reference
+             (owner_pu_st, request.source_value_id, &source_reference) ||
+        source_reference.descriptor_ty != request.descriptor_ty ||
+        !DSL_IR_Image_Get_Value(request.source_value_id, &source))
+        return FALSE;
+    if (source_value != NULL)
+        *source_value = source;
+
+    if (request.call != NULL) {
+        if (request.insert_before != request.call ||
+            request.expected_actual_value_id == DSL_IR_VALUE_INVALID_ID ||
+            !DSL_IR_Value_From_Call_Actual
+                 (owner_pu_st, request.call, request.actual_ordinal,
+                  &actual_value) ||
+            actual_value.id != request.expected_actual_value_id ||
+            actual_value.id != request.source_value_id ||
+            actual_value.ty != request.descriptor_ty)
+            return FALSE;
+    } else if (request.expected_actual_value_id !=
+                   DSL_IR_VALUE_INVALID_ID) {
+        return FALSE;
+    }
+
+    char offset_text[32];
+    char length_text[32];
+    snprintf(offset_text, sizeof(offset_text), "%llu",
+             (unsigned long long)request.byte_offset);
+    snprintf(length_text, sizeof(length_text), "%llu",
+             (unsigned long long)request.byte_length);
+    size_t uri_size = strlen(request.storage_format) +
+                      strlen(request.side_file) + strlen(request.tensor_key) +
+                      strlen(request.checksum == NULL ? "" :
+                                                        request.checksum) +
+                      96;
+    char *uri_text = new char[uri_size];
+    snprintf(uri_text, uri_size,
+             "%s://%s#%s?offset=%s&length=%s&checksum=%s",
+             request.storage_format, request.side_file, request.tensor_key,
+             offset_text, length_text,
+             request.checksum == NULL ? "" : request.checksum);
+    *uri = uri_text;
+    delete [] uri_text;
+
+    const char *dtype = Index_To_Str(descriptor.dtype);
+    const char *shape = Index_To_Str(descriptor.logical_shape);
+    size_t payload_size =
+        strlen("name=;dtype=;rank=;shape=;value_kind=external_data;value=") +
+        strlen(request.name) + strlen(dtype) + strlen(shape) + uri->size() +
+        16;
+    char *payload_text = new char[payload_size];
+    snprintf(payload_text, payload_size,
+             "name=%s;dtype=%s;rank=%d;shape=%s;"
+             "value_kind=external_data;value=%s",
+             request.name, dtype, descriptor.rank, shape, uri->c_str());
+    *payload = payload_text;
+    delete [] payload_text;
+    return TRUE;
+}
+
+static void
+DSL_IR_Copy_Tensor_Metadata (ST_IDX source, ST_IDX destination)
+{
+    for (UINT32 i = 0; i < ST_tensor_metadata_count(source); ++i) {
+        const char *key;
+        const char *value;
+        TY_DSL_BIND_STATE state;
+        if (ST_tensor_metadata_at(source, i, &key, &value, &state) &&
+            state == TY_DSL_BIND_BOUND && key != NULL && value != NULL)
+            ST_tensor_bind_metadata(destination, key, value);
+    }
+}
+
+BOOL
+DSL_IR_Materialize_External_Tensor_Values
+        (ST_IDX owner_pu_st,
+         const DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST *requests,
+         UINT32 request_count,
+         DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_RESULT *results)
+{
+    if (!DSL_IR_Image_Current_PU_Is(owner_pu_st) || requests == NULL ||
+        request_count == 0 || results == NULL)
+        return FALSE;
+
+    std::vector<DSL_IR_VALUE_RECORD> source_values(request_count);
+    std::vector<std::string> uris(request_count);
+    std::vector<std::string> payloads(request_count);
+    for (UINT32 i = 0; i < request_count; ++i) {
+        if (!DSL_IR_External_Tensor_Request_Valid
+                 (owner_pu_st, requests[i], &source_values[i], &uris[i],
+                  &payloads[i]) ||
+            DSL_IR_PU_Value_Name_Exists(owner_pu_st, requests[i].name))
+            return FALSE;
+        for (UINT32 prior = 0; prior < i; ++prior) {
+            if (strcmp(requests[prior].name, requests[i].name) == 0 ||
+                (requests[i].call != NULL &&
+                 requests[i].call == requests[prior].call &&
+                 requests[i].actual_ordinal ==
+                     requests[prior].actual_ordinal))
+                return FALSE;
+        }
+    }
+
+    DSL_IR_OPCODE_DESCRIPTOR_ID descriptor_id =
+        DSL_IR_Image_Find_Opcode_Descriptor(OPR_DSLTENSORCONST, 1);
+    if (descriptor_id == DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID)
+        return FALSE;
+
+    memset(results, 0, request_count * sizeof(*results));
+
+    for (UINT32 i = 0; i < request_count; ++i) {
+        const DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST &request =
+            requests[i];
+        ST_IDX result_st = DSL_Tensor_Create_Result_Symbol
+                               (request.name, request.descriptor_ty,
+                                SCLASS_AUTO, EXPORT_LOCAL);
+        Set_ST_Srcpos(St_Table[result_st], request.source_position);
+        DSL_IR_Copy_Tensor_Metadata(source_values[i].st, result_st);
+
+        char offset_text[32];
+        char length_text[32];
+        char tcon_text[32];
+        char source_text[32];
+        snprintf(offset_text, sizeof(offset_text), "%llu",
+                 (unsigned long long)request.byte_offset);
+        snprintf(length_text, sizeof(length_text), "%llu",
+                 (unsigned long long)request.byte_length);
+        snprintf(tcon_text, sizeof(tcon_text), "%u",
+                 (UINT32)request.tensor_tcon);
+        snprintf(source_text, sizeof(source_text), "%u",
+                 request.source_value_id);
+        ST_tensor_bind_metadata(result_st, "storage_format",
+                                request.storage_format);
+        ST_tensor_bind_metadata(result_st, "storage_file", request.side_file);
+        ST_tensor_bind_metadata(result_st, "storage_tensor_key",
+                                request.tensor_key);
+        ST_tensor_bind_metadata(result_st, "storage_byte_offset",
+                                offset_text);
+        ST_tensor_bind_metadata(result_st, "storage_byte_length",
+                                length_text);
+        ST_tensor_bind_metadata(result_st, "storage_checksum",
+                                request.checksum == NULL ? "" :
+                                                           request.checksum);
+        ST_tensor_bind_metadata(result_st, "tensor_tcon_idx", tcon_text);
+        ST_tensor_bind_metadata(result_st, "dsl.converted_from_value_id",
+                                source_text);
+
+        WN *expression = DSL_WN_Create_Native
+                             (OPR_DSLTENSORCONST, 1, payloads[i].c_str(),
+                              NULL, 0);
+        WN *definition = WN_CreateStid
+                             (OPR_STID, MTYPE_V, MTYPE_M, 0, result_st,
+                              request.descriptor_ty, expression);
+        WN_Set_Linenum(definition, request.source_position);
+
+        DSL_IR_NODE_RECORD node;
+        DSL_IR_Node_Record_Init(&node);
+        node.opcode_descriptor_id = descriptor_id;
+        node.payload = Save_Str(payloads[i].c_str());
+        DSL_IR_NODE_ID node_id = DSL_IR_Image_Add_Node(&node);
+
+        DSL_IR_ATTRIBUTE_RECORD attributes[2];
+        DSL_IR_Attribute_Record_Init(&attributes[0]);
+        attributes[0].owner_node_id = node_id;
+        attributes[0].value_kind = DSL_IR_ATTRIBUTE_VALUE_STRING;
+        attributes[0].name = Save_Str("value_kind");
+        attributes[0].value = Save_Str("external_data");
+        DSL_IR_ATTRIBUTE_ID first_attribute =
+            DSL_IR_Image_Add_Attribute(&attributes[0]);
+        DSL_IR_Attribute_Record_Init(&attributes[1]);
+        attributes[1].owner_node_id = node_id;
+        attributes[1].value_kind = DSL_IR_ATTRIBUTE_VALUE_STRING;
+        attributes[1].name = Save_Str("value");
+        attributes[1].value = Save_Str(uris[i].c_str());
+        DSL_IR_Image_Add_Attribute(&attributes[1]);
+
+        DSL_IR_VALUE_RECORD value;
+        DSL_IR_Value_Record_Init(&value);
+        value.value_kind = DSL_IR_VALUE_CONSTANT;
+        value.producer_node_id = node_id;
+        value.ty = request.descriptor_ty;
+        value.st = result_st;
+        value.name = Save_Str(request.name);
+        std::string owner = "owner_pu=";
+        owner += ST_name(St_Table[owner_pu_st]);
+        value.metadata = Save_Str(owner.c_str());
+        DSL_IR_VALUE_ID value_id = DSL_IR_Image_Add_Value(&value);
+        DSL_IR_Image_Set_Node_Links
+            (node_id, DSL_IR_VALUE_REFERENCE_INVALID_ID, 0,
+             first_attribute, 2, value_id);
+
+        WN_INSERT_BlockBefore(request.insertion_block,
+                              request.insert_before, definition);
+        if (request.call != NULL) {
+            WN *parm = WN_COPY_Tree
+                           (WN_kid(request.call, request.actual_ordinal));
+            WN_st_idx(WN_kid0(parm)) = result_st;
+            WN_kid(request.call, request.actual_ordinal) = parm;
+        }
+
+        results[i].value_id = value_id;
+        results[i].st = result_st;
+        results[i].definition = definition;
+    }
+    return TRUE;
 }
 
 BOOL

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -4705,6 +4705,7 @@ Check_FHE_SYNC1_Mapped_Image(void)
     DSL_FHE_ENTRY_VALUE_INFO value_info;
     DSL_FHE_KEY_REQUIREMENT_RECORD key_requirement;
     DSL_FHE_IMAGE_HEADER image_header;
+    DSL_IR_EXTERNAL_TENSOR_REFERENCE observed_external;
     TY_IDX weight_ty;
     DSL_FHE_CONFIG_ID config_id;
     DSL_FHE_ENCRYPTION_DESCRIPTOR_ID ciphertext_id;
@@ -4787,6 +4788,26 @@ Check_FHE_SYNC1_Mapped_Image(void)
     FHE_SYNC1_CHECK
         (DSL_Builder_Set_Value_Source_Position(weight, &source_position),
          "parameter source position");
+    FHE_SYNC1_CHECK
+        (DSL_IR_Image_Get_External_Tensor_Reference
+             (PU_Info_proc_sym(pu),
+              DSL_Builder_Get_Value_Image_Id(weight), &observed_external) &&
+         observed_external.value_id ==
+             DSL_Builder_Get_Value_Image_Id(weight) &&
+         observed_external.descriptor_ty == weight_ty &&
+         observed_external.st == WN_st_idx(weight) &&
+         observed_external.rank == 2 &&
+         observed_external.byte_offset == 0 &&
+         observed_external.byte_length == 16 &&
+         strcmp(observed_external.storage_format, "safetensors") == 0 &&
+         strcmp(observed_external.side_file,
+                "fhe_sync1_weights.safetensors") == 0 &&
+         strcmp(observed_external.tensor_key, "weight") == 0 &&
+         strcmp(observed_external.checksum, checksum) == 0 &&
+         strcmp(observed_external.dtype, "float32") == 0 &&
+         strcmp(observed_external.logical_shape, "[2,2]") == 0 &&
+         strcmp(observed_external.layout, "row_major") == 0,
+         "typed external tensor lookup");
     ++source_position.line;
     FHE_SYNC1_CHECK
         (DSL_Builder_Set_Value_Source_Position(result, &source_position),
@@ -4866,6 +4887,11 @@ Check_FHE_SYNC1_Mapped_Image(void)
     FHE_SYNC1_CHECK
         (foreign_value_rejected,
          "reject an entry value owned by another program unit");
+    FHE_SYNC1_CHECK
+        (!DSL_IR_Image_Get_External_Tensor_Reference
+              (PU_Info_proc_sym(foreign_pu),
+               DSL_Builder_Get_Value_Image_Id(weight), &observed_external),
+         "typed external tensor lookup rejects a foreign PU value");
     FHE_SYNC1_CHECK
         (DSL_Builder_Select_PU(pu), "restore entry program unit");
     FHE_SYNC1_CHECK
@@ -5088,6 +5114,440 @@ Check_FHE_SYNC1_Mapped_Image(void)
     printf("FHE SYNC-1 mapped-image contract passed\n");
 #undef FHE_SYNC1_CHECK
     return 0;
+}
+
+static DSL_BUILDER_VALUE
+Create_External_Rewrite_Source
+        (const char *name,
+         TY_IDX ty,
+         const char *tensor_key,
+         UINT64 byte_offset,
+         UINT64 byte_length,
+         const char *context,
+         const char *checksum,
+         DSL_BUILDER_SOURCE_POSITION *position)
+{
+    DSL_BUILDER_EXTERNAL_TENSOR_REFERENCE reference;
+    DSL_BUILDER_COMPILER_METADATA metadata;
+
+    memset(&reference, 0, sizeof(reference));
+    reference.storage_format = "safetensors";
+    reference.side_file = "source.safetensors";
+    reference.tensor_key = tensor_key;
+    reference.byte_offset = byte_offset;
+    reference.byte_length = byte_length;
+    reference.checksum = checksum;
+    DSL_BUILDER_VALUE value = DSL_Builder_Create_External_Tensor_Constant
+                                  (name, ty, &reference);
+    if (value == NULL ||
+        !DSL_Builder_Set_Value_Source_Position(value, position))
+        return NULL;
+    metadata.name = "source.instance_path";
+    metadata.value = context;
+    if (!DSL_Builder_Attach_Value_Metadata(value, &metadata, 1))
+        return NULL;
+    ++position->line;
+    return value;
+}
+
+static TCON_IDX
+Create_External_Rewrite_TCON
+        (TY_IDX ty,
+         UINT64 element_count,
+         UINT64 byte_offset,
+         UINT64 byte_length)
+{
+    DSL_TENSOR_TCON_CREATE_INFO info;
+    TCON_IDX tcon = TCON_IDX_ZERO;
+
+    memset(&info, 0, sizeof(info));
+    info.descriptor_ty = ty;
+    info.element_mtype = MTYPE_F4;
+    info.element_count = element_count;
+    info.logical_bytes = byte_length;
+    info.required_alignment = 16;
+    info.element_size = 4;
+    info.side_path = "converted.safetensors";
+    info.side_path_length = strlen(info.side_path);
+    info.byte_offset = byte_offset;
+    info.byte_length = byte_length;
+    info.checksum_hi = 0x0123456789abcdefULL + byte_offset;
+    info.checksum_lo = 0xfedcba9876543210ULL - byte_offset;
+    if (!DSL_Tensor_TCON_Create_Side_File_Dense(&info, &tcon, NULL))
+        return TCON_IDX_ZERO;
+    return tcon;
+}
+
+static int
+Check_External_Tensor_Materialization(void)
+{
+    const char *artifact =
+        getenv("OPEN64_DSL_EXTERNAL_TENSOR_REWRITE_ARTIFACT");
+    DSL_BUILDER_TENSOR_DESCRIPTOR weight_descriptor;
+    DSL_BUILDER_TENSOR_DESCRIPTOR bias_descriptor;
+    DSL_BUILDER_SOURCE_POSITION position;
+    DSL_BUILDER_CALLSITE_INFO callsite;
+    DSL_BUILDER_MAPPED_IMAGE_REQUEST image_request;
+    DSL_BUILDER_VERIFY_RESULT verify;
+    DSL_BUILDER_PROGRAM_UNIT callee;
+    DSL_BUILDER_PROGRAM_UNIT caller;
+    DSL_BUILDER_VALUE formals[2];
+    DSL_BUILDER_VALUE result;
+    DSL_BUILDER_VALUE sources[6];
+    DSL_BUILDER_VALUE arguments[2];
+    DSL_BUILDER_CALL calls[2];
+    DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST requests[6];
+    DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST rejected[2];
+    DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_RESULT materialized[6];
+    DSL_IR_EXTERNAL_TENSOR_REFERENCE observed;
+    TCON_IDX folded_tcons[6];
+    TY_IDX weight_ty;
+    TY_IDX bias_ty;
+    WN *body;
+    ST_IDX original_actual_st[4];
+    UINT32 node_count;
+    UINT32 value_count;
+    UINT32 st_count;
+    char diagnostic[4096];
+    const char checksum[] =
+        "abcdef0123456789abcdef0123456789"
+        "abcdef0123456789abcdef0123456789";
+    const char *source_names[6] = {
+        "layer1_0_source_weight", "layer1_0_source_bias",
+        "layer1_1_source_weight", "layer1_1_source_bias",
+        "stem_source_weight", "stem_source_bias"
+    };
+    const char *source_keys[6] = {
+        "layer1.0.conv1.weight", "layer1.0.conv1.bias",
+        "layer1.1.conv1.weight", "layer1.1.conv1.bias",
+        "stem.conv.weight", "stem.conv.bias"
+    };
+    const char *contexts[6] = {
+        "layer1.0.conv1", "layer1.0.conv1",
+        "layer1.1.conv1", "layer1.1.conv1",
+        "stem.conv", "stem.conv"
+    };
+    const char *first_result_names[1] = { "layer1_0_result" };
+    const char *second_result_names[1] = { "layer1_1_result" };
+    const char *converted_names[6] = {
+        "layer1_0_folded_weight", "layer1_0_folded_bias",
+        "layer1_1_folded_weight", "layer1_1_folded_bias",
+        "stem_folded_weight", "stem_folded_bias"
+    };
+    const char *converted_keys[6] = {
+        "layer1.0.conv1.folded_weight", "layer1.0.conv1.folded_bias",
+        "layer1.1.conv1.folded_weight", "layer1.1.conv1.folded_bias",
+        "stem.conv.folded_weight", "stem.conv.folded_bias"
+    };
+    int failed = 0;
+#define EXTERNAL_REWRITE_CHECK(condition, message) \
+    do { \
+        if (!(condition)) { \
+            fprintf(stderr, "external tensor rewrite check failed: %s\n", \
+                    message); \
+            failed = 1; \
+        } \
+    } while (0)
+
+    EXTERNAL_REWRITE_CHECK(DSL_Builder_Begin_Program(),
+                           "program initialization");
+    DSL_Opcode_Register_Common_Substrate();
+    memset(&weight_descriptor, 0, sizeof(weight_descriptor));
+    weight_descriptor.type_core.kind = "tensor";
+    weight_descriptor.type_core.dtype = "float32";
+    weight_descriptor.type_core.rank = 4;
+    weight_descriptor.type_core.logical_shape = "[2,2,1,1]";
+    weight_descriptor.traits.traits = "parameter.weight";
+    weight_descriptor.representation.layout = "row_major";
+    weight_descriptor.representation.sharding = "replicated";
+    weight_descriptor.representation.placement = "side_file";
+    weight_descriptor.representation.memory = "external_data";
+    weight_descriptor.representation.quantization = "none";
+    bias_descriptor = weight_descriptor;
+    bias_descriptor.type_core.rank = 1;
+    bias_descriptor.type_core.logical_shape = "[2]";
+    bias_descriptor.traits.traits = "parameter.bias";
+    weight_ty = DSL_Builder_Intern_Tensor_Type
+                    ("external_rewrite_weight_f32_2x2x1x1",
+                     MTYPE_To_TY(MTYPE_F4), &weight_descriptor);
+    bias_ty = DSL_Builder_Intern_Tensor_Type
+                  ("external_rewrite_bias_f32_2",
+                   MTYPE_To_TY(MTYPE_F4), &bias_descriptor);
+
+    callee = DSL_Builder_Create_Minimal_PU("external_tensor_callee");
+    UINT32 callee_file = DSL_Builder_Register_Source_File(callee, __FILE__);
+    memset(&position, 0, sizeof(position));
+    position.file_id = callee_file;
+    position.line = __LINE__ + 1;
+    position.statement_begin = 1;
+    formals[0] = DSL_Builder_Declare_PU_Formal
+                     (callee, "weight", 0, weight_ty, &position);
+    ++position.line;
+    formals[1] = DSL_Builder_Declare_PU_Formal
+                     (callee, "bias", 1, bias_ty, &position);
+    ++position.line;
+    result = DSL_Builder_Declare_PU_Result
+                 (callee, "result", 0, weight_ty, DSL_PU_RESULT_TENSOR,
+                  &position);
+    EXTERNAL_REWRITE_CHECK
+        (weight_ty != TY_IDX_ZERO && bias_ty != TY_IDX_ZERO &&
+         weight_ty != bias_ty && callee != NULL && callee_file != 0 &&
+         formals[0] != NULL && formals[1] != NULL && result != NULL &&
+         DSL_Builder_Return_PU_Values(callee, &formals[0], 1) &&
+         WN_num_formals(PU_Info_tree_ptr(callee)) == 3,
+         "two-formal callee interface");
+
+    caller = DSL_Builder_Create_Minimal_PU("external_tensor_caller");
+    UINT32 caller_file = DSL_Builder_Register_Source_File(caller, __FILE__);
+    memset(&position, 0, sizeof(position));
+    position.file_id = caller_file;
+    position.line = __LINE__ + 1;
+    position.statement_begin = 1;
+    for (UINT32 i = 0; i < 6; ++i) {
+        TY_IDX ty = (i & 1) == 0 ? weight_ty : bias_ty;
+        UINT64 byte_length = (i & 1) == 0 ? 16 : 8;
+        sources[i] = Create_External_Rewrite_Source
+                         (source_names[i], ty, source_keys[i],
+                          i * 32, byte_length, contexts[i], checksum,
+                          &position);
+    }
+    EXTERNAL_REWRITE_CHECK(caller != NULL && caller_file != 0,
+                           "caller program unit");
+    for (UINT32 i = 0; i < 6; ++i)
+        EXTERNAL_REWRITE_CHECK(sources[i] != NULL,
+                               "caller source tensor");
+    EXTERNAL_REWRITE_CHECK
+        (DSL_Builder_Append_PU_Value(caller, sources[4]) &&
+         DSL_Builder_Append_PU_Value(caller, sources[5]),
+         "materialize entry-owned source tensors");
+    if (failed)
+        return failed;
+
+    memset(&callsite, 0, sizeof(callsite));
+    callsite.canonical_class_name = "ExternalTensorCallee";
+    callsite.instance_path = "layer1.0";
+    callsite.context_identity = "layer1.0.conv1";
+    callsite.call_ordinal = 0;
+    callsite.source_position = position;
+    arguments[0] = sources[0];
+    arguments[1] = sources[1];
+    calls[0] = DSL_Builder_Create_PU_Call
+                   (caller, callee, arguments, 2, first_result_names, 1,
+                    &callsite);
+    ++callsite.source_position.line;
+    callsite.instance_path = "layer1.1";
+    callsite.context_identity = "layer1.1.conv1";
+    callsite.call_ordinal = 1;
+    arguments[0] = sources[2];
+    arguments[1] = sources[3];
+    calls[1] = DSL_Builder_Create_PU_Call
+                   (caller, callee, arguments, 2, second_result_names, 1,
+                    &callsite);
+    EXTERNAL_REWRITE_CHECK(calls[0] != NULL && calls[1] != NULL,
+                           "two shared-callee calls");
+    if (failed)
+        return failed;
+
+    for (UINT32 i = 0; i < 6; ++i) {
+        TY_IDX ty = (i & 1) == 0 ? weight_ty : bias_ty;
+        UINT64 element_count = (i & 1) == 0 ? 4 : 2;
+        UINT64 byte_length = (i & 1) == 0 ? 16 : 8;
+        UINT64 byte_offset = i * 32;
+        folded_tcons[i] = Create_External_Rewrite_TCON
+                              (ty, element_count, byte_offset, byte_length);
+        EXTERNAL_REWRITE_CHECK(folded_tcons[i] != TCON_IDX_ZERO,
+                               "converted side-file TCON");
+    }
+    if (failed)
+        return failed;
+
+    body = WN_func_body(PU_Info_tree_ptr(caller));
+    original_actual_st[0] = WN_st_idx(WN_kid0(WN_kid(calls[0], 0)));
+    original_actual_st[1] = WN_st_idx(WN_kid0(WN_kid(calls[0], 1)));
+    original_actual_st[2] = WN_st_idx(WN_kid0(WN_kid(calls[1], 0)));
+    original_actual_st[3] = WN_st_idx(WN_kid0(WN_kid(calls[1], 1)));
+    memset(requests, 0, sizeof(requests));
+    for (UINT32 i = 0; i < 6; ++i) {
+        requests[i].name = converted_names[i];
+        requests[i].descriptor_ty = (i & 1) == 0 ? weight_ty : bias_ty;
+        requests[i].tensor_tcon = folded_tcons[i];
+        requests[i].source_value_id =
+            DSL_Builder_Get_Value_Image_Id(sources[i]);
+        requests[i].insertion_block = body;
+        requests[i].insert_before = i < 2 ? calls[0] : calls[1];
+        requests[i].source_position =
+            WN_Get_Linenum(i < 2 ? calls[0] : calls[1]);
+        requests[i].storage_format = "safetensors";
+        requests[i].side_file = "converted.safetensors";
+        requests[i].tensor_key = converted_keys[i];
+        requests[i].byte_offset = i * 32;
+        requests[i].byte_length = (i & 1) == 0 ? 16 : 8;
+        requests[i].checksum = checksum;
+        if (i < 4) {
+            requests[i].call = calls[i / 2];
+            requests[i].actual_ordinal = i & 1;
+            requests[i].expected_actual_value_id =
+                DSL_Builder_Get_Value_Image_Id(sources[i]);
+        }
+    }
+
+    node_count = DSL_IR_Image_Node_Count();
+    value_count = DSL_IR_Image_Value_Count();
+    st_count = ST_Table_Size(CURRENT_SYMTAB);
+    memcpy(rejected, requests, sizeof(rejected));
+    rejected[1].byte_length = 4;
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_IR_Materialize_External_Tensor_Values
+              (PU_Info_proc_sym(caller), rejected, 2, materialized) &&
+         DSL_IR_Image_Node_Count() == node_count &&
+         DSL_IR_Image_Value_Count() == value_count &&
+         ST_Table_Size(CURRENT_SYMTAB) == st_count &&
+         WN_st_idx(WN_kid0(WN_kid(calls[0], 0))) ==
+             original_actual_st[0] &&
+         WN_st_idx(WN_kid0(WN_kid(calls[0], 1))) ==
+             original_actual_st[1],
+         "weight and bias batch rejects without partial mutation");
+
+    memcpy(rejected, requests, sizeof(rejected));
+    rejected[1].name = rejected[0].name;
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_IR_Materialize_External_Tensor_Values
+              (PU_Info_proc_sym(caller), rejected, 2, materialized) &&
+         DSL_IR_Image_Node_Count() == node_count &&
+         DSL_IR_Image_Value_Count() == value_count &&
+         ST_Table_Size(CURRENT_SYMTAB) == st_count,
+         "duplicate materialized name rejects the complete batch");
+
+    memcpy(rejected, requests, sizeof(rejected));
+    rejected[1] = rejected[0];
+    rejected[1].name = "duplicate_target_bias";
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_IR_Materialize_External_Tensor_Values
+              (PU_Info_proc_sym(caller), rejected, 2, materialized) &&
+         DSL_IR_Image_Node_Count() == node_count &&
+         DSL_IR_Image_Value_Count() == value_count &&
+         ST_Table_Size(CURRENT_SYMTAB) == st_count,
+         "duplicate call actual target rejects the complete batch");
+
+    memcpy(rejected, requests, sizeof(rejected));
+    rejected[1].checksum = "bad-checksum";
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_IR_Materialize_External_Tensor_Values
+              (PU_Info_proc_sym(caller), rejected, 2, materialized) &&
+         DSL_IR_Image_Node_Count() == node_count &&
+         DSL_IR_Image_Value_Count() == value_count &&
+         ST_Table_Size(CURRENT_SYMTAB) == st_count,
+         "bad checksum syntax rejects the complete batch");
+
+    memcpy(rejected, requests, sizeof(rejected));
+    rejected[1].tensor_tcon = TCON_IDX_ZERO;
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_IR_Materialize_External_Tensor_Values
+              (PU_Info_proc_sym(caller), rejected, 2, materialized) &&
+         DSL_IR_Image_Node_Count() == node_count &&
+         DSL_IR_Image_Value_Count() == value_count &&
+         ST_Table_Size(CURRENT_SYMTAB) == st_count,
+         "bad tensor TCON rejects the complete batch");
+
+    memcpy(rejected, requests, sizeof(rejected));
+    rejected[1].descriptor_ty = MTYPE_To_TY(MTYPE_F4);
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_IR_Materialize_External_Tensor_Values
+              (PU_Info_proc_sym(caller), rejected, 2, materialized) &&
+         DSL_IR_Image_Node_Count() == node_count &&
+         DSL_IR_Image_Value_Count() == value_count &&
+         ST_Table_Size(CURRENT_SYMTAB) == st_count,
+         "wrong descriptor type rejects the complete batch");
+
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_IR_Materialize_External_Tensor_Values
+              (PU_Info_proc_sym(callee), requests, 6, materialized) &&
+         DSL_IR_Image_Node_Count() == node_count &&
+         DSL_IR_Image_Value_Count() == value_count &&
+         ST_Table_Size(CURRENT_SYMTAB) == st_count,
+         "wrong owner rejects the complete batch");
+
+    EXTERNAL_REWRITE_CHECK
+        (DSL_IR_Materialize_External_Tensor_Values
+             (PU_Info_proc_sym(caller), requests, 6, materialized),
+         "two contexts plus entry weight and bias materialization");
+    for (UINT32 i = 0; i < 6; ++i) {
+        EXTERNAL_REWRITE_CHECK
+            (materialized[i].value_id != DSL_IR_VALUE_INVALID_ID &&
+             ST_type(St_Table[materialized[i].st]) ==
+                 ((i & 1) == 0 ? weight_ty : bias_ty) &&
+             strcmp(ST_tensor_metadata
+                        (materialized[i].st, "source.instance_path"),
+                    contexts[i]) == 0 &&
+             strtoul(ST_tensor_metadata
+                         (materialized[i].st,
+                          "dsl.converted_from_value_id"),
+                     NULL, 10) ==
+                 DSL_Builder_Get_Value_Image_Id(sources[i]),
+             "same-TY replacement and source context metadata");
+    }
+    for (UINT32 i = 0; i < 4; ++i)
+        EXTERNAL_REWRITE_CHECK
+            (WN_st_idx(WN_kid0(WN_kid(calls[i / 2], i & 1))) ==
+                 materialized[i].st,
+             "caller actual uses the context-owned folded value");
+    EXTERNAL_REWRITE_CHECK
+        (DSL_IR_Image_Get_External_Tensor_Reference
+             (PU_Info_proc_sym(caller), materialized[0].value_id,
+              &observed) &&
+         strcmp(observed.tensor_key,
+                "layer1.0.conv1.folded_weight") == 0 &&
+         DSL_IR_Image_Get_External_Tensor_Reference
+             (PU_Info_proc_sym(caller), materialized[2].value_id,
+              &observed) &&
+         strcmp(observed.tensor_key,
+                "layer1.1.conv1.folded_weight") == 0 &&
+         DSL_IR_Image_Get_External_Tensor_Reference
+             (PU_Info_proc_sym(caller), materialized[4].value_id,
+              &observed) &&
+         strcmp(observed.tensor_key, "stem.conv.folded_weight") == 0,
+         "typed lookup distinguishes contexts and entry values");
+    EXTERNAL_REWRITE_CHECK
+        (DSL_IR_Image_Get_External_Tensor_Reference
+             (PU_Info_proc_sym(caller),
+              DSL_Builder_Get_Value_Image_Id(sources[0]), &observed) &&
+         strcmp(observed.side_file, "source.safetensors") == 0 &&
+         strcmp(observed.tensor_key, "layer1.0.conv1.weight") == 0,
+         "source payload remains immutable");
+
+    EXTERNAL_REWRITE_CHECK
+        (DSL_Builder_Select_PU(callee) &&
+         WN_num_formals(PU_Info_tree_ptr(callee)) == 3 &&
+         strcmp(ST_name(St_Table
+                    [WN_st_idx(WN_formal(PU_Info_tree_ptr(callee), 0))]),
+                "weight") == 0 &&
+         strcmp(ST_name(St_Table
+                    [WN_st_idx(WN_formal(PU_Info_tree_ptr(callee), 1))]),
+                "bias") == 0,
+         "shared callee signature remains unchanged");
+    EXTERNAL_REWRITE_CHECK(DSL_Builder_Select_PU(caller),
+                           "restore caller program unit");
+
+    memset(&verify, 0, sizeof(verify));
+    memset(diagnostic, 0, sizeof(diagnostic));
+    verify.diagnostic = diagnostic;
+    verify.diagnostic_capacity = sizeof(diagnostic);
+    EXTERNAL_REWRITE_CHECK
+        (DSL_Builder_Verify_Program(&verify),
+         diagnostic[0] == '\0' ? "program verification" : diagnostic);
+
+    if (!failed && artifact != NULL && artifact[0] != '\0') {
+        image_request.path = artifact;
+        image_request.flags = 0;
+        (void) unlink(artifact);
+        EXTERNAL_REWRITE_CHECK
+            (DSL_Builder_Finalize_Mapped_Image(&image_request),
+             "mapped-image finalization");
+    }
+    if (!failed)
+        printf("external tensor materialization contract passed\n");
+#undef EXTERNAL_REWRITE_CHECK
+    return failed;
 }
 
 static int
@@ -5632,6 +6092,8 @@ main(void)
         return Check_FHE_SYNC3_Plan_Image();
     if (getenv("OPEN64_DSL_FHE_SYNC3_REWRITE_ONLY") != NULL)
         return Check_FHE_SYNC3_Native_Rewrite();
+    if (getenv("OPEN64_DSL_EXTERNAL_TENSOR_REWRITE_ONLY") != NULL)
+        return Check_External_Tensor_Materialization();
 
     failed |= Check_Tensor_Type_And_Descriptor();
     failed |= Check_Symbol_Metadata();
@@ -5653,6 +6115,7 @@ main(void)
     failed |= Check_FHE_SYNC1_Mapped_Image();
     failed |= Check_FHE_SYNC3_Plan_Image();
     failed |= Check_FHE_SYNC3_Native_Rewrite();
+    failed |= Check_External_Tensor_Materialization();
     failed |= Check_DSL_Simplifier_Bridge();
 
     return failed;

--- a/osprey/common/com/tests/dsl_external_tensor_rewrite_test.sh
+++ b/osprey/common/com/tests/dsl_external_tensor_rewrite_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Preserve and inspect the typed external tensor and atomic rewrite contract.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+contract_test="${OPEN64_DSL_CONTRACT_TEST:-$repo_root/build/osprey/targdir/ir_tools/dsl_builder_contract_test}"
+ir_b2a="${OPEN64_IR_B2A:-$repo_root/build/osprey/targdir/ir_tools/ir_b2a}"
+artifact_dir="${OPEN64_DSL_EXTERNAL_TENSOR_REWRITE_ARTIFACT_DIR:-$repo_root/artifacts/fhe/external-tensor-rewrite}"
+image="$artifact_dir/external_tensor_rewrite.B"
+trace="$artifact_dir/external_tensor_rewrite.T"
+command_log="$artifact_dir/commands.txt"
+validation_log="$artifact_dir/validation.log"
+
+for executable in "$contract_test" "$ir_b2a"; do
+  if [[ ! -x "$executable" ]]; then
+    echo "missing executable: $executable" >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$artifact_dir"
+find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -delete
+
+printf '%s\n' \
+  "OPEN64_DSL_EXTERNAL_TENSOR_REWRITE_ONLY=1 OPEN64_DSL_EXTERNAL_TENSOR_REWRITE_ARTIFACT=$image $contract_test" \
+  "$ir_b2a -st -src $image $trace" >"$command_log"
+
+if ! (cd "$repo_root" && \
+  OPEN64_DSL_EXTERNAL_TENSOR_REWRITE_ONLY=1 \
+  OPEN64_DSL_EXTERNAL_TENSOR_REWRITE_ARTIFACT="$image" \
+    "$contract_test") >"$validation_log" 2>&1; then
+  cat "$validation_log" >&2
+  exit 1
+fi
+if ! (cd "$repo_root" && \
+  "$ir_b2a" -st -src "$image" "$trace") >>"$validation_log" 2>&1; then
+  cat "$validation_log" >&2
+  exit 1
+fi
+
+for evidence in \
+  'name=layer1_0_source_weight;dtype=float32;rank=4' \
+  'name=layer1_0_source_bias;dtype=float32;rank=1' \
+  'name=layer1_0_folded_weight;dtype=float32;rank=4' \
+  'name=layer1_1_folded_weight;dtype=float32;rank=4' \
+  'name=stem_folded_bias;dtype=float32;rank=1' \
+  'source.safetensors#layer1.0.conv1.weight' \
+  'converted.safetensors#layer1.0.conv1.folded_weight' \
+  'converted.safetensors#layer1.1.conv1.folded_weight' \
+  'converted.safetensors#stem.conv.folded_bias' \
+  'side_file=converted.safetensors' \
+  'dsl.converted_from_value_id' \
+  'dsl_builder_contract_test.cxx'; do
+  if ! grep -Fq "$evidence" "$trace"; then
+    echo "missing external tensor rewrite evidence '$evidence' in $trace" >&2
+    exit 1
+  fi
+done
+
+for evidence in \
+  'FUNC_ENTRY .*external_tensor_callee' \
+  'FUNC_ENTRY .*external_tensor_caller' \
+  'U8LDA .*layer1_0_folded_weight' \
+  'U8LDA .*layer1_0_folded_bias' \
+  'U8LDA .*layer1_1_folded_weight' \
+  'U8LDA .*layer1_1_folded_bias'; do
+  if ! grep -Eq "$evidence" "$trace"; then
+    echo "missing external tensor rewrite evidence '$evidence' in $trace" >&2
+    exit 1
+  fi
+done
+
+if [[ "$(grep -Ec '^FUNC_ENTRY ' "$trace")" -ne 2 ]] ||
+   [[ "$(grep -Ec 'VCALL .*external_tensor_callee' "$trace")" -ne 2 ]]; then
+  echo "shared-callee PU/call census changed in $trace" >&2
+  exit 1
+fi
+
+if grep -Fq 'OPR_DSL ' "$trace"; then
+  echo "physical DSL escape tag leaked into $trace" >&2
+  exit 1
+fi
+
+echo "external tensor rewrite fixture passed"
+echo "review image: $image"
+echo "review trace: $trace"
+echo "review commands: $command_log"
+echo "review diagnostics: $validation_log"


### PR DESCRIPTION
## Summary

- add backend-safe typed lookup for existing external tensor constants
- add complete-array preflight and commit for same-TY converted tensor values, caller actual replacement, and entry-owned creation
- preserve source/context provenance, tensor TCON evidence, no-alias symbols, source positions, and logical ir_b2a output
- document the SYNC-3 atomicity boundary and unchanged shared-callee ABI rule

## Compatibility

No ELF section, mapped-image row, opcode, TY encoding, or binary WHIRL revision is added. The APIs build on existing DSL node/value/ST metadata and tensor TCON tables. Backend consumers do not depend on DSL_Builder_* APIs.

## Validation

- focused external tensor rewrite fixture and ir_b2a -st -src trace
- existing FHE SYNC-1 mapped-image fixture
- existing FHE SYNC-3 native rewrite fixture
- native syntax, simplifier, tensor-fold, operator-layout, and WOPT semantic matrix
- rebuilt be.so and verified be.so/lw_inline contain no DSL_Builder_* symbols

The focused fixture covers distinct rank-4 weight and rank-1 bias TYs, failure in the second batch request without partial mutation, duplicate name/target rejection, two calls sharing one unchanged callee, context-specific payloads, and entry stem weight/bias creation.

FHE consumer review completed with no remaining contract blocker.