### PR TITLE
Add atomic FHE checkpoint artifact lifecycle

### DIFF
--- a/doc/FHE-SYNC3-CHECKPOINT-ARTIFACT-CONTRACT.md
+++ b/doc/FHE-SYNC3-CHECKPOINT-ARTIFACT-CONTRACT.md
@@ -1,0 +1,124 @@
+# FHE SYNC-3 Checkpoint Artifact Contract
+
+## Purpose
+
+FHE conversion may produce a converted tensor side payload and a conversion
+report in addition to the binary WHIRL checkpoint. Per-PU conversion callbacks
+cannot safely publish those files because complete validation occurs only after
+every PU has been processed. This contract adds an all-PU lifecycle without
+giving FHE code access to backend driver or binary writer internals.
+
+## Published Lifecycle
+
+The backend-safe FHE conversion service publishes:
+
+```c++
+BOOL VHO_FHE_Convert_Register_Checkpoint_Lifecycle(
+    VHO_FHE_CHECKPOINT_FINALIZER finalizer,
+    VHO_FHE_CHECKPOINT_COMPLETION completion);
+
+BOOL VHO_FHE_Convert_Checkpoint_Begin(
+    const char *temporary_binary_path,
+    const char *final_binary_path,
+    FILE *diagnostic);
+
+BOOL VHO_FHE_Convert_Checkpoint_Register_Artifact(
+    const char *temporary_path,
+    const char *final_path);
+
+BOOL VHO_FHE_Convert_Checkpoint_Finalize(
+    const VHO_FHE_CONVERT_RESULT *aggregate,
+    FILE *diagnostic);
+
+BOOL VHO_FHE_Convert_Checkpoint_Publish_Artifacts(FILE *diagnostic);
+void VHO_FHE_Convert_Checkpoint_Complete(void);
+void VHO_FHE_Convert_Checkpoint_Abort(void);
+```
+
+The driver begins the transaction by recording an in-process reservation for
+the temporary and final binary WHIRL paths. This is not a cross-process lock;
+atomic no-replace publication handles a concurrent destination race. The final
+destination must not exist; a stale `.fhe.B` is rejected
+before conversion begins so it cannot be mistaken for the commit marker of a
+failed new run. The FHE semantic module registers one finalizer and one
+completion callback. During conversion or finalization it may register owned
+temporary/final path pairs. Paths are copied into runtime-only backend state.
+Empty or identical endpoints are rejected. Every auxiliary endpoint must be
+distinct from both endpoints of every other pair and from the reserved binary
+temporary and final paths. A producer must register each path pair before
+creating or opening its temporary file so the shared abort path can remove a
+partially written file.
+
+The finalizer receives the complete aggregate result after PU coverage and all
+managed DSL/FHE image validation. It may finalize and digest temporary side
+payloads, write a temporary report, and reject incorrect aggregate semantic
+counts. It must not mutate WN, ST, TY, RID, or managed image tables at this
+late boundary.
+
+The completion callback receives `TRUE` only after every registered auxiliary
+artifact and the binary WHIRL checkpoint have been published. It receives
+`FALSE` on the shared abort path and must discard any FHE-owned runtime state.
+
+## Driver Order
+
+Checkpoint publication follows this order:
+
+1. Convert every PU and write its in-memory checkpoint contribution while its
+   local symbol table is active.
+2. Validate PU coverage, aggregate counters, and all managed images.
+3. Invoke the registered FHE checkpoint finalizer.
+4. Write global WHIRL tables and close the temporary `.fhe.B`.
+5. Preflight all registered auxiliary artifacts and publish them without
+   replacement in final-path order.
+6. Publish the temporary binary WHIRL file without replacement as `.fhe.B`
+   last.
+7. Disable rollback cleanup and invoke the successful completion callback.
+
+This is a deterministic publication transaction, not a claim that POSIX
+provides one multi-file atomic rename. The binary checkpoint is the commit
+marker because it is published last. Publication uses an atomic hard-link
+creation followed by removal of the temporary name. This provides no-clobber
+semantics and requires each temporary/final pair to reside on the same file
+system. If an auxiliary publication or the final binary publication fails, the
+abort path removes all temporary files and every
+auxiliary member already published by this run. Final auxiliary destinations
+must not exist when publication starts. The binary final destination must not
+exist when the transaction begins and is protected again by atomic no-replace
+publication.
+
+The standard backend cleanup callback invokes the same abort path for compiler
+errors and handled signals. Handled signals are blocked across each atomic
+publication and its corresponding published-state update, so cleanup cannot
+miss a newly visible transaction member. A post-materialization failure
+remains terminal; the process must not retry or continue conversion on the
+mutated memory image.
+
+## Ownership
+
+- FHE owns converted payload bytes, payload digest verification, report
+  contents, aggregate semantic checks, and lifecycle callback registration.
+- `fhe_convert.cxx` owns runtime lifecycle and auxiliary-artifact records so
+  `be.so` remains link-closed and has no driver-only callback dependency.
+- `driver.cxx` owns all-PU ordering, binary WHIRL close, final publication, and
+  the standard cleanup callback.
+- Python and torch2whirl do not use these APIs and gain no backend dependency.
+
+This stage adds no mapped-image row, ELF section, opcode, TY encoding, or
+binary WHIRL revision.
+
+## Diagnostics And Tests
+
+- `CFHE-CHECKPOINT-004` reports invalid or failed finalization.
+- `CFHE-CHECKPOINT-005` reports an unready or failed auxiliary publication.
+- `CFHE-CHECKPOINT-006` reports an invalid reservation or pre-existing binary
+  checkpoint destination.
+
+`fhe_convert_contract_test.cxx` covers registration, the complete cross-alias
+matrix, binary-path collision rejection,
+aggregate finalization, deterministic publication, rollback after auxiliary
+publication, no-clobber preservation of a foreign destination, successful
+completion, stale binary destination rejection, and failed-finalizer cleanup.
+`dsl_fhe_sync3_vho_driver_test.sh` checks the driver phase order and retains
+the before/after conversion trace. Full FHE acceptance additionally requires a
+real six-PU SecureResNet checkpoint that jointly publishes `.fhe.B`, its
+converted tensor payload, the conversion report, and `ir_b2a -st -src` output.

--- a/doc/FHE-SYNC3-NATIVE-PLAN-CONTRACT.md
+++ b/doc/FHE-SYNC3-NATIVE-PLAN-CONTRACT.md
@@ -685,8 +685,11 @@ standard `Write_PU_Info()` service. After all PUs have succeeded, it aggregates
 the `VHO_FHE_CONVERT_RESULT` counters and calls
 `VHO_FHE_Convert_Checkpoint_Validate()` to prove that every expected PU was
 converted without an error and that the complete DSL, effect, call, FHE, and
-FHE-plan images are valid. It then calls the standard `Write_Global_Info()`
-and closes the binary WHIRL image.
+FHE-plan images are valid. It then invokes the registered
+`VHO_FHE_CHECKPOINT_FINALIZER`, calls the standard `Write_Global_Info()`, and
+closes the binary WHIRL image. The finalizer may complete temporary FHE side
+payloads and reports and validate aggregate semantics, but it may not mutate
+WHIRL or managed image tables at this late boundary.
 
 Checkpoint mode does not initialize the backend REGION optimization service
 after conversion, and its matching PU postprocessing does not finalize that
@@ -695,15 +698,31 @@ managed RID records; it does not consume, lower, or optimize them. Optional
 DSL WOPT preparation retains its own paired REGION initialization and
 finalization before FHE conversion.
 
-The writer initially uses `<path>.tmp` in the destination directory. Only a
-fully converted, validated, and closed file is atomically renamed to `<path>`.
-A failed run removes the temporary file and never publishes a partial artifact
-under the requested checkpoint name. The temporary output is registered with
+The writer records an in-process reservation for `<path>.tmp` and `<path>`
+before conversion begins and rejects a pre-existing final destination. This
+reservation is not a cross-process lock; atomic no-replace publication handles
+a concurrent destination race. Only a fully converted, validated,
+and closed file is published to `<path>` with an atomic no-replace hard link,
+then the temporary name is removed. Temporary and final paths must reside on
+the same file system. A failed run removes the temporary file and never
+publishes a partial artifact under the requested checkpoint name. The
+temporary output is registered with
 the backend's standard error and signal cleanup callback service so failures
 outside the conversion callback also remove it without introducing a shared
-library dependency on the backend driver executable. The FHE semantic task consumes this mode;
-it must not reproduce PU selection, local-symbol-table lifetime, managed image
-validation, or binary writer orchestration.
+library dependency on the backend driver executable.
+
+FHE-owned side payloads and reports register temporary/final path pairs through
+the backend-safe service described in
+`doc/FHE-SYNC3-CHECKPOINT-ARTIFACT-CONTRACT.md`. After finalization and binary
+close, the driver publishes auxiliary artifacts with atomic no-replace
+semantics in deterministic final-path order and publishes `.fhe.B` last. Every
+auxiliary endpoint must be distinct from all other transaction endpoints,
+including the binary temporary and final paths. Handled signals are blocked
+across each publication and its published-state update. Any later publication
+failure removes every member published by the current run. The FHE semantic
+task consumes this mode; it must
+not reproduce PU selection, local-symbol-table lifetime, managed image
+validation, binary writer orchestration, or final artifact publication.
 
 The retained integration fixture is
 `osprey/common/com/tests/dsl_fhe_conversion_checkpoint_test.sh`. It requires a
@@ -718,9 +737,13 @@ absent.
 
 Stable checkpoint diagnostics are `CFHE-CHECKPOINT-001` for incomplete PU
 coverage, `CFHE-CHECKPOINT-002` for aggregated conversion errors, and
-`CFHE-CHECKPOINT-003` for an invalid complete managed image. A successful run
-reports PU, semantic-gate, pass, disposition, rewrite, BatchNorm-fold,
-approximation, and error counts.
+`CFHE-CHECKPOINT-003` for an invalid complete managed image.
+`CFHE-CHECKPOINT-004` covers finalizer failure, and
+`CFHE-CHECKPOINT-005` covers auxiliary-artifact publication failure.
+`CFHE-CHECKPOINT-006` covers invalid binary output reservation and stale final
+checkpoint rejection. A successful run reports PU, semantic-gate, pass,
+disposition, rewrite,
+BatchNorm-fold, approximation, and error counts.
 
 No bootstrap insertion, SIHE/CKKS arithmetic opcode allocation,
 `fhe.cnn.poly_activation` emission, OpenFHE/runtime lowering, or generated-C

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1889,6 +1889,28 @@ full-sequence causal prompt evaluation with no KV cache.
    checkpoint: a later failure is terminal, publishes neither `.fhe.B` nor its
    converted side payload, and does not continue on the mutated memory image.
 
+40. [x] Publish the FHE checkpoint auxiliary-artifact transaction.
+
+   Add a registered all-PU finalizer/completion lifecycle to the backend-safe
+   FHE conversion service. The finalizer runs only after PU coverage and all
+   managed-image gates; it may finish and digest temporary side payloads and
+   reports and validate aggregate semantic counts, but it must not mutate
+   WHIRL or managed tables at that late boundary.
+
+   Add runtime-only temporary/final auxiliary-artifact registration. The
+   backend records an in-process reservation for an absent `.fhe.B`
+   destination before conversion and
+   rejects every collision across auxiliary and binary transaction endpoints.
+   It closes the temporary binary WHIRL image, publishes auxiliary files in
+   deterministic order with atomic no-replace semantics, and publishes
+   `.fhe.B` last as the commit marker. Signals are blocked across each
+   publication and its rollback-state update. Any failure or handled signal
+   removes temporary files and every auxiliary member already published by
+   the current run. The exact API, ordering, ownership, diagnostics, and test
+   contract are in
+   `doc/FHE-SYNC3-CHECKPOINT-ARTIFACT-CONTRACT.md`. This adds no mapped-image
+   row, ELF section, opcode, type encoding, or binary revision.
+
 ### Deferred work TODO
 
 Deferred work remains tracked but does not block the active native DSL bring-up

--- a/osprey/be/be/driver.cxx
+++ b/osprey/be/be/driver.cxx
@@ -72,6 +72,7 @@
 #include <cmplrs/rcodes.h>
 #include <dirent.h>
 #include <errno.h>
+#include <signal.h>
 #include <stdlib.h>
 #include <string.h>
 #ifndef __MINGW32__
@@ -428,6 +429,7 @@ static Output_File *ir_output = 0;
 static char *fhe_checkpoint_temp_name = NULL;
 static UINT32 fhe_checkpoint_pu_count;
 static VHO_FHE_CONVERT_RESULT fhe_checkpoint_result;
+static BOOL fhe_checkpoint_published = FALSE;
 
 // options stack for PU and region level pragmas
 static OPTIONS_STACK *Options_Stack;
@@ -472,6 +474,7 @@ Release_FHE_Conversion_Checkpoint (void)
   Register_Cleanup_Callback(NULL);
   free(fhe_checkpoint_temp_name);
   fhe_checkpoint_temp_name = NULL;
+  fhe_checkpoint_published = FALSE;
   need_fhe_checkpoint_output = FALSE;
 }
 
@@ -485,7 +488,44 @@ Cleanup_FHE_Conversion_Checkpoint (void)
   Close_FHE_Conversion_Checkpoint();
   if (fhe_checkpoint_temp_name != NULL)
     remove(fhe_checkpoint_temp_name);
+  if (fhe_checkpoint_published &&
+      VHO_FHE_Conversion_Checkpoint_Output != NULL)
+    remove(VHO_FHE_Conversion_Checkpoint_Output);
+  VHO_FHE_Convert_Checkpoint_Abort();
   Release_FHE_Conversion_Checkpoint();
+}
+
+static BOOL
+Publish_FHE_Conversion_Checkpoint (void)
+{
+  sigset_t all_signals;
+  sigset_t previous_signals;
+  if (sigfillset(&all_signals) != 0 ||
+      sigprocmask(SIG_BLOCK, &all_signals, &previous_signals) != 0)
+    return FALSE;
+
+  BOOL published = FALSE;
+  INT publish_error = 0;
+  if (link(fhe_checkpoint_temp_name,
+           VHO_FHE_Conversion_Checkpoint_Output) != 0) {
+    publish_error = errno;
+  }
+  else {
+    fhe_checkpoint_published = TRUE;
+    if (unlink(fhe_checkpoint_temp_name) != 0)
+      publish_error = errno;
+    else
+      published = TRUE;
+  }
+
+  INT restore_error = 0;
+  if (sigprocmask(SIG_SETMASK, &previous_signals, NULL) != 0)
+    restore_error = errno;
+  if (restore_error != 0)
+    errno = restore_error;
+  else if (!published)
+    errno = publish_error;
+  return published && restore_error == 0;
 }
 
 static void
@@ -500,8 +540,16 @@ Open_FHE_Conversion_Checkpoint (void)
   snprintf(fhe_checkpoint_temp_name, length, "%s.tmp", output);
   remove(fhe_checkpoint_temp_name);
 
+  if (!VHO_FHE_Convert_Checkpoint_Begin
+           (fhe_checkpoint_temp_name, output, stderr)) {
+    free(fhe_checkpoint_temp_name);
+    fhe_checkpoint_temp_name = NULL;
+    FmtAssert(FALSE, ("could not reserve FHE checkpoint output %s", output));
+  }
+
   VHO_FHE_Convert_Result_Init(&fhe_checkpoint_result);
   fhe_checkpoint_pu_count = 0;
+  fhe_checkpoint_published = FALSE;
   need_fhe_checkpoint_output = TRUE;
   Register_Cleanup_Callback(Cleanup_FHE_Conversion_Checkpoint);
   ir_output = Open_Output_Info(fhe_checkpoint_temp_name);
@@ -2539,18 +2587,31 @@ main (INT argc, char **argv)
       Cleanup_FHE_Conversion_Checkpoint();
       FmtAssert(FALSE, ("FHE conversion checkpoint validation failed"));
     }
+    if (!VHO_FHE_Convert_Checkpoint_Finalize
+             (&fhe_checkpoint_result, stderr)) {
+      Cleanup_FHE_Conversion_Checkpoint();
+      FmtAssert(FALSE, ("FHE conversion checkpoint finalization failed"));
+    }
 
     Write_Global_Info(pu_tree);
     Close_FHE_Conversion_Checkpoint();
-    if (rename(fhe_checkpoint_temp_name,
-               VHO_FHE_Conversion_Checkpoint_Output) != 0) {
+    if (!VHO_FHE_Convert_Checkpoint_Publish_Artifacts(stderr)) {
+      Cleanup_FHE_Conversion_Checkpoint();
+      FmtAssert(FALSE,
+                ("FHE conversion checkpoint auxiliary publication failed"));
+    }
+    if (!Publish_FHE_Conversion_Checkpoint()) {
       INT rename_error = errno;
       Cleanup_FHE_Conversion_Checkpoint();
       FmtAssert(FALSE,
-                ("could not publish FHE conversion checkpoint %s: %s",
-                 VHO_FHE_Conversion_Checkpoint_Output,
+                ("could not publish FHE conversion checkpoint %s without "
+                 "replacement: %s",
+                VHO_FHE_Conversion_Checkpoint_Output,
                  strerror(rename_error)));
     }
+    Register_Cleanup_Callback(NULL);
+    fhe_checkpoint_published = FALSE;
+    VHO_FHE_Convert_Checkpoint_Complete();
     fprintf(stderr,
             "FHE conversion checkpoint: output=%s pu=%u "
             "semantic_gates=%u passes=%u source=%u converted=%u "

--- a/osprey/be/vho/fhe_convert.cxx
+++ b/osprey/be/vho/fhe_convert.cxx
@@ -2,7 +2,13 @@
  * Copyright (C) 2026 Open64 Project
  */
 
+#include <algorithm>
+#include <errno.h>
+#include <signal.h>
 #include <string.h>
+#include <unistd.h>
+#include <string>
+#include <vector>
 
 #include "fhe_convert.h"
 #include "config_fhe.h"
@@ -18,6 +24,41 @@
 
 static VHO_FHE_SEMANTIC_GATEKEEPER VHO_FHE_semantic_gatekeeper;
 static VHO_FHE_CONVERSION_PASS VHO_FHE_conversion_pass;
+static VHO_FHE_CHECKPOINT_FINALIZER VHO_FHE_checkpoint_finalizer;
+static VHO_FHE_CHECKPOINT_COMPLETION VHO_FHE_checkpoint_completion;
+
+typedef struct {
+    std::string temporary_path;
+    std::string final_path;
+    BOOL published;
+} VHO_FHE_CHECKPOINT_ARTIFACT;
+
+static std::vector<VHO_FHE_CHECKPOINT_ARTIFACT>
+    VHO_FHE_checkpoint_artifacts;
+static std::string VHO_FHE_checkpoint_binary_temporary_path;
+static std::string VHO_FHE_checkpoint_binary_final_path;
+static BOOL VHO_FHE_checkpoint_active;
+static BOOL VHO_FHE_checkpoint_finalized;
+
+static BOOL
+VHO_FHE_Checkpoint_Artifact_Order
+        (const VHO_FHE_CHECKPOINT_ARTIFACT &left,
+         const VHO_FHE_CHECKPOINT_ARTIFACT &right)
+{
+    return left.final_path < right.final_path;
+}
+
+static void
+VHO_FHE_Convert_Checkpoint_Clear_State (void)
+{
+    VHO_FHE_checkpoint_artifacts.clear();
+    VHO_FHE_checkpoint_binary_temporary_path.clear();
+    VHO_FHE_checkpoint_binary_final_path.clear();
+    VHO_FHE_checkpoint_active = FALSE;
+    VHO_FHE_checkpoint_finalizer = NULL;
+    VHO_FHE_checkpoint_completion = NULL;
+    VHO_FHE_checkpoint_finalized = FALSE;
+}
 
 void
 VHO_FHE_Convert_Result_Init (VHO_FHE_CONVERT_RESULT *result)
@@ -133,9 +174,240 @@ VHO_FHE_Convert_Register_Pass (VHO_FHE_CONVERSION_PASS pass)
     return TRUE;
 }
 
+BOOL
+VHO_FHE_Convert_Register_Checkpoint_Lifecycle
+        (VHO_FHE_CHECKPOINT_FINALIZER finalizer,
+         VHO_FHE_CHECKPOINT_COMPLETION completion)
+{
+    if (finalizer == NULL || completion == NULL ||
+        VHO_FHE_checkpoint_finalizer != NULL ||
+        VHO_FHE_checkpoint_completion != NULL ||
+        !VHO_FHE_checkpoint_artifacts.empty() ||
+        VHO_FHE_checkpoint_finalized)
+        return FALSE;
+    VHO_FHE_checkpoint_finalizer = finalizer;
+    VHO_FHE_checkpoint_completion = completion;
+    return TRUE;
+}
+
+BOOL
+VHO_FHE_Convert_Checkpoint_Begin
+        (const char *temporary_binary_path,
+         const char *final_binary_path,
+         FILE *diagnostic)
+{
+    if (VHO_FHE_checkpoint_active || VHO_FHE_checkpoint_finalized ||
+        !VHO_FHE_checkpoint_artifacts.empty() ||
+        temporary_binary_path == NULL ||
+        temporary_binary_path[0] == '\0' || final_binary_path == NULL ||
+        final_binary_path[0] == '\0' ||
+        strcmp(temporary_binary_path, final_binary_path) == 0) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "CFHE-CHECKPOINT-006: invalid checkpoint output "
+                    "reservation\n");
+        return FALSE;
+    }
+
+    errno = 0;
+    if (access(final_binary_path, F_OK) == 0 || errno != ENOENT) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "CFHE-CHECKPOINT-006: checkpoint destination already "
+                    "exists or cannot be inspected: %s\n",
+                    final_binary_path);
+        return FALSE;
+    }
+
+    VHO_FHE_checkpoint_binary_temporary_path = temporary_binary_path;
+    VHO_FHE_checkpoint_binary_final_path = final_binary_path;
+    VHO_FHE_checkpoint_active = TRUE;
+    return TRUE;
+}
+
+BOOL
+VHO_FHE_Convert_Checkpoint_Register_Artifact
+        (const char *temporary_path, const char *final_path)
+{
+    if (VHO_FHE_checkpoint_finalizer == NULL ||
+        !VHO_FHE_checkpoint_active || VHO_FHE_checkpoint_finalized ||
+        temporary_path == NULL ||
+        temporary_path[0] == '\0' || final_path == NULL ||
+        final_path[0] == '\0' || strcmp(temporary_path, final_path) == 0)
+        return FALSE;
+    if (VHO_FHE_checkpoint_binary_temporary_path == temporary_path ||
+        VHO_FHE_checkpoint_binary_temporary_path == final_path ||
+        VHO_FHE_checkpoint_binary_final_path == temporary_path ||
+        VHO_FHE_checkpoint_binary_final_path == final_path)
+        return FALSE;
+    for (size_t i = 0; i < VHO_FHE_checkpoint_artifacts.size(); ++i) {
+        const VHO_FHE_CHECKPOINT_ARTIFACT &artifact =
+            VHO_FHE_checkpoint_artifacts[i];
+        if (artifact.temporary_path == temporary_path ||
+            artifact.temporary_path == final_path ||
+            artifact.final_path == temporary_path ||
+            artifact.final_path == final_path)
+            return FALSE;
+    }
+
+    VHO_FHE_CHECKPOINT_ARTIFACT artifact;
+    artifact.temporary_path = temporary_path;
+    artifact.final_path = final_path;
+    artifact.published = FALSE;
+    VHO_FHE_checkpoint_artifacts.push_back(artifact);
+    return TRUE;
+}
+
+UINT32
+VHO_FHE_Convert_Checkpoint_Artifact_Count (void)
+{
+    return (UINT32)VHO_FHE_checkpoint_artifacts.size();
+}
+
+BOOL
+VHO_FHE_Convert_Checkpoint_Finalize
+        (const VHO_FHE_CONVERT_RESULT *aggregate, FILE *diagnostic)
+{
+    if (!VHO_FHE_checkpoint_active || aggregate == NULL ||
+        VHO_FHE_checkpoint_finalized) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "CFHE-CHECKPOINT-004: invalid checkpoint finalization "
+                    "state\n");
+        return FALSE;
+    }
+    if (VHO_FHE_checkpoint_finalizer != NULL &&
+        !VHO_FHE_checkpoint_finalizer(aggregate, diagnostic)) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "CFHE-CHECKPOINT-004: registered checkpoint finalizer "
+                    "failed\n");
+        return FALSE;
+    }
+    VHO_FHE_checkpoint_finalized = TRUE;
+    return TRUE;
+}
+
+static BOOL
+VHO_FHE_Checkpoint_Publish_No_Replace
+        (VHO_FHE_CHECKPOINT_ARTIFACT *artifact, FILE *diagnostic)
+{
+    sigset_t all_signals;
+    sigset_t previous_signals;
+    if (sigfillset(&all_signals) != 0 ||
+        sigprocmask(SIG_BLOCK, &all_signals, &previous_signals) != 0) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "CFHE-CHECKPOINT-005: could not protect auxiliary "
+                    "artifact publication: %s\n", strerror(errno));
+        return FALSE;
+    }
+
+    BOOL published = FALSE;
+    INT publish_error = 0;
+    if (link(artifact->temporary_path.c_str(),
+             artifact->final_path.c_str()) != 0) {
+        publish_error = errno;
+    }
+    else {
+        artifact->published = TRUE;
+        if (unlink(artifact->temporary_path.c_str()) != 0)
+            publish_error = errno;
+        else
+            published = TRUE;
+    }
+
+    INT restore_error = 0;
+    if (sigprocmask(SIG_SETMASK, &previous_signals, NULL) != 0)
+        restore_error = errno;
+    if (!published || restore_error != 0) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "CFHE-CHECKPOINT-005: could not publish auxiliary "
+                    "artifact %s without replacement: %s\n",
+                    artifact->final_path.c_str(),
+                    strerror(restore_error != 0 ? restore_error :
+                             publish_error));
+        return FALSE;
+    }
+    return TRUE;
+}
+
+BOOL
+VHO_FHE_Convert_Checkpoint_Publish_Artifacts (FILE *diagnostic)
+{
+    if (!VHO_FHE_checkpoint_active || !VHO_FHE_checkpoint_finalized) {
+        if (diagnostic != NULL)
+            fprintf(diagnostic,
+                    "CFHE-CHECKPOINT-005: auxiliary artifacts were not "
+                    "finalized\n");
+        return FALSE;
+    }
+
+    std::sort(VHO_FHE_checkpoint_artifacts.begin(),
+              VHO_FHE_checkpoint_artifacts.end(),
+              VHO_FHE_Checkpoint_Artifact_Order);
+    for (size_t i = 0; i < VHO_FHE_checkpoint_artifacts.size(); ++i) {
+        VHO_FHE_CHECKPOINT_ARTIFACT &artifact =
+            VHO_FHE_checkpoint_artifacts[i];
+        errno = 0;
+        if (access(artifact.temporary_path.c_str(), F_OK) != 0 ||
+            access(artifact.final_path.c_str(), F_OK) == 0 ||
+            errno != ENOENT) {
+            if (diagnostic != NULL)
+                fprintf(diagnostic,
+                        "CFHE-CHECKPOINT-005: auxiliary artifact is not "
+                        "ready for publication: %s -> %s\n",
+                        artifact.temporary_path.c_str(),
+                        artifact.final_path.c_str());
+            return FALSE;
+        }
+    }
+    for (size_t i = 0; i < VHO_FHE_checkpoint_artifacts.size(); ++i) {
+        VHO_FHE_CHECKPOINT_ARTIFACT &artifact =
+            VHO_FHE_checkpoint_artifacts[i];
+        if (!VHO_FHE_Checkpoint_Publish_No_Replace
+                 (&artifact, diagnostic))
+            return FALSE;
+    }
+    return TRUE;
+}
+
+void
+VHO_FHE_Convert_Checkpoint_Complete (void)
+{
+    VHO_FHE_CHECKPOINT_COMPLETION completion =
+        VHO_FHE_checkpoint_completion;
+    for (size_t i = 0; i < VHO_FHE_checkpoint_artifacts.size(); ++i) {
+        if (!VHO_FHE_checkpoint_artifacts[i].published)
+            remove(VHO_FHE_checkpoint_artifacts[i].temporary_path.c_str());
+    }
+    VHO_FHE_Convert_Checkpoint_Clear_State();
+    if (completion != NULL)
+        completion(TRUE);
+}
+
+void
+VHO_FHE_Convert_Checkpoint_Abort (void)
+{
+    VHO_FHE_CHECKPOINT_COMPLETION completion =
+        VHO_FHE_checkpoint_completion;
+    for (size_t i = 0; i < VHO_FHE_checkpoint_artifacts.size(); ++i) {
+        VHO_FHE_CHECKPOINT_ARTIFACT &artifact =
+            VHO_FHE_checkpoint_artifacts[i];
+        remove(artifact.temporary_path.c_str());
+        if (artifact.published)
+            remove(artifact.final_path.c_str());
+    }
+    VHO_FHE_Convert_Checkpoint_Clear_State();
+    if (completion != NULL)
+        completion(FALSE);
+}
+
 void
 VHO_FHE_Convert_Reset_Passes (void)
 {
+    VHO_FHE_Convert_Checkpoint_Abort();
     VHO_FHE_semantic_gatekeeper = NULL;
     VHO_FHE_conversion_pass = NULL;
 }

--- a/osprey/be/vho/fhe_convert.h
+++ b/osprey/be/vho/fhe_convert.h
@@ -40,10 +40,23 @@ typedef BOOL (*VHO_FHE_CONVERSION_PASS)
                                  FILE *diagnostic,
                                  VHO_FHE_CONVERT_RESULT *result);
 
+typedef BOOL (*VHO_FHE_CHECKPOINT_FINALIZER)
+                                (const VHO_FHE_CONVERT_RESULT *aggregate,
+                                 FILE *diagnostic);
+
+typedef void (*VHO_FHE_CHECKPOINT_COMPLETION) (BOOL committed);
+
 extern BOOL VHO_FHE_Convert_Register_Semantic_Gatekeeper
                                 (VHO_FHE_SEMANTIC_GATEKEEPER gatekeeper);
 extern BOOL VHO_FHE_Convert_Register_Pass
                                 (VHO_FHE_CONVERSION_PASS pass);
+extern BOOL VHO_FHE_Convert_Register_Checkpoint_Lifecycle
+                                (VHO_FHE_CHECKPOINT_FINALIZER finalizer,
+                                 VHO_FHE_CHECKPOINT_COMPLETION completion);
+extern BOOL VHO_FHE_Convert_Checkpoint_Begin
+                                (const char *temporary_binary_path,
+                                 const char *final_binary_path,
+                                 FILE *diagnostic);
 extern void VHO_FHE_Convert_Reset_Passes (void);
 extern BOOL VHO_FHE_Convert_Program_Unit
                                 (struct pu_info *pu_info,
@@ -60,6 +73,17 @@ extern BOOL VHO_FHE_Convert_Checkpoint_Validate
                                  UINT32 converted_pu_count,
                                  const VHO_FHE_CONVERT_RESULT *aggregate,
                                  FILE *diagnostic);
+extern BOOL VHO_FHE_Convert_Checkpoint_Register_Artifact
+                                (const char *temporary_path,
+                                 const char *final_path);
+extern UINT32 VHO_FHE_Convert_Checkpoint_Artifact_Count (void);
+extern BOOL VHO_FHE_Convert_Checkpoint_Finalize
+                                (const VHO_FHE_CONVERT_RESULT *aggregate,
+                                 FILE *diagnostic);
+extern BOOL VHO_FHE_Convert_Checkpoint_Publish_Artifacts
+                                (FILE *diagnostic);
+extern void VHO_FHE_Convert_Checkpoint_Complete (void);
+extern void VHO_FHE_Convert_Checkpoint_Abort (void);
 extern BOOL VHO_FHE_Convert_Driver_Try
                                 (struct pu_info *pu_info,
                                  WN **tree,

--- a/osprey/be/vho/tests/fhe_convert_contract_test.cxx
+++ b/osprey/be/vho/tests/fhe_convert_contract_test.cxx
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "defs.h"
 #include "config.h"
@@ -46,6 +47,15 @@ Host_Format_Parm(INT kind, MEM_PTR parm)
 static char observed_order[8];
 static UINT32 observed_count;
 static BOOL observed_strict_o0;
+static char checkpoint_temporary[2][256];
+static char checkpoint_final[2][256];
+static char checkpoint_alias[2][256];
+static char checkpoint_binary_temporary[256];
+static char checkpoint_binary_final[256];
+static UINT32 checkpoint_finalizer_count;
+static UINT32 checkpoint_completion_count;
+static BOOL checkpoint_committed;
+static BOOL checkpoint_fail_finalizer;
 
 static BOOL
 Observe_Semantic_Gatekeeper
@@ -74,6 +84,216 @@ Observe_Conversion
     result->source_disposition_count = 1;
     result->converted_disposition_count = 1;
     return pu_info != NULL && tree != NULL && *tree != NULL;
+}
+
+static BOOL
+Observe_Checkpoint_Finalizer
+        (const VHO_FHE_CONVERT_RESULT *aggregate, FILE *diagnostic)
+{
+    (void)diagnostic;
+    ++checkpoint_finalizer_count;
+    if (aggregate == NULL || aggregate->conversion_pass_count != 1)
+        return FALSE;
+    if (!VHO_FHE_Convert_Checkpoint_Register_Artifact
+             (checkpoint_temporary[1], checkpoint_final[1]) ||
+        !VHO_FHE_Convert_Checkpoint_Register_Artifact
+             (checkpoint_temporary[0], checkpoint_final[0]) ||
+        VHO_FHE_Convert_Checkpoint_Register_Artifact
+             (checkpoint_temporary[0], checkpoint_final[1]) ||
+        VHO_FHE_Convert_Checkpoint_Register_Artifact
+             (checkpoint_temporary[1], checkpoint_final[0]) ||
+        VHO_FHE_Convert_Checkpoint_Register_Artifact
+             (checkpoint_final[0], checkpoint_alias[0]) ||
+        VHO_FHE_Convert_Checkpoint_Register_Artifact
+             (checkpoint_alias[0], checkpoint_temporary[0]) ||
+        VHO_FHE_Convert_Checkpoint_Register_Artifact
+             (checkpoint_binary_temporary, checkpoint_alias[0]) ||
+        VHO_FHE_Convert_Checkpoint_Register_Artifact
+             (checkpoint_alias[0], checkpoint_binary_temporary) ||
+        VHO_FHE_Convert_Checkpoint_Register_Artifact
+             (checkpoint_binary_final, checkpoint_alias[1]) ||
+        VHO_FHE_Convert_Checkpoint_Register_Artifact
+             (checkpoint_alias[1], checkpoint_binary_final))
+        return FALSE;
+    for (UINT32 i = 0; i < 2; ++i) {
+        FILE *file = fopen(checkpoint_temporary[i], "w");
+        if (file == NULL)
+            return FALSE;
+        fprintf(file, "auxiliary artifact %u\n", i);
+        if (fclose(file) != 0)
+            return FALSE;
+    }
+    return !checkpoint_fail_finalizer;
+}
+
+static void
+Observe_Checkpoint_Completion (BOOL committed)
+{
+    ++checkpoint_completion_count;
+    checkpoint_committed = committed;
+}
+
+static void
+Prepare_Checkpoint_Artifact_Paths (void)
+{
+    snprintf(checkpoint_binary_temporary,
+             sizeof(checkpoint_binary_temporary),
+             "/tmp/open64_fhe_checkpoint_%ld.B.tmp", (long)getpid());
+    snprintf(checkpoint_binary_final, sizeof(checkpoint_binary_final),
+             "/tmp/open64_fhe_checkpoint_%ld.B", (long)getpid());
+    remove(checkpoint_binary_temporary);
+    remove(checkpoint_binary_final);
+    for (UINT32 i = 0; i < 2; ++i) {
+        snprintf(checkpoint_temporary[i], sizeof(checkpoint_temporary[i]),
+                 "/tmp/open64_fhe_checkpoint_%ld_%u.tmp",
+                 (long)getpid(), i);
+        snprintf(checkpoint_final[i], sizeof(checkpoint_final[i]),
+                 "/tmp/open64_fhe_checkpoint_%ld_%u.out",
+                 (long)getpid(), i);
+        snprintf(checkpoint_alias[i], sizeof(checkpoint_alias[i]),
+                 "/tmp/open64_fhe_checkpoint_%ld_alias_%u",
+                 (long)getpid(), i);
+        remove(checkpoint_temporary[i]);
+        remove(checkpoint_final[i]);
+        remove(checkpoint_alias[i]);
+    }
+}
+
+static BOOL
+Check_Checkpoint_Artifact_Lifecycle
+        (const VHO_FHE_CONVERT_RESULT *aggregate)
+{
+    Prepare_Checkpoint_Artifact_Paths();
+    checkpoint_finalizer_count = 0;
+    checkpoint_completion_count = 0;
+    checkpoint_committed = TRUE;
+    checkpoint_fail_finalizer = FALSE;
+    if (!VHO_FHE_Convert_Register_Checkpoint_Lifecycle
+             (Observe_Checkpoint_Finalizer,
+              Observe_Checkpoint_Completion) ||
+        VHO_FHE_Convert_Register_Checkpoint_Lifecycle
+             (Observe_Checkpoint_Finalizer,
+              Observe_Checkpoint_Completion) ||
+        !VHO_FHE_Convert_Checkpoint_Begin
+             (checkpoint_binary_temporary, checkpoint_binary_final,
+              stderr) ||
+        VHO_FHE_Convert_Checkpoint_Begin
+             (checkpoint_binary_temporary, checkpoint_binary_final, NULL) ||
+        !VHO_FHE_Convert_Checkpoint_Finalize(aggregate, stderr) ||
+        checkpoint_finalizer_count != 1 ||
+        VHO_FHE_Convert_Checkpoint_Artifact_Count() != 2 ||
+        VHO_FHE_Convert_Checkpoint_Finalize(aggregate, NULL) ||
+        !VHO_FHE_Convert_Checkpoint_Publish_Artifacts(stderr))
+        return FALSE;
+    for (UINT32 i = 0; i < 2; ++i) {
+        if (access(checkpoint_temporary[i], F_OK) == 0 ||
+            access(checkpoint_final[i], F_OK) != 0)
+            return FALSE;
+    }
+    VHO_FHE_Convert_Checkpoint_Abort();
+    if (checkpoint_completion_count != 1 || checkpoint_committed ||
+        VHO_FHE_Convert_Checkpoint_Artifact_Count() != 0)
+        return FALSE;
+    for (UINT32 i = 0; i < 2; ++i) {
+        if (access(checkpoint_temporary[i], F_OK) == 0 ||
+            access(checkpoint_final[i], F_OK) == 0)
+            return FALSE;
+    }
+
+    checkpoint_finalizer_count = 0;
+    checkpoint_completion_count = 0;
+    checkpoint_committed = FALSE;
+    if (!VHO_FHE_Convert_Register_Checkpoint_Lifecycle
+             (Observe_Checkpoint_Finalizer,
+              Observe_Checkpoint_Completion) ||
+        !VHO_FHE_Convert_Checkpoint_Begin
+             (checkpoint_binary_temporary, checkpoint_binary_final,
+              stderr) ||
+        !VHO_FHE_Convert_Checkpoint_Finalize(aggregate, stderr) ||
+        !VHO_FHE_Convert_Checkpoint_Publish_Artifacts(stderr))
+        return FALSE;
+    VHO_FHE_Convert_Checkpoint_Complete();
+    if (checkpoint_finalizer_count != 1 ||
+        checkpoint_completion_count != 1 || !checkpoint_committed ||
+        VHO_FHE_Convert_Checkpoint_Artifact_Count() != 0)
+        return FALSE;
+    for (UINT32 i = 0; i < 2; ++i) {
+        if (access(checkpoint_temporary[i], F_OK) == 0 ||
+            access(checkpoint_final[i], F_OK) != 0)
+            return FALSE;
+        remove(checkpoint_final[i]);
+    }
+
+    checkpoint_finalizer_count = 0;
+    checkpoint_completion_count = 0;
+    checkpoint_committed = TRUE;
+    checkpoint_fail_finalizer = TRUE;
+    if (!VHO_FHE_Convert_Register_Checkpoint_Lifecycle
+             (Observe_Checkpoint_Finalizer,
+              Observe_Checkpoint_Completion) ||
+        !VHO_FHE_Convert_Checkpoint_Begin
+             (checkpoint_binary_temporary, checkpoint_binary_final,
+              stderr) ||
+        VHO_FHE_Convert_Checkpoint_Finalize(aggregate, NULL))
+        return FALSE;
+    VHO_FHE_Convert_Checkpoint_Abort();
+    if (checkpoint_finalizer_count != 1 ||
+        checkpoint_completion_count != 1 || checkpoint_committed)
+        return FALSE;
+    for (UINT32 i = 0; i < 2; ++i) {
+        if (access(checkpoint_temporary[i], F_OK) == 0 ||
+            access(checkpoint_final[i], F_OK) == 0)
+            return FALSE;
+    }
+    checkpoint_fail_finalizer = FALSE;
+
+    checkpoint_completion_count = 0;
+    checkpoint_committed = TRUE;
+    if (!VHO_FHE_Convert_Register_Checkpoint_Lifecycle
+             (Observe_Checkpoint_Finalizer,
+              Observe_Checkpoint_Completion) ||
+        !VHO_FHE_Convert_Checkpoint_Begin
+             (checkpoint_binary_temporary, checkpoint_binary_final,
+              stderr) ||
+        !VHO_FHE_Convert_Checkpoint_Finalize(aggregate, stderr))
+        return FALSE;
+    FILE *foreign = fopen(checkpoint_final[0], "w");
+    if (foreign == NULL)
+        return FALSE;
+    fprintf(foreign, "foreign artifact\n");
+    if (fclose(foreign) != 0 ||
+        VHO_FHE_Convert_Checkpoint_Publish_Artifacts(NULL))
+        return FALSE;
+    VHO_FHE_Convert_Checkpoint_Abort();
+    char foreign_contents[32];
+    foreign = fopen(checkpoint_final[0], "r");
+    if (foreign == NULL ||
+        fgets(foreign_contents, sizeof(foreign_contents), foreign) == NULL ||
+        fclose(foreign) != 0 ||
+        strcmp(foreign_contents, "foreign artifact\n") != 0 ||
+        checkpoint_completion_count != 1 || checkpoint_committed)
+        return FALSE;
+    remove(checkpoint_final[0]);
+
+    checkpoint_completion_count = 0;
+    checkpoint_committed = TRUE;
+    FILE *stale = fopen(checkpoint_binary_final, "w");
+    if (stale == NULL)
+        return FALSE;
+    fprintf(stale, "stale checkpoint\n");
+    if (fclose(stale) != 0 ||
+        !VHO_FHE_Convert_Register_Checkpoint_Lifecycle
+             (Observe_Checkpoint_Finalizer,
+              Observe_Checkpoint_Completion) ||
+        VHO_FHE_Convert_Checkpoint_Begin
+             (checkpoint_binary_temporary, checkpoint_binary_final, NULL))
+        return FALSE;
+    VHO_FHE_Convert_Checkpoint_Abort();
+    if (checkpoint_completion_count != 1 || checkpoint_committed ||
+        access(checkpoint_binary_final, F_OK) != 0)
+        return FALSE;
+    remove(checkpoint_binary_final);
+    return TRUE;
 }
 
 static void
@@ -176,6 +396,10 @@ main(void)
         !VHO_FHE_Convert_Checkpoint_Validate(1, 1, &aggregate, stderr) ||
         VHO_FHE_Convert_Checkpoint_Validate(2, 1, &aggregate, NULL)) {
         fprintf(stderr, "FHE checkpoint aggregation contract changed\n");
+        return 1;
+    }
+    if (!Check_Checkpoint_Artifact_Lifecycle(&aggregate)) {
+        fprintf(stderr, "FHE checkpoint artifact lifecycle changed\n");
         return 1;
     }
 

--- a/osprey/common/com/tests/dsl_fhe_conversion_checkpoint_test.sh
+++ b/osprey/common/com/tests/dsl_fhe_conversion_checkpoint_test.sh
@@ -39,11 +39,14 @@ output="$artifact_dir/$input_stem.fhe.B"
 trace="$artifact_dir/$input_stem.fhe.T"
 validation_log="$artifact_dir/validation.log"
 failure_log="$artifact_dir/failure.log"
+stale_output_log="$artifact_dir/stale-output.log"
 command_log="$artifact_dir/commands.txt"
 
 printf '%s\n' \
   "$be -FHE:checkpoint=$output $input" \
-  "$ir_b2a -st -src $output $trace" >"$command_log"
+  "$ir_b2a -st -src $output $trace" \
+  "$be -FHE:checkpoint=$output $input # must reject stale output" \
+  >"$command_log"
 
 if [[ -n "$source_file" ]]; then
   if [[ ! -f "$source_file" ]]; then
@@ -86,6 +89,25 @@ if ! grep -Fq 'FHE conversion checkpoint: output=' "$validation_log"; then
   exit 1
 fi
 
+output_checksum="$(cksum "$output")"
+if "$be" -FHE:checkpoint="$output" "$input" \
+    >"$stale_output_log" 2>&1; then
+  echo "checkpoint unexpectedly replaced a stale final output" >&2
+  exit 1
+fi
+if [[ "$(cksum "$output")" != "$output_checksum" ]]; then
+  echo "stale checkpoint output changed after rejected publication" >&2
+  exit 1
+fi
+if [[ -e "$output.tmp" ]]; then
+  echo "stale-output rejection left a temporary checkpoint" >&2
+  exit 1
+fi
+if ! grep -Fq 'CFHE-CHECKPOINT-006' "$stale_output_log"; then
+  echo "missing stale checkpoint destination diagnostic" >&2
+  exit 1
+fi
+
 if [[ -n "$reject_input" ]]; then
   rejected_output="$artifact_dir/must_not_exist.fhe.B"
   if "$be" -FHE:checkpoint="$rejected_output" "$reject_input" \
@@ -108,6 +130,7 @@ echo "review binary: $output"
 echo "review trace: $trace"
 echo "review commands: $command_log"
 echo "review diagnostics: $validation_log"
+echo "review stale-output diagnostics: $stale_output_log"
 if [[ -f "$failure_log" ]]; then
   echo "review rejected-run diagnostics: $failure_log"
 fi

--- a/osprey/common/com/tests/dsl_fhe_sync3_vho_driver_test.sh
+++ b/osprey/common/com/tests/dsl_fhe_sync3_vho_driver_test.sh
@@ -43,15 +43,31 @@ done
 
 for evidence in \
   'VHO_FHE_Convert_Driver_With_Result' \
+  'VHO_FHE_Convert_Checkpoint_Begin' \
   'VHO_FHE_Convert_Checkpoint_Validate' \
+  'VHO_FHE_Convert_Checkpoint_Finalize' \
+  'VHO_FHE_Convert_Checkpoint_Publish_Artifacts' \
+  'VHO_FHE_Convert_Checkpoint_Complete' \
+  'VHO_FHE_Convert_Checkpoint_Abort' \
   'Write_PU_Info(current_pu)' \
   'Write_Global_Info(pu_tree)' \
-  'rename(fhe_checkpoint_temp_name'; do
+  'Publish_FHE_Conversion_Checkpoint'; do
   if ! grep -Fq "$evidence" "$driver_source"; then
     echo "missing all-PU checkpoint evidence '$evidence' in $driver_source" >&2
     exit 1
   fi
 done
+
+finalize_line="$(grep -n 'VHO_FHE_Convert_Checkpoint_Finalize' "$driver_source" | tail -1 | cut -d: -f1)"
+global_line="$(grep -n 'Write_Global_Info(pu_tree)' "$driver_source" | tail -1 | cut -d: -f1)"
+publish_line="$(grep -n 'VHO_FHE_Convert_Checkpoint_Publish_Artifacts' "$driver_source" | tail -1 | cut -d: -f1)"
+binary_line="$(grep -n 'if (!Publish_FHE_Conversion_Checkpoint())' "$driver_source" | tail -1 | cut -d: -f1)"
+complete_line="$(grep -n 'VHO_FHE_Convert_Checkpoint_Complete' "$driver_source" | tail -1 | cut -d: -f1)"
+if (( finalize_line >= global_line || global_line >= publish_line ||
+      publish_line >= binary_line || binary_line >= complete_line )); then
+  echo "FHE checkpoint publication ordering changed in $driver_source" >&2
+  exit 1
+fi
 
 if ! grep -Fq '"checkpoint", "checkpoint"' "$config_source"; then
   echo "missing -FHE:checkpoint option in $config_source" >&2


### PR DESCRIPTION
## Summary

- add an all-PU FHE checkpoint finalizer/completion lifecycle and backend-owned auxiliary artifact registry
- reserve the binary checkpoint endpoints before conversion and reject stale `.fhe.B` commit markers
- reject the complete auxiliary/binary pathname alias matrix
- publish auxiliary files deterministically with atomic no-replace semantics, then publish `.fhe.B` last as the commit marker
- block handled signals across publication and rollback-state updates
- document ownership, ordering, diagnostics, and the same-filesystem requirement

## Compatibility

This is runtime-only backend orchestration. It adds no mapped-image row, ELF section, opcode, TY encoding, or binary WHIRL revision. `be.so` and `lw_inline` retain zero `DSL_Builder_*` and driver-only cleanup symbol dependencies.

## Validation

- `fhe_convert_contract_test`: passed, including cross-alias, no-clobber, rollback, completion, failed-finalizer, and stale-marker cases
- all-PU checkpoint integration: passed; rebuilt `ir_b2a -st -src` reopened two PUs and two call edges
- stale-output integration: rejected with `CFHE-CHECKPOINT-006`, checksum unchanged, no `.tmp` left
- `dsl_native_syntax_test.sh`: passed
- rebuilt `be.so`, `be`, and `lw_inline`
- symbol audit: zero `DSL_Builder_*` and zero `Cleanup_FHE_Conversion_Checkpoint` in `be.so`/`lw_inline`

## Coordination

Reviewed and accepted by the FHE producer task. After merge, that task can jointly publish the converted tensor payload and conversion report with the all-PU `.fhe.B` checkpoint.