### PR TITLE
Complete native FHE BatchNorm fold infrastructure

### DIFF
--- a/doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md
+++ b/doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md
@@ -51,7 +51,7 @@ FHE producer and semantic gatekeeper own payload digest verification.
 
 `DSL_IR_Materialize_External_Tensor_Values()` preflights the complete request
 array before creating a symbol, WN, image row, or call replacement. Each
-request names an existing owner-PU external tensor source and creates one
+request names an existing owner-PU tensor-constant source and creates one
 caller-owned `common.tensor_const.v1` value with:
 
 - the exact canonical tensor `TY_IDX`;
@@ -62,6 +62,18 @@ caller-owned `common.tensor_const.v1` value with:
 - `dsl.converted_from_value_id` provenance;
 - immutable original source payload and source value; and
 - stable logical `ir_b2a -st -src` evidence.
+
+The request's named `source_policy` is fail-closed. Its zero/default value,
+`DSL_IR_MATERIALIZE_SOURCE_EXTERNAL_ONLY`, preserves the original contract.
+`DSL_IR_MATERIALIZE_SOURCE_EXTERNAL_OR_IMPLICIT_ZERO` additionally admits an
+exact, pure `common.tensor_const.v1` constant whose value kind is
+`implicit_zero`. The implicit-zero value must be the existing physical actual,
+have the exact owner and canonical `TY_IDX`, and agree with the output's dtype,
+shape, and byte length. It legitimately has no source checksum. The resulting
+external-data value must have a nonempty checksum, valid tensor TCON, and valid
+side-file byte range. `dsl.converted_from_value_id` continues to identify the
+implicit-zero source; BatchNorm inputs remain separately identified by the
+fold-provenance row.
 
 When `call` is non-null, the request must identify one existing read-only,
 passed-not-saved, by-reference actual and its expected source value. Commit
@@ -109,9 +121,88 @@ continued conversion. A failure after materialization is terminal for the
 conversion-only process: it must not retry or continue transforming the
 mutated in-memory image.
 
-No mapped-image row, ELF section, WHIRL opcode, TY encoding, or binary revision
-is added. New logical node/value/ST metadata records use the existing managed
-tables and mapped-image writer/reader path.
+The call-ABI extension below adds one optional ELF section. It does not change
+an existing mapped-image row, WHIRL opcode, TY encoding, binary revision, or
+the `.WHIRL.dsl` v1 row sizes.
+
+## Durable Call ABI Roles
+
+The optional `.WHIRL.dsl_call_abi` image records the semantic relationship
+between a call argument and a callee formal without retaining caller-local WN
+pointers or parsing source variable names. Its v1 header is 24 bytes and each
+argument row is 32 bytes. Row identity is `(callsite_id, actual_ordinal)`;
+zero IDs, `UINT32_MAX` ordinals, unknown flags, duplicate identities, and
+trailing or truncated images are rejected.
+
+Each row records `argument_value_id`, `callee_formal_ordinal`, and a stable
+structural semantic role. Role names are versioned by the producer/domain
+contract and use lowercase dot-separated identifiers, for example
+`cnn.basic_block.conv1.weight`. They describe structural paths, not Python or
+source variable spellings. Equivalent contexts that call one shared PU must
+agree on the role assigned to a given callee formal ordinal.
+
+Validation proves that the callsite's callee agrees, both ordinals are in
+range, the argument value is caller-owned and matches the physical call
+actual's ST and `TY_IDX`, and the callee formal has that exact `TY_IDX`.
+Per-PU validation requires that PU's local symbol table and `Current_pu` to be
+active; a mismatched active PU is rejected before any local ST is dereferenced.
+Consumers may enumerate rows, query by `(callsite_id, actual_ordinal)`, or
+query by `(callee_pu_st, callee_formal_ordinal)`. Borrowed records must not be
+retained across managed-table mutation or reset.
+
+Batch materialization updates `argument_value_id` in the same preflight/commit
+unit as the physical call actual. A rejected request array changes neither the
+call nor the ABI table. Original provenance remains in
+`dsl.converted_from_value_id` and does not enter ABI-row identity.
+
+## Native Value Redirection And Retirement
+
+`DSL_IR_Redirect_And_Retire_Native_Value()` supports the narrow pure-expression
+case required to retire a folded BatchNorm result. The caller supplies the
+owner PU, function root, containing BLOCK, replacement and retiring STIDs,
+their managed value IDs, the expected logical operator/version, and the
+operand ordinal that names the replacement.
+
+Preflight requires:
+
+- both definitions are in the same BLOCK and the replacement precedes the
+  retiring STID, so it dominates every accepted use;
+- every executable use occurs after the retiring STID;
+- the retiring result symbol has one definition and unique ownership;
+- the registered logical operator is pure and has no state-effect rows;
+- the replacement operand agrees in the physical WN, logical operand row,
+  result ST, and exact canonical `TY_IDX`;
+- uses are direct LDID reads, including nested BLOCK/REGION bodies; and
+- no LDA/address-taken use, second STID/write, alias escape, call-ABI argument,
+  or unsupported managed relationship exists.
+
+Commit redirects physical LDID reads, managed DSL value references, and
+managed REGION interface ST references, then removes the retiring STID from
+the executable tree. FHE disposition and fold rows remain provenance and are
+not redirected. The logical node and value rows remain visible for inspection:
+the node carries `DSL_IR_NODE_FLAG_RETIRED`, the value carries
+`DSL_IR_VALUE_FLAG_REDIRECTED`, and the redirect target is derived from the
+retired node's recorded replacement operand ordinal. No existing reserved row
+field is reclassified.
+
+REGION interface redirection has its own no-mutation preflight. It applies the
+candidate ST replacement to a copied interface set and runs the same generic
+and contract-profile verifier used after mapped reopen. A duplicate symbol,
+role/ordinal conflict, or profile violation rejects retirement before any WN,
+REGION, or DSL row changes.
+
+Gatekeeper and `ir_b2a -st -src` distinguish total logical rows from executable
+nodes. Mapped reopen preserves the retired/redirected evidence and validates
+that the derived target remains well formed. The immediately previous
+same-revision reader ignores the unknown optional `.WHIRL.dsl_call_abi`
+section, reopens both fixtures, and passes its traditional WHIRL verifier. Its
+per-PU DSL gatekeeper also accepts the non-retirement fixture because the
+physical tree and the existing DSL image remain consistent. For a
+retirement-bearing image, its program-level DSL gatekeeper fails closed with a
+physical/logical node-count mismatch; it does not silently treat the retained
+logical row as executable. Such images therefore require the updated DSL-aware
+gatekeeper even though their physical WHIRL remains readable by the previous
+tool.
 
 ## Focused Evidence
 

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1911,6 +1911,32 @@ full-sequence causal prompt evaluation with no KV cache.
    `doc/FHE-SYNC3-CHECKPOINT-ARTIFACT-CONTRACT.md`. This adds no mapped-image
    row, ELF section, opcode, type encoding, or binary revision.
 
+41. [x] Publish cross-PU call roles, implicit-zero materialization, and pure
+   value retirement.
+
+   Add optional `.WHIRL.dsl_call_abi` fixed rows that map each call actual to
+   its callee formal and versioned structural semantic role. Validate exact
+   owner, callsite, ST, `TY_IDX`, ordinal, and shared-callee role agreement;
+   provide enumeration plus callsite/actual and callee/formal queries. Batch
+   external-tensor materialization updates the physical actual and its ABI row
+   atomically within the complete request-array preflight/commit unit.
+
+   Extend materialization with a named, fail-closed source policy. The default
+   remains external-data only; an explicit policy also accepts an exact pure,
+   typed `common.tensor_const.v1` implicit-zero source while requiring full
+   checksum, TCON, range, shape, and dtype evidence on the new external value.
+
+   Add conservative redirection and executable retirement for a uniquely
+   defined pure DSL result. Require same-BLOCK dominance, post-definition
+   direct LDID uses, no address taking or second write, exact operand/TY
+   agreement, no state effects, and complete managed-reference coverage.
+   Redirect WN, DSL, and REGION-interface references together, remove the STID
+   from the executable tree, and retain explicitly flagged logical
+   node/value rows for provenance and `ir_b2a -st -src` review. Derive the
+   redirect target from the retired node operand instead of repurposing a
+   reserved fixed-row field. The detailed compatibility and atomicity contract
+   is in `doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md`.
+
 ### Deferred work TODO
 
 Deferred work remains tracked but does not block the active native DSL bring-up

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -107,6 +107,7 @@ struct dsl_builder_call_record {
     std::string context_identity;
     UINT32 call_ordinal;
     DSL_BUILDER_SOURCE_POSITION source_position;
+    std::vector<DSL_BUILDER_VALUE> arguments;
     std::vector<DSL_BUILDER_VALUE> results;
 };
 
@@ -129,6 +130,7 @@ DSL_Builder_Reset_Program (void)
     DSL_Builder_PU_Root = NULL;
     DSL_Builder_PU_Last = NULL;
     DSL_Builder_Active_PU = NULL;
+    Current_PU_Info = NULL;
     DSL_Builder_Result_Number = 0;
     DSL_Builder_CU_DST = DST_INVALID_IDX;
     DSL_builder_source_files.clear();
@@ -221,6 +223,7 @@ DSL_Builder_Select_PU (DSL_BUILDER_PROGRAM_UNIT pu)
     Current_scope = Current_pu->lexical_level;
     Restore_Local_Symtab(pu);
     Current_Map_Tab = PU_Info_maptab(pu);
+    Current_PU_Info = pu;
     DSL_Builder_Active_PU = pu;
     return TRUE;
 }
@@ -3416,6 +3419,7 @@ DSL_Builder_Create_Minimal_PU (const char *name)
 
     Save_Local_Symtab(Current_scope, pu_info);
     DSL_Builder_Active_PU = pu_info;
+    Current_PU_Info = pu_info;
 
     dsl_builder_pu_interface *interface_record =
         new dsl_builder_pu_interface;
@@ -3666,6 +3670,8 @@ DSL_Builder_Create_PU_Call
                                         (callsite->context_identity);
     call_record->call_ordinal = callsite->call_ordinal;
     call_record->source_position = callsite->source_position;
+    for (UINT32 i = 0; i < argument_count; ++i)
+        call_record->arguments.push_back(arguments[i]);
     for (UINT32 i = 0; i < result_count; ++i) {
         TY_IDX result_ty = callee_interface->results[i].ty;
         ST_IDX result_st = DSL_Builder_Create_Tensor_Result_Symbol
@@ -3768,6 +3774,67 @@ DSL_Builder_Create_PU_Call
     WN_INSERT_BlockLast(body, call);
     DSL_builder_call_registry.push_back(call_record);
     return call;
+}
+
+static BOOL
+DSL_Builder_Call_Argument_Role_Valid (const char *role)
+{
+    if (role == NULL || role[0] == '\0')
+        return FALSE;
+    BOOL component_start = TRUE;
+    for (const char *cursor = role; *cursor != '\0'; ++cursor) {
+        if (*cursor == '.') {
+            if (component_start)
+                return FALSE;
+            component_start = TRUE;
+            continue;
+        }
+        if (component_start) {
+            if (*cursor < 'a' || *cursor > 'z')
+                return FALSE;
+            component_start = FALSE;
+        } else if ((*cursor < 'a' || *cursor > 'z') &&
+                   (*cursor < '0' || *cursor > '9') && *cursor != '_') {
+            return FALSE;
+        }
+    }
+    return !component_start;
+}
+
+BOOL
+DSL_Builder_Set_PU_Call_Argument_Role
+        (DSL_BUILDER_CALL call, UINT32 actual_ordinal,
+         UINT32 callee_formal_ordinal, const char *semantic_role)
+{
+    dsl_builder_call_record *call_record =
+        DSL_Builder_Find_Call_Record(call);
+    dsl_builder_pu_interface *callee_interface = call_record == NULL ? NULL :
+        DSL_Builder_Find_PU_Interface(call_record->callee);
+    if (call_record == NULL || callee_interface == NULL ||
+        !DSL_Builder_Call_Argument_Role_Valid(semantic_role) ||
+        actual_ordinal >= call_record->arguments.size() ||
+        callee_formal_ordinal >= callee_interface->formals.size())
+        return FALSE;
+
+    DSL_BUILDER_VALUE_RECORD *argument = DSL_Builder_Find_Value_Record
+        (call_record->arguments[actual_ordinal]);
+    if (argument == NULL || argument->pu != call_record->caller ||
+        argument->result_ty !=
+            callee_interface->formals[callee_formal_ordinal].ty)
+        return FALSE;
+
+    DSL_CALLSITE_METADATA_RECORD callsite;
+    if (!DSL_Call_Image_Find_Callsite(call, &callsite))
+        return FALSE;
+    DSL_CALL_ARGUMENT_RECORD record;
+    memset(&record, 0, sizeof(record));
+    record.callsite_id = callsite.id;
+    record.argument_value_id = argument->image_value_id;
+    record.actual_ordinal = actual_ordinal;
+    record.callee_formal_ordinal = callee_formal_ordinal;
+    record.semantic_role = Save_Str(semantic_role);
+    return DSL_Call_ABI_Image_Add_Argument(call, &record) !=
+           DSL_CALL_ARGUMENT_INVALID_ID;
 }
 
 BOOL
@@ -4075,6 +4142,10 @@ DSL_Builder_Verify_Program (DSL_BUILDER_VERIFY_RESULT *result)
             valid = FALSE;
             ++gatekeeper_result.error_count;
         }
+        if (!DSL_Call_ABI_Image_Validate_PU(pu, diagnostic)) {
+            valid = FALSE;
+            ++gatekeeper_result.error_count;
+        }
     }
     if (!DSL_FHE_Image_Validate(diagnostic)) {
         valid = FALSE;
@@ -4084,13 +4155,14 @@ DSL_Builder_Verify_Program (DSL_BUILDER_VERIFY_RESULT *result)
         valid = FALSE;
         ++gatekeeper_result.error_count;
     }
-    if (gatekeeper_result.native_node_count != DSL_IR_Image_Node_Count()) {
+    if (gatekeeper_result.native_node_count !=
+            DSL_IR_Image_Executable_Node_Count()) {
         if (diagnostic != NULL)
             fprintf(diagnostic,
                     "native tree node count %u does not match "
                     "DSL image node count %u\n",
                     gatekeeper_result.native_node_count,
-                    DSL_IR_Image_Node_Count());
+                    DSL_IR_Image_Executable_Node_Count());
         valid = FALSE;
         ++gatekeeper_result.error_count;
     }

--- a/osprey/common/com/dsl_builder.h
+++ b/osprey/common/com/dsl_builder.h
@@ -269,6 +269,11 @@ extern DSL_BUILDER_CALL DSL_Builder_Create_PU_Call
                                  const char *const *result_names,
                                  UINT32 result_count,
                                  const DSL_BUILDER_CALLSITE_INFO *callsite);
+extern BOOL DSL_Builder_Set_PU_Call_Argument_Role
+                                (DSL_BUILDER_CALL call,
+                                 UINT32 actual_ordinal,
+                                 UINT32 callee_formal_ordinal,
+                                 const char *semantic_role);
 extern BOOL DSL_Builder_Get_PU_Call_Result
                                 (DSL_BUILDER_CALL call,
                                  UINT32 ordinal,

--- a/osprey/common/com/dsl_gatekeeper.cxx
+++ b/osprey/common/com/dsl_gatekeeper.cxx
@@ -305,6 +305,7 @@ DSL_Gatekeeper_Find_Image_Node
     for (UINT32 i = 1; i <= DSL_IR_Image_Value_Count(); ++i) {
         DSL_IR_VALUE_RECORD value;
         if (!DSL_IR_Image_Get_Value(i, &value) || value.st != result_st ||
+            (value.flags & DSL_IR_VALUE_FLAG_REDIRECTED) != 0 ||
             value.producer_node_id == DSL_IR_NODE_INVALID_ID ||
             result_name == NULL ||
             value.name == STR_IDX_ZERO ||
@@ -1845,6 +1846,10 @@ DSL_Gatekeeper_Verify_PU
         valid = FALSE;
         ++context.result.error_count;
     }
+    if (!DSL_Call_ABI_Image_Validate(diagnostic)) {
+        valid = FALSE;
+        ++context.result.error_count;
+    }
     if (pu == NULL || PU_Info_state(pu, WT_TREE) != Subsect_InMem ||
         PU_Info_tree_ptr(pu) == NULL)
         valid = DSL_Gatekeeper_Report
@@ -1884,6 +1889,10 @@ DSL_Gatekeeper_Verify_Program
         valid = FALSE;
         ++context.result.error_count;
     }
+    if (!DSL_Call_ABI_Image_Validate(diagnostic)) {
+        valid = FALSE;
+        ++context.result.error_count;
+    }
 
     for (PU_Info *pu = pu_tree; pu != NULL; pu = PU_Info_next(pu)) {
         if (PU_Info_state(pu, WT_TREE) != Subsect_InMem ||
@@ -1904,12 +1913,13 @@ DSL_Gatekeeper_Verify_Program
             valid = FALSE;
     }
 
-    if (context.result.native_node_count != DSL_IR_Image_Node_Count())
+    if (context.result.native_node_count !=
+            DSL_IR_Image_Executable_Node_Count())
         valid = DSL_Gatekeeper_Report
                     (&context, "native tree node count %u does not match "
                      "DSL image node count %u",
                      context.result.native_node_count,
-                     DSL_IR_Image_Node_Count());
+                     DSL_IR_Image_Executable_Node_Count());
 
     if (result != NULL)
         *result = context.result;

--- a/osprey/common/com/dsl_ir_image.cxx
+++ b/osprey/common/com/dsl_ir_image.cxx
@@ -29,6 +29,7 @@ typedef SEGMENTED_ARRAY<DSL_PU_SOURCE_IDENTITY_RECORD>
     DSL_PU_SOURCE_IDENTITY_TABLE;
 typedef SEGMENTED_ARRAY<DSL_CALLSITE_METADATA_RECORD>
     DSL_CALLSITE_METADATA_TABLE;
+typedef SEGMENTED_ARRAY<DSL_CALL_ARGUMENT_RECORD> DSL_CALL_ARGUMENT_TABLE;
 
 static DSL_IR_OPCODE_DESCRIPTOR_TABLE DSL_ir_opcode_descriptor_table;
 static DSL_IR_NODE_TABLE DSL_ir_node_table;
@@ -39,6 +40,7 @@ static DSL_STATE_OBJECT_TABLE DSL_state_object_table;
 static DSL_STATE_EFFECT_TABLE DSL_state_effect_table;
 static DSL_PU_SOURCE_IDENTITY_TABLE DSL_pu_source_identity_table;
 static DSL_CALLSITE_METADATA_TABLE DSL_callsite_metadata_table;
+static DSL_CALL_ARGUMENT_TABLE DSL_call_argument_table;
 
 typedef struct {
     ST_IDX owner_pu_st;
@@ -88,6 +90,10 @@ typedef char DSL_PU_Source_Identity_Size_Check
 typedef char DSL_Callsite_Metadata_Size_Check
     [sizeof(DSL_CALLSITE_METADATA_RECORD) ==
         DSL_CALLSITE_METADATA_RECORD_SIZE ? 1 : -1];
+typedef char DSL_Call_ABI_Image_Header_Size_Check
+    [sizeof(DSL_CALL_ABI_IMAGE_HEADER) == DSL_CALL_ABI_IMAGE_HEADER_SIZE ? 1 : -1];
+typedef char DSL_Call_Argument_Size_Check
+    [sizeof(DSL_CALL_ARGUMENT_RECORD) == DSL_CALL_ARGUMENT_RECORD_SIZE ? 1 : -1];
 
 template <typename RECORD>
 static void
@@ -120,6 +126,7 @@ DSL_IR_Image_Reset (void)
     DSL_state_object_table.Delete_down_to(0);
     DSL_state_effect_table.Delete_down_to(0);
     DSL_Call_Image_Reset();
+    DSL_Call_ABI_Image_Reset();
 }
 
 static BOOL
@@ -292,6 +299,16 @@ DSL_Call_Image_Find_Callsite
     return FALSE;
 }
 
+const WN *
+DSL_Call_Image_Get_Call_WN (DSL_CALLSITE_METADATA_ID id)
+{
+    for (UINT32 i = 0; i < DSL_callsite_runtime_associations.size(); ++i) {
+        if (DSL_callsite_runtime_associations[i].id == id)
+            return DSL_callsite_runtime_associations[i].call;
+    }
+    return NULL;
+}
+
 UINT32 DSL_Call_Image_PU_Identity_Count (void)
 { return DSL_pu_source_identity_table.Size(); }
 
@@ -400,6 +417,227 @@ DSL_Call_Image_Load_Mapped
     return TRUE;
 }
 
+static BOOL
+DSL_Call_ABI_Image_Report (FILE *diagnostic, const char *message, UINT32 id)
+{
+    if (diagnostic != NULL)
+        fprintf(diagnostic, "DSL call ABI image error: %s id=%u\n",
+                message, id);
+    return FALSE;
+}
+
+void
+DSL_Call_ABI_Image_Get_Header (DSL_CALL_ABI_IMAGE_HEADER *header)
+{
+    if (header == NULL)
+        return;
+    memset(header, 0, sizeof(*header));
+    header->magic = DSL_CALL_ABI_IMAGE_MAGIC;
+    header->version = DSL_CALL_ABI_IMAGE_VERSION;
+    header->argument_count = DSL_call_argument_table.Size();
+}
+
+void
+DSL_Call_ABI_Image_Reset (void)
+{
+    DSL_call_argument_table.Delete_down_to(0);
+}
+
+BOOL
+DSL_Call_ABI_Image_Has_Records (void)
+{
+    return DSL_call_argument_table.Size() != 0;
+}
+
+BOOL
+DSL_Call_ABI_Image_Validate (FILE *diagnostic)
+{
+    for (UINT32 i = 0; i < DSL_call_argument_table.Size(); ++i) {
+        const DSL_CALL_ARGUMENT_RECORD &record = DSL_call_argument_table[i];
+        DSL_CALLSITE_METADATA_RECORD callsite;
+        if (record.id != i + 1 ||
+            record.callsite_id == DSL_CALLSITE_METADATA_INVALID_ID ||
+            !DSL_Call_Image_Get_Callsite(record.callsite_id, &callsite) ||
+            record.argument_value_id == DSL_IR_VALUE_INVALID_ID ||
+            record.argument_value_id > DSL_ir_value_table.Size() ||
+            record.actual_ordinal == DSL_CALL_ARGUMENT_INVALID_ORDINAL ||
+            record.callee_formal_ordinal ==
+                DSL_CALL_ARGUMENT_INVALID_ORDINAL ||
+            record.flags != 0 ||
+            !DSL_IR_Image_String_Id_Valid(record.semantic_role, TRUE))
+            return DSL_Call_ABI_Image_Report
+                       (diagnostic, "invalid argument", i + 1);
+
+        for (UINT32 j = 0; j < i; ++j) {
+            const DSL_CALL_ARGUMENT_RECORD &previous =
+                DSL_call_argument_table[j];
+            if (previous.callsite_id == record.callsite_id &&
+                previous.actual_ordinal == record.actual_ordinal)
+                return DSL_Call_ABI_Image_Report
+                           (diagnostic, "duplicate call argument", i + 1);
+            DSL_CALLSITE_METADATA_RECORD previous_callsite;
+            if (previous.callee_formal_ordinal ==
+                    record.callee_formal_ordinal &&
+                DSL_Call_Image_Get_Callsite
+                    (previous.callsite_id, &previous_callsite) &&
+                previous_callsite.callee_pu_st == callsite.callee_pu_st &&
+                strcmp(Index_To_Str(previous.semantic_role),
+                       Index_To_Str(record.semantic_role)) != 0)
+                return DSL_Call_ABI_Image_Report
+                           (diagnostic, "inconsistent formal role", i + 1);
+        }
+    }
+    return TRUE;
+}
+
+DSL_CALL_ARGUMENT_ID
+DSL_Call_ABI_Image_Add_Argument
+        (const WN *call, const DSL_CALL_ARGUMENT_RECORD *record)
+{
+    DSL_CALLSITE_METADATA_RECORD callsite;
+    if (call == NULL || record == NULL ||
+        !DSL_Call_Image_Find_Callsite(call, &callsite) ||
+        record->callsite_id != callsite.id)
+        return DSL_CALL_ARGUMENT_INVALID_ID;
+
+    DSL_CALL_ARGUMENT_RECORD copy = *record;
+    UINT32 index = DSL_call_argument_table.Insert(copy);
+    DSL_call_argument_table[index].id = index + 1;
+    if (!DSL_Call_ABI_Image_Validate(NULL)) {
+        DSL_call_argument_table.Delete_down_to(index);
+        return DSL_CALL_ARGUMENT_INVALID_ID;
+    }
+    return index + 1;
+}
+
+UINT32
+DSL_Call_ABI_Image_Argument_Count (void)
+{
+    return DSL_call_argument_table.Size();
+}
+
+BOOL
+DSL_Call_ABI_Image_Get_Argument
+        (DSL_CALL_ARGUMENT_ID id, DSL_CALL_ARGUMENT_RECORD *record)
+{
+    return DSL_IR_Table_Get(DSL_call_argument_table, id, record);
+}
+
+BOOL
+DSL_Call_ABI_Image_Find_Argument_By_Id
+        (DSL_CALLSITE_METADATA_ID callsite_id, UINT32 actual_ordinal,
+         DSL_CALL_ARGUMENT_RECORD *record)
+{
+    for (UINT32 i = 0; i < DSL_call_argument_table.Size(); ++i) {
+        if (DSL_call_argument_table[i].callsite_id == callsite_id &&
+            DSL_call_argument_table[i].actual_ordinal == actual_ordinal)
+            return DSL_IR_Table_Get(DSL_call_argument_table, i + 1, record);
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_Call_ABI_Image_Find_Argument
+        (const WN *call, UINT32 actual_ordinal,
+         DSL_CALL_ARGUMENT_RECORD *record)
+{
+    DSL_CALLSITE_METADATA_RECORD callsite;
+    return DSL_Call_Image_Find_Callsite(call, &callsite) &&
+           DSL_Call_ABI_Image_Find_Argument_By_Id
+               (callsite.id, actual_ordinal, record);
+}
+
+BOOL
+DSL_Call_ABI_Image_Update_Argument_Value
+        (const WN *call, UINT32 actual_ordinal,
+         DSL_IR_VALUE_ID expected_value_id,
+         DSL_IR_VALUE_ID replacement_value_id)
+{
+    DSL_CALLSITE_METADATA_RECORD callsite;
+    if (call == NULL || replacement_value_id == DSL_IR_VALUE_INVALID_ID ||
+        replacement_value_id > DSL_ir_value_table.Size() ||
+        !DSL_Call_Image_Find_Callsite(call, &callsite))
+        return FALSE;
+    for (UINT32 i = 0; i < DSL_call_argument_table.Size(); ++i) {
+        DSL_CALL_ARGUMENT_RECORD &argument = DSL_call_argument_table[i];
+        if (argument.callsite_id == callsite.id &&
+            argument.actual_ordinal == actual_ordinal) {
+            if (argument.argument_value_id != expected_value_id)
+                return FALSE;
+            argument.argument_value_id = replacement_value_id;
+            return TRUE;
+        }
+    }
+    return TRUE;
+}
+
+UINT32
+DSL_Call_ABI_Image_Callee_Formal_Count
+        (ST_IDX callee_pu_st, UINT32 callee_formal_ordinal)
+{
+    UINT32 count = 0;
+    for (UINT32 i = 0; i < DSL_call_argument_table.Size(); ++i) {
+        DSL_CALLSITE_METADATA_RECORD callsite;
+        if (DSL_call_argument_table[i].callee_formal_ordinal ==
+                callee_formal_ordinal &&
+            DSL_Call_Image_Get_Callsite
+                (DSL_call_argument_table[i].callsite_id, &callsite) &&
+            callsite.callee_pu_st == callee_pu_st)
+            ++count;
+    }
+    return count;
+}
+
+BOOL
+DSL_Call_ABI_Image_Get_Callee_Formal_Argument
+        (ST_IDX callee_pu_st, UINT32 callee_formal_ordinal, UINT32 index,
+         DSL_CALL_ARGUMENT_RECORD *record)
+{
+    UINT32 found = 0;
+    for (UINT32 i = 0; i < DSL_call_argument_table.Size(); ++i) {
+        DSL_CALLSITE_METADATA_RECORD callsite;
+        if (DSL_call_argument_table[i].callee_formal_ordinal !=
+                callee_formal_ordinal ||
+            !DSL_Call_Image_Get_Callsite
+                (DSL_call_argument_table[i].callsite_id, &callsite) ||
+            callsite.callee_pu_st != callee_pu_st)
+            continue;
+        if (found++ == index)
+            return DSL_IR_Table_Get(DSL_call_argument_table, i + 1, record);
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_Call_ABI_Image_Load_Mapped
+        (const void *section_base, UINT64 section_size, FILE *diagnostic)
+{
+    if (section_base == NULL || section_size < DSL_CALL_ABI_IMAGE_HEADER_SIZE)
+        return DSL_Call_ABI_Image_Report
+                   (diagnostic, "section is truncated", 0);
+    const DSL_CALL_ABI_IMAGE_HEADER *header =
+        (const DSL_CALL_ABI_IMAGE_HEADER *)section_base;
+    UINT64 expected = DSL_CALL_ABI_IMAGE_HEADER_SIZE +
+        (UINT64)header->argument_count * DSL_CALL_ARGUMENT_RECORD_SIZE;
+    if (header->magic != DSL_CALL_ABI_IMAGE_MAGIC ||
+        header->version != DSL_CALL_ABI_IMAGE_VERSION || header->flags != 0 ||
+        header->reserved0 != 0 || header->reserved1 != 0 ||
+        expected != section_size)
+        return DSL_Call_ABI_Image_Report(diagnostic, "invalid header", 0);
+
+    const DSL_CALL_ARGUMENT_RECORD *arguments =
+        (const DSL_CALL_ARGUMENT_RECORD *)
+            ((const char *)section_base + DSL_CALL_ABI_IMAGE_HEADER_SIZE);
+    DSL_Call_ABI_Image_Reset();
+    if (header->argument_count != 0)
+        DSL_call_argument_table.Insert(arguments, header->argument_count);
+    if (!DSL_Call_ABI_Image_Validate(diagnostic)) {
+        DSL_Call_ABI_Image_Reset();
+        return FALSE;
+    }
+    return TRUE;
+}
+
 void
 DSL_IR_Image_Get_Header (DSL_IR_IMAGE_HEADER *header)
 {
@@ -490,6 +728,8 @@ DSL_IR_Image_View_Validate (const DSL_IR_IMAGE_VIEW *view, FILE *diagnostic)
         const DSL_IR_VALUE_RECORD &record = view->values[i];
         if (record.id != i + 1 || record.value_kind == DSL_IR_VALUE_UNKNOWN ||
             record.producer_node_id > header.node_count ||
+            (record.flags & ~DSL_IR_VALUE_FLAG_REDIRECTED) != 0 ||
+            record.reserved != 0 ||
             !DSL_IR_Image_String_Id_Valid(record.name, FALSE) ||
             !DSL_IR_Image_String_Id_Valid(record.metadata, FALSE))
             return DSL_IR_Image_Report(diagnostic, "invalid value", i + 1);
@@ -517,12 +757,17 @@ DSL_IR_Image_View_Validate (const DSL_IR_IMAGE_VIEW *view, FILE *diagnostic)
 
     for (UINT32 i = 0; i < header.node_count; ++i) {
         const DSL_IR_NODE_RECORD &record = view->nodes[i];
+        const UINT32 valid_node_flags = DSL_IR_NODE_FLAG_RETIRED |
+                                        DSL_IR_NODE_REDIRECT_ORDINAL_MASK;
         active_attribute_count += record.attribute_count;
         active_value_reference_count += record.operand_count;
         if (record.id != i + 1 || record.opcode_descriptor_id == 0 ||
             record.opcode_descriptor_id > header.opcode_descriptor_count ||
             record.result_value_id == 0 ||
             record.result_value_id > header.value_count ||
+            (record.flags & ~valid_node_flags) != 0 ||
+            ((record.flags & DSL_IR_NODE_FLAG_RETIRED) == 0 &&
+             (record.flags & DSL_IR_NODE_REDIRECT_ORDINAL_MASK) != 0) ||
             !DSL_IR_Image_String_Id_Valid(record.payload, FALSE))
             return DSL_IR_Image_Report(diagnostic, "invalid node", i + 1);
 
@@ -574,6 +819,30 @@ DSL_IR_Image_View_Validate (const DSL_IR_IMAGE_VIEW *view, FILE *diagnostic)
         if (result.producer_node_id != record.id)
             return DSL_IR_Image_Report
                        (diagnostic, "node result provenance mismatch", i + 1);
+        if ((record.flags & DSL_IR_NODE_FLAG_RETIRED) != 0) {
+            UINT32 ordinal = (record.flags &
+                              DSL_IR_NODE_REDIRECT_ORDINAL_MASK) >>
+                             DSL_IR_NODE_REDIRECT_ORDINAL_SHIFT;
+            const DSL_IR_VALUE_REFERENCE_RECORD *target_reference =
+                ordinal >= record.operand_count ? NULL :
+                &view->value_references
+                    [record.first_operand_reference_id - 1 + ordinal];
+            const DSL_IR_VALUE_RECORD *target = target_reference == NULL ?
+                NULL : &view->values[target_reference->value_id - 1];
+            if ((result.flags & DSL_IR_VALUE_FLAG_REDIRECTED) == 0 ||
+                descriptor.effect_model != DSL_EFFECT_MODEL_PURE ||
+                target_reference == NULL ||
+                target_reference->owner_node_id != record.id ||
+                target_reference->ordinal != ordinal ||
+                target == NULL || target->id == result.id ||
+                target->ty != result.ty ||
+                (target->flags & DSL_IR_VALUE_FLAG_REDIRECTED) != 0)
+                return DSL_IR_Image_Report
+                           (diagnostic, "invalid retired node", i + 1);
+        } else if ((result.flags & DSL_IR_VALUE_FLAG_REDIRECTED) != 0) {
+            return DSL_IR_Image_Report
+                       (diagnostic, "redirected live value", result.id);
+        }
     }
 
     if (active_attribute_count != header.attribute_count ||
@@ -581,6 +850,88 @@ DSL_IR_Image_View_Validate (const DSL_IR_IMAGE_VIEW *view, FILE *diagnostic)
         return DSL_IR_Image_Report
                    (diagnostic, "unowned relationship record", 0);
 
+    for (UINT32 i = 0; i < header.value_reference_count; ++i) {
+        const DSL_IR_VALUE_RECORD &referenced =
+            view->values[view->value_references[i].value_id - 1];
+        if ((referenced.flags & DSL_IR_VALUE_FLAG_REDIRECTED) != 0)
+            return DSL_IR_Image_Report
+                       (diagnostic, "reference to redirected value", i + 1);
+    }
+
+    return TRUE;
+}
+
+BOOL
+DSL_IR_Image_Redirect_And_Retire_Value
+        (DSL_IR_VALUE_ID replacement_value_id,
+         DSL_IR_VALUE_ID retiring_value_id,
+         UINT32 replacement_operand_ordinal)
+{
+    DSL_IR_VALUE_RECORD replacement;
+    DSL_IR_VALUE_RECORD retiring;
+    if (!DSL_IR_Table_Get
+            (DSL_ir_value_table, replacement_value_id, &replacement) ||
+        !DSL_IR_Table_Get
+            (DSL_ir_value_table, retiring_value_id, &retiring) ||
+        replacement_value_id == retiring_value_id ||
+        replacement.ty != retiring.ty ||
+        retiring.producer_node_id == DSL_IR_NODE_INVALID_ID ||
+        retiring.producer_node_id > DSL_ir_node_table.Size() ||
+        (retiring.flags & DSL_IR_VALUE_FLAG_REDIRECTED) != 0)
+        return FALSE;
+
+    DSL_IR_NODE_RECORD &node =
+        DSL_ir_node_table[retiring.producer_node_id - 1];
+    if ((node.flags & DSL_IR_NODE_FLAG_RETIRED) != 0 ||
+        node.result_value_id != retiring_value_id ||
+        replacement_operand_ordinal >= node.operand_count)
+        return FALSE;
+    DSL_IR_VALUE_REFERENCE_RECORD &replacement_reference =
+        DSL_ir_value_reference_table
+            [node.first_operand_reference_id - 1 + replacement_operand_ordinal];
+    if (replacement_reference.value_id != replacement_value_id)
+        return FALSE;
+
+    for (UINT32 i = 0; i < DSL_ir_value_reference_table.Size(); ++i) {
+        const DSL_IR_VALUE_REFERENCE_RECORD &reference =
+            DSL_ir_value_reference_table[i];
+        if (reference.value_id == retiring_value_id &&
+            reference.owner_node_id == node.id)
+            return FALSE;
+    }
+
+    for (UINT32 i = 0; i < DSL_ir_value_reference_table.Size(); ++i) {
+        DSL_IR_VALUE_REFERENCE_RECORD &reference =
+            DSL_ir_value_reference_table[i];
+        if (reference.value_id == retiring_value_id)
+            reference.value_id = replacement_value_id;
+    }
+    node.flags = DSL_IR_NODE_FLAG_RETIRED |
+        (replacement_operand_ordinal << DSL_IR_NODE_REDIRECT_ORDINAL_SHIFT);
+    DSL_ir_value_table[retiring_value_id - 1].flags |=
+        DSL_IR_VALUE_FLAG_REDIRECTED;
+    return TRUE;
+}
+
+BOOL
+DSL_IR_Image_Value_Redirect_Target
+        (DSL_IR_VALUE_ID value_id, DSL_IR_VALUE_ID *target_value_id)
+{
+    DSL_IR_VALUE_RECORD value;
+    if (target_value_id == NULL ||
+        !DSL_IR_Table_Get(DSL_ir_value_table, value_id, &value) ||
+        (value.flags & DSL_IR_VALUE_FLAG_REDIRECTED) == 0 ||
+        value.producer_node_id == DSL_IR_NODE_INVALID_ID)
+        return FALSE;
+    const DSL_IR_NODE_RECORD &node =
+        DSL_ir_node_table[value.producer_node_id - 1];
+    UINT32 ordinal = (node.flags & DSL_IR_NODE_REDIRECT_ORDINAL_MASK) >>
+                     DSL_IR_NODE_REDIRECT_ORDINAL_SHIFT;
+    if ((node.flags & DSL_IR_NODE_FLAG_RETIRED) == 0 ||
+        ordinal >= node.operand_count)
+        return FALSE;
+    *target_value_id = DSL_ir_value_reference_table
+        [node.first_operand_reference_id - 1 + ordinal].value_id;
     return TRUE;
 }
 
@@ -1114,6 +1465,17 @@ UINT32
 DSL_IR_Image_Node_Count (void)
 {
     return DSL_ir_node_table.Size();
+}
+
+UINT32
+DSL_IR_Image_Executable_Node_Count (void)
+{
+    UINT32 count = 0;
+    for (UINT32 i = 0; i < DSL_ir_node_table.Size(); ++i) {
+        if ((DSL_ir_node_table[i].flags & DSL_IR_NODE_FLAG_RETIRED) == 0)
+            ++count;
+    }
+    return count;
 }
 
 UINT32

--- a/osprey/common/com/dsl_ir_image.h
+++ b/osprey/common/com/dsl_ir_image.h
@@ -14,6 +14,8 @@
 #include "targ_const.h"
 
 class WN;
+struct pu_info;
+typedef struct pu_info PU_Info;
 typedef INT32 WN_MAP;
 
 /*
@@ -49,6 +51,11 @@ typedef INT32 WN_MAP;
 #define DSL_PU_SOURCE_IDENTITY_RECORD_SIZE  48
 #define DSL_CALLSITE_METADATA_RECORD_SIZE   48
 
+#define DSL_CALL_ABI_IMAGE_MAGIC            0x44534142
+#define DSL_CALL_ABI_IMAGE_VERSION          1
+#define DSL_CALL_ABI_IMAGE_HEADER_SIZE      24
+#define DSL_CALL_ARGUMENT_RECORD_SIZE       32
+
 #define DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID 0
 #define DSL_IR_NODE_INVALID_ID              0
 #define DSL_IR_ATTRIBUTE_INVALID_ID         0
@@ -64,11 +71,14 @@ typedef UINT32 DSL_STATE_OBJECT_ID;
 typedef UINT32 DSL_STATE_EFFECT_ID;
 typedef UINT32 DSL_PU_SOURCE_IDENTITY_ID;
 typedef UINT32 DSL_CALLSITE_METADATA_ID;
+typedef UINT32 DSL_CALL_ARGUMENT_ID;
 
 #define DSL_STATE_OBJECT_INVALID_ID 0
 #define DSL_STATE_EFFECT_INVALID_ID 0
 #define DSL_PU_SOURCE_IDENTITY_INVALID_ID 0
 #define DSL_CALLSITE_METADATA_INVALID_ID 0
+#define DSL_CALL_ARGUMENT_INVALID_ID 0
+#define DSL_CALL_ARGUMENT_INVALID_ORDINAL ((UINT32)-1)
 
 typedef struct {
     UINT32 magic;
@@ -101,6 +111,25 @@ typedef struct {
     UINT32 source_call_ordinal;
     UINT32 flags;
 } DSL_CALLSITE_METADATA_RECORD;
+
+typedef struct {
+    UINT32 magic;
+    UINT32 version;
+    UINT32 argument_count;
+    UINT32 flags;
+    UINT32 reserved0;
+    UINT32 reserved1;
+} DSL_CALL_ABI_IMAGE_HEADER;
+
+typedef struct {
+    DSL_CALL_ARGUMENT_ID id;
+    DSL_CALLSITE_METADATA_ID callsite_id;
+    DSL_IR_VALUE_ID argument_value_id;
+    UINT32 actual_ordinal;
+    UINT32 callee_formal_ordinal;
+    UINT32 flags;
+    STR_IDX semantic_role;
+} DSL_CALL_ARGUMENT_RECORD;
 
 typedef enum {
     DSL_IR_IMAGE_RECORD_UNKNOWN = 0,
@@ -173,6 +202,14 @@ typedef struct {
 } DSL_IR_NODE_RECORD;
 
 typedef enum {
+    DSL_IR_NODE_FLAG_NONE = 0,
+    DSL_IR_NODE_FLAG_RETIRED = 0x00000001
+} DSL_IR_NODE_FLAG;
+
+#define DSL_IR_NODE_REDIRECT_ORDINAL_SHIFT 16
+#define DSL_IR_NODE_REDIRECT_ORDINAL_MASK  0xffff0000
+
+typedef enum {
     DSL_IR_ATTRIBUTE_VALUE_UNKNOWN = 0,
     DSL_IR_ATTRIBUTE_VALUE_STRING = 1,
     DSL_IR_ATTRIBUTE_VALUE_SIGNED = 2,
@@ -212,6 +249,11 @@ typedef struct {
     STR_IDX metadata;
 } DSL_IR_VALUE_RECORD;
 
+typedef enum {
+    DSL_IR_VALUE_FLAG_NONE = 0,
+    DSL_IR_VALUE_FLAG_REDIRECTED = 0x00000001
+} DSL_IR_VALUE_FLAG;
+
 /*
  * Runtime-only borrowed view of one external tensor constant. The underlying
  * facts remain in the existing DSL value, ST metadata, and canonical TY
@@ -236,6 +278,11 @@ typedef struct {
     const char *layout;
 } DSL_IR_EXTERNAL_TENSOR_REFERENCE;
 
+typedef enum {
+    DSL_IR_MATERIALIZE_SOURCE_EXTERNAL_ONLY = 0,
+    DSL_IR_MATERIALIZE_SOURCE_EXTERNAL_OR_IMPLICIT_ZERO = 1
+} DSL_IR_MATERIALIZE_SOURCE_POLICY;
+
 /*
  * Runtime-only request for materializing converted side-file tensor values.
  * All requests are preflighted before any symbol, WN, or image table changes.
@@ -259,6 +306,7 @@ typedef struct {
     UINT64 byte_offset;
     UINT64 byte_length;
     const char *checksum;
+    UINT32 source_policy;
 } DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST;
 
 typedef struct {
@@ -266,6 +314,10 @@ typedef struct {
     ST_IDX st;
     WN *definition;
 } DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_RESULT;
+
+extern void DSL_IR_External_Tensor_Materialization_Request_Init
+                                (DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST
+                                     *request);
 
 typedef struct {
     DSL_IR_VALUE_REFERENCE_ID id;
@@ -311,6 +363,18 @@ typedef struct {
     STR_IDX payload;
     UINT32 result_value_kind;
 } DSL_IR_NATIVE_VALUE_REWRITE_REQUEST;
+
+typedef struct {
+    WN *pu_root;
+    WN *containing_block;
+    WN *replacement_definition;
+    DSL_IR_VALUE_ID replacement_value_id;
+    WN *retiring_definition;
+    DSL_IR_VALUE_ID retiring_value_id;
+    DSL_OPERATOR expected_retiring_operator;
+    UINT16 expected_retiring_version;
+    UINT16 replacement_operand_ordinal;
+} DSL_IR_NATIVE_VALUE_RETIRE_REQUEST;
 
 typedef enum {
     DSL_STATE_KIND_UNKNOWN = 0,
@@ -388,6 +452,8 @@ extern BOOL DSL_Call_Image_Find_PU_Identity
 extern BOOL DSL_Call_Image_Find_Callsite
                                 (const WN *call,
                                  DSL_CALLSITE_METADATA_RECORD *record);
+extern const WN *DSL_Call_Image_Get_Call_WN
+                                (DSL_CALLSITE_METADATA_ID id);
 extern UINT32 DSL_Call_Image_PU_Identity_Count (void);
 extern UINT32 DSL_Call_Image_Callsite_Count (void);
 extern BOOL DSL_Call_Image_Get_PU_Identity
@@ -401,6 +467,38 @@ extern BOOL DSL_Call_Image_Finalize_PU (ST_IDX owner_pu_st, WN_MAP off_map);
 extern BOOL DSL_Call_Image_Load_PU (ST_IDX owner_pu_st,
                                     const void *tree_base,
                                     UINT64 tree_size);
+
+extern void DSL_Call_ABI_Image_Get_Header (DSL_CALL_ABI_IMAGE_HEADER *header);
+extern void DSL_Call_ABI_Image_Reset (void);
+extern BOOL DSL_Call_ABI_Image_Has_Records (void);
+extern BOOL DSL_Call_ABI_Image_Validate (FILE *diagnostic);
+extern BOOL DSL_Call_ABI_Image_Load_Mapped (const void *section_base,
+                                            UINT64 section_size,
+                                            FILE *diagnostic);
+extern DSL_CALL_ARGUMENT_ID DSL_Call_ABI_Image_Add_Argument
+                                (const WN *call,
+                                 const DSL_CALL_ARGUMENT_RECORD *record);
+extern UINT32 DSL_Call_ABI_Image_Argument_Count (void);
+extern BOOL DSL_Call_ABI_Image_Get_Argument
+                                (DSL_CALL_ARGUMENT_ID id,
+                                 DSL_CALL_ARGUMENT_RECORD *record);
+extern BOOL DSL_Call_ABI_Image_Find_Argument
+                                (const WN *call, UINT32 actual_ordinal,
+                                 DSL_CALL_ARGUMENT_RECORD *record);
+extern BOOL DSL_Call_ABI_Image_Find_Argument_By_Id
+                                (DSL_CALLSITE_METADATA_ID callsite_id,
+                                 UINT32 actual_ordinal,
+                                 DSL_CALL_ARGUMENT_RECORD *record);
+extern UINT32 DSL_Call_ABI_Image_Callee_Formal_Count
+                                (ST_IDX callee_pu_st,
+                                 UINT32 callee_formal_ordinal);
+extern BOOL DSL_Call_ABI_Image_Get_Callee_Formal_Argument
+                                (ST_IDX callee_pu_st,
+                                 UINT32 callee_formal_ordinal,
+                                 UINT32 index,
+                                 DSL_CALL_ARGUMENT_RECORD *record);
+extern BOOL DSL_Call_ABI_Image_Validate_PU
+                                (PU_Info *pu, FILE *diagnostic);
 
 extern void DSL_Effect_Image_Get_Header (DSL_EFFECT_IMAGE_HEADER *header);
 extern void DSL_Effect_Image_Reset (void);
@@ -481,6 +579,13 @@ extern BOOL DSL_IR_Rewrite_Native_Value
                                  DSL_IR_VALUE_ID value_id,
                                  const DSL_IR_NATIVE_VALUE_REWRITE_REQUEST
                                      *request);
+extern BOOL DSL_IR_Redirect_And_Retire_Native_Value
+                                (ST_IDX owner_pu_st,
+                                 const DSL_IR_NATIVE_VALUE_RETIRE_REQUEST
+                                     *request);
+extern BOOL DSL_IR_Image_Value_Redirect_Target
+                                (DSL_IR_VALUE_ID value_id,
+                                 DSL_IR_VALUE_ID *target_value_id);
 extern BOOL DSL_IR_Image_Find_Value
                                 (ST_IDX st,
                                  const char *name,
@@ -493,6 +598,7 @@ extern BOOL DSL_IR_Image_Find_PU_Value
 
 extern UINT32 DSL_IR_Image_Opcode_Descriptor_Count (void);
 extern UINT32 DSL_IR_Image_Node_Count (void);
+extern UINT32 DSL_IR_Image_Executable_Node_Count (void);
 extern UINT32 DSL_IR_Image_Attribute_Count (void);
 extern UINT32 DSL_IR_Image_Value_Count (void);
 extern UINT32 DSL_IR_Image_Value_Reference_Count (void);

--- a/osprey/common/com/dsl_ir_print.cxx
+++ b/osprey/common/com/dsl_ir_print.cxx
@@ -150,6 +150,11 @@ DSL_IR_Image_Print (FILE *file)
                      DSL_IR_String(attribute.value));
         }
         fprintf (file, "] result=value%u", node.result_value_id);
+        if ((node.flags & DSL_IR_NODE_FLAG_RETIRED) != 0) {
+            DSL_IR_VALUE_ID target = DSL_IR_VALUE_INVALID_ID;
+            DSL_IR_Image_Value_Redirect_Target(node.result_value_id, &target);
+            fprintf(file, " status=retired redirected_to=value%u", target);
+        }
         if (node.payload != STR_IDX_ZERO)
             fprintf (file, " payload=%s", DSL_IR_String(node.payload));
         fprintf (file, " flags=0x%x\n", node.flags);
@@ -181,6 +186,11 @@ DSL_IR_Image_Print (FILE *file)
         DSL_IR_Print_Result_Symbol(file, record.st, record.name);
         if (record.metadata != STR_IDX_ZERO)
             fprintf (file, " metadata=%s", DSL_IR_String(record.metadata));
+        if ((record.flags & DSL_IR_VALUE_FLAG_REDIRECTED) != 0) {
+            DSL_IR_VALUE_ID target = DSL_IR_VALUE_INVALID_ID;
+            DSL_IR_Image_Value_Redirect_Target(record.id, &target);
+            fprintf(file, " status=redirected redirected_to=value%u", target);
+        }
         fprintf (file, " flags=0x%x\n", record.flags);
     }
 
@@ -256,6 +266,23 @@ DSL_IR_Image_Print (FILE *file)
                 DSL_IR_String(record.instance_path),
                 DSL_IR_String(record.context_identity),
                 record.source_call_ordinal, record.flags);
+    }
+    DSL_CALL_ABI_IMAGE_HEADER call_abi_header;
+    DSL_Call_ABI_Image_Get_Header(&call_abi_header);
+    fprintf(file, "DSL Call ABI Argument Table: version=%u entries=%u\n",
+            call_abi_header.version, call_abi_header.argument_count);
+    for (UINT32 i = 1; i <= call_abi_header.argument_count; ++i) {
+        DSL_CALL_ARGUMENT_RECORD record;
+        DSL_CALLSITE_METADATA_RECORD callsite;
+        DSL_Call_ABI_Image_Get_Argument(i, &record);
+        DSL_Call_Image_Get_Callsite(record.callsite_id, &callsite);
+        fprintf(file, "  [%u] callsite=%u callee=<%u,%u> actual=%u "
+                "formal=%u argument_value=%u role=%s flags=0x%x\n",
+                record.id, record.callsite_id,
+                ST_IDX_level(callsite.callee_pu_st),
+                ST_IDX_index(callsite.callee_pu_st), record.actual_ordinal,
+                record.callee_formal_ordinal, record.argument_value_id,
+                DSL_IR_String(record.semantic_role), record.flags);
     }
     DSL_FHE_Image_Print(file);
     DSL_FHE_Plan_Image_Print(file);

--- a/osprey/common/com/dsl_ir_rewrite.cxx
+++ b/osprey/common/com/dsl_ir_rewrite.cxx
@@ -12,9 +12,21 @@
 #include "dsl_memory_behavior.h"
 #include "dsl_tensor_fold.h"
 #include "dsl_ir_image.h"
+#include "dsl_region.h"
+#include "pu_info.h"
 #include "strtab.h"
 #include "symtab.h"
 #include "wn.h"
+
+/* Commit-only helpers; public callers must use the transactional APIs below. */
+extern BOOL DSL_Call_ABI_Image_Update_Argument_Value
+                                (const WN *, UINT32, DSL_IR_VALUE_ID,
+                                 DSL_IR_VALUE_ID);
+extern BOOL DSL_IR_Image_Redirect_And_Retire_Value
+                                (DSL_IR_VALUE_ID, DSL_IR_VALUE_ID, UINT32);
+extern UINT32 DSL_Region_Symbol_Use_Count (PU_Info *, ST_IDX);
+extern BOOL DSL_Region_Can_Redirect_Symbol (PU_Info *, ST_IDX, ST_IDX);
+extern BOOL DSL_Region_Redirect_Symbol (PU_Info *, ST_IDX, ST_IDX);
 #include "wn_util.h"
 
 static BOOL
@@ -31,6 +43,89 @@ DSL_IR_Image_Current_PU_Is (ST_IDX owner_pu_st)
 {
     return DSL_IR_Image_PU_ST_Valid(owner_pu_st) && Current_pu != NULL &&
            Current_pu == &Pu_Table[ST_pu(St_Table[owner_pu_st])];
+}
+
+static BOOL
+DSL_Call_ABI_PU_Report (FILE *diagnostic, const char *message, UINT32 id)
+{
+    if (diagnostic != NULL)
+        fprintf(diagnostic, "DSL call ABI PU error: %s id=%u\n", message, id);
+    return FALSE;
+}
+
+static BOOL
+DSL_Call_ABI_Value_Matches_ST
+        (const DSL_IR_VALUE_RECORD &value, ST_IDX owner_pu_st, ST_IDX st)
+{
+    if (ST_IDX_level(st) != CURRENT_SYMTAB || ST_IDX_index(st) == 0 ||
+        ST_IDX_index(st) >= ST_Table_Size(CURRENT_SYMTAB) ||
+        value.st != st || value.ty != ST_type(St_Table[st]) ||
+        value.metadata == STR_IDX_ZERO)
+        return FALSE;
+    std::string owner = "owner_pu=";
+    owner += ST_name(St_Table[owner_pu_st]);
+    return owner == Index_To_Str(value.metadata);
+}
+
+BOOL
+DSL_Call_ABI_Image_Validate_PU (PU_Info *pu, FILE *diagnostic)
+{
+    if (pu == NULL || PU_Info_tree_ptr(pu) == NULL ||
+        ST_IDX_index(PU_Info_proc_sym(pu)) == 0 || Current_pu == NULL ||
+        Current_pu != &Pu_Table[ST_pu(St_Table[PU_Info_proc_sym(pu)])])
+        return DSL_Call_ABI_PU_Report(diagnostic, "missing program unit", 0);
+    ST_IDX owner_pu_st = PU_Info_proc_sym(pu);
+    WN *entry = PU_Info_tree_ptr(pu);
+
+    for (UINT32 i = 1; i <= DSL_Call_ABI_Image_Argument_Count(); ++i) {
+        DSL_CALL_ARGUMENT_RECORD argument;
+        DSL_CALLSITE_METADATA_RECORD callsite;
+        if (!DSL_Call_ABI_Image_Get_Argument(i, &argument) ||
+            !DSL_Call_Image_Get_Callsite(argument.callsite_id, &callsite))
+            return DSL_Call_ABI_PU_Report
+                       (diagnostic, "missing relationship", i);
+
+        if (callsite.owner_pu_st == owner_pu_st) {
+            const WN *call = DSL_Call_Image_Get_Call_WN(callsite.id);
+            if (call == NULL || argument.actual_ordinal >= WN_kid_count(call))
+                return DSL_Call_ABI_PU_Report
+                           (diagnostic, "actual ordinal out of range",
+                            argument.id);
+            const WN *parm = WN_kid(call, argument.actual_ordinal);
+            const WN *address = parm == NULL || WN_operator(parm) != OPR_PARM ?
+                                NULL : WN_kid0(parm);
+            DSL_IR_VALUE_RECORD value;
+            if (WN_st_idx(call) != callsite.callee_pu_st ||
+                address == NULL || WN_operator(address) != OPR_LDA ||
+                !WN_Parm_By_Reference(parm) || !WN_Parm_Read_Only(parm) ||
+                WN_Parm_Out(parm) || !WN_Parm_Passed_Not_Saved(parm) ||
+                !DSL_IR_Image_Get_Value(argument.argument_value_id, &value) ||
+                !DSL_Call_ABI_Value_Matches_ST
+                    (value, owner_pu_st, WN_st_idx(address)) ||
+                WN_ty(parm) != WN_ty(address) ||
+                TY_kind(WN_ty(parm)) != KIND_POINTER ||
+                TY_pointed(WN_ty(parm)) != value.ty)
+                return DSL_Call_ABI_PU_Report
+                           (diagnostic, "argument value mismatch", argument.id);
+        }
+
+        if (callsite.callee_pu_st == owner_pu_st) {
+            if (entry == NULL || WN_operator(entry) != OPR_FUNC_ENTRY ||
+                argument.callee_formal_ordinal >= WN_num_formals(entry))
+                return DSL_Call_ABI_PU_Report
+                           (diagnostic, "formal ordinal out of range",
+                            argument.id);
+            ST_IDX formal_st =
+                WN_st_idx(WN_formal(entry, argument.callee_formal_ordinal));
+            DSL_IR_VALUE_RECORD value;
+            if (!DSL_IR_Image_Get_Value(argument.argument_value_id, &value) ||
+                value.ty != ST_type(St_Table[formal_st]))
+                return DSL_Call_ABI_PU_Report
+                           (diagnostic, "actual/formal type mismatch",
+                            argument.id);
+        }
+    }
+    return TRUE;
 }
 
 static BOOL
@@ -404,7 +499,11 @@ DSL_IR_External_Tensor_Request_Valid
         request.side_file[0] == '\0' || request.tensor_key == NULL ||
         request.tensor_key[0] == '\0' || request.byte_length == 0 ||
         request.byte_offset + request.byte_length < request.byte_offset ||
+        request.checksum == NULL || request.checksum[0] == '\0' ||
         !DSL_IR_Checksum_Valid(request.checksum) ||
+        (request.source_policy != DSL_IR_MATERIALIZE_SOURCE_EXTERNAL_ONLY &&
+         request.source_policy !=
+             DSL_IR_MATERIALIZE_SOURCE_EXTERNAL_OR_IMPLICIT_ZERO) ||
         !TY_get_tensor_descriptor_record(request.descriptor_ty, &descriptor) ||
         !DSL_IR_Static_Tensor_Byte_Size
              (descriptor, &element_size, &tensor_size) ||
@@ -437,11 +536,46 @@ DSL_IR_External_Tensor_Request_Valid
         return FALSE;
 
     DSL_IR_VALUE_RECORD source;
-    if (!DSL_IR_Image_Get_External_Tensor_Reference
-             (owner_pu_st, request.source_value_id, &source_reference) ||
-        source_reference.descriptor_ty != request.descriptor_ty ||
-        !DSL_IR_Image_Get_Value(request.source_value_id, &source))
+    BOOL source_is_external =
+        DSL_IR_Image_Get_External_Tensor_Reference
+            (owner_pu_st, request.source_value_id, &source_reference);
+    BOOL source_is_implicit_zero = FALSE;
+    if (!source_is_external && request.source_policy ==
+            DSL_IR_MATERIALIZE_SOURCE_EXTERNAL_OR_IMPLICIT_ZERO &&
+        DSL_IR_Image_Get_Value(request.source_value_id, &source) &&
+        source.value_kind == DSL_IR_VALUE_CONSTANT &&
+        source.ty == request.descriptor_ty &&
+        DSL_IR_Image_Value_Belongs_To_PU(source, owner_pu_st)) {
+        DSL_IR_NODE_RECORD source_node;
+        DSL_IR_OPCODE_DESCRIPTOR_RECORD source_opcode;
+        const char *source_kind = NULL;
+        source_is_implicit_zero =
+            DSL_IR_Image_Get_Node(source.producer_node_id, &source_node) &&
+            source_node.result_value_id == source.id &&
+            DSL_IR_Image_Get_Opcode_Descriptor
+                (source_node.opcode_descriptor_id, &source_opcode) &&
+            source_opcode.logical_operator == OPR_DSLTENSORCONST &&
+            source_opcode.version == 1 &&
+            source_opcode.effect_model == DSL_EFFECT_MODEL_PURE &&
+            DSL_IR_Node_Attribute
+                (source_node, "value_kind", &source_kind) &&
+            strcmp(source_kind, "implicit_zero") == 0;
+        for (UINT32 i = 1;
+             source_is_implicit_zero &&
+             i <= DSL_Effect_Image_State_Effect_Count(); ++i) {
+            DSL_STATE_EFFECT_RECORD effect;
+            if (!DSL_Effect_Image_Get_State_Effect(i, &effect) ||
+                effect.owner_node_id == source_node.id)
+                source_is_implicit_zero = FALSE;
+        }
+    }
+    if (!source_is_external && !source_is_implicit_zero)
         return FALSE;
+    if (source_is_external) {
+        if (source_reference.descriptor_ty != request.descriptor_ty ||
+            !DSL_IR_Image_Get_Value(request.source_value_id, &source))
+            return FALSE;
+    }
     if (source_value != NULL)
         *source_value = source;
 
@@ -496,6 +630,16 @@ DSL_IR_External_Tensor_Request_Valid
     return TRUE;
 }
 
+void
+DSL_IR_External_Tensor_Materialization_Request_Init
+        (DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST *request)
+{
+    if (request != NULL) {
+        memset(request, 0, sizeof(*request));
+        request->source_policy = DSL_IR_MATERIALIZE_SOURCE_EXTERNAL_ONLY;
+    }
+}
+
 static void
 DSL_IR_Copy_Tensor_Metadata (ST_IDX source, ST_IDX destination)
 {
@@ -523,12 +667,23 @@ DSL_IR_Materialize_External_Tensor_Values
     std::vector<DSL_IR_VALUE_RECORD> source_values(request_count);
     std::vector<std::string> uris(request_count);
     std::vector<std::string> payloads(request_count);
+    std::vector<BOOL> update_call_abi(request_count, FALSE);
     for (UINT32 i = 0; i < request_count; ++i) {
         if (!DSL_IR_External_Tensor_Request_Valid
                  (owner_pu_st, requests[i], &source_values[i], &uris[i],
                   &payloads[i]) ||
             DSL_IR_PU_Value_Name_Exists(owner_pu_st, requests[i].name))
             return FALSE;
+        if (requests[i].call != NULL) {
+            DSL_CALL_ARGUMENT_RECORD argument;
+            if (DSL_Call_ABI_Image_Find_Argument
+                    (requests[i].call, requests[i].actual_ordinal,
+                     &argument)) {
+                if (argument.argument_value_id != requests[i].source_value_id)
+                    return FALSE;
+                update_call_abi[i] = TRUE;
+            }
+        }
         for (UINT32 prior = 0; prior < i; ++prior) {
             if (strcmp(requests[prior].name, requests[i].name) == 0 ||
                 (requests[i].call != NULL &&
@@ -634,6 +789,13 @@ DSL_IR_Materialize_External_Tensor_Values
                            (WN_kid(request.call, request.actual_ordinal));
             WN_st_idx(WN_kid0(parm)) = result_st;
             WN_kid(request.call, request.actual_ordinal) = parm;
+            if (update_call_abi[i]) {
+                BOOL updated = DSL_Call_ABI_Image_Update_Argument_Value
+                    (request.call, request.actual_ordinal,
+                     request.source_value_id, value_id);
+                FmtAssert(updated,
+                          ("preflighted DSL call ABI update failed"));
+            }
         }
 
         results[i].value_id = value_id;
@@ -790,5 +952,220 @@ DSL_IR_Rewrite_Native_Value
         return FALSE;
 
     WN_kid0(definition) = replacement;
+    return TRUE;
+}
+
+typedef struct {
+    ST_IDX retiring_st;
+    WN *retiring_definition;
+    BOOL retiring_seen;
+    BOOL valid;
+    UINT32 definition_count;
+    std::vector<WN *> reads;
+} DSL_IR_RETIRE_USE_SCAN;
+
+static void
+DSL_IR_Retire_Scan_Tree (WN *wn, DSL_IR_RETIRE_USE_SCAN *scan)
+{
+    if (wn == NULL || scan == NULL || !scan->valid)
+        return;
+    if (WN_operator(wn) == OPR_BLOCK) {
+        for (WN *statement = WN_first(wn); statement != NULL;
+             statement = WN_next(statement)) {
+            if (statement == scan->retiring_definition) {
+                if (scan->retiring_seen) {
+                    scan->valid = FALSE;
+                    return;
+                }
+                for (INT32 kid = 0; kid < WN_kid_count(statement); ++kid)
+                    DSL_IR_Retire_Scan_Tree(WN_kid(statement, kid), scan);
+                ++scan->definition_count;
+                scan->retiring_seen = TRUE;
+            } else {
+                DSL_IR_Retire_Scan_Tree(statement, scan);
+            }
+        }
+        return;
+    }
+
+    if (WN_has_sym(wn) && WN_st_idx(wn) == scan->retiring_st) {
+        if (WN_operator(wn) == OPR_STID) {
+            ++scan->definition_count;
+            if (wn != scan->retiring_definition)
+                scan->valid = FALSE;
+        } else if (WN_operator(wn) == OPR_LDID && scan->retiring_seen) {
+            scan->reads.push_back(wn);
+        } else {
+            scan->valid = FALSE;
+        }
+    }
+    for (INT32 kid = 0; scan->valid && kid < WN_kid_count(wn); ++kid)
+        DSL_IR_Retire_Scan_Tree(WN_kid(wn, kid), scan);
+}
+
+static BOOL
+DSL_IR_Definition_Precedes
+        (const WN *block, const WN *first, const WN *second)
+{
+    if (block == NULL || WN_operator(block) != OPR_BLOCK || first == NULL ||
+        second == NULL)
+        return FALSE;
+    BOOL first_seen = FALSE;
+    for (const WN *statement = WN_first(block); statement != NULL;
+         statement = WN_next(statement)) {
+        if (statement == first)
+            first_seen = TRUE;
+        if (statement == second)
+            return first_seen;
+    }
+    return FALSE;
+}
+
+static BOOL
+DSL_IR_Retire_Has_Use_Outside_Block
+        (const WN *wn, const WN *containing_block, ST_IDX retiring_st)
+{
+    if (wn == NULL || wn == containing_block)
+        return FALSE;
+    if (WN_has_sym(wn) && WN_st_idx(wn) == retiring_st)
+        return TRUE;
+    if (WN_operator(wn) == OPR_BLOCK) {
+        for (const WN *statement = WN_first(wn); statement != NULL;
+             statement = WN_next(statement)) {
+            if (DSL_IR_Retire_Has_Use_Outside_Block
+                    (statement, containing_block, retiring_st))
+                return TRUE;
+        }
+        return FALSE;
+    }
+    for (INT32 kid = 0; kid < WN_kid_count(wn); ++kid) {
+        if (DSL_IR_Retire_Has_Use_Outside_Block
+                (WN_kid(wn, kid), containing_block, retiring_st))
+            return TRUE;
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_IR_Redirect_And_Retire_Native_Value
+        (ST_IDX owner_pu_st,
+         const DSL_IR_NATIVE_VALUE_RETIRE_REQUEST *request)
+{
+    if (!DSL_IR_Image_Current_PU_Is(owner_pu_st) || request == NULL ||
+        Current_PU_Info == NULL ||
+        PU_Info_proc_sym(Current_PU_Info) != owner_pu_st ||
+        request->pu_root != PU_Info_tree_ptr(Current_PU_Info) ||
+        request->containing_block == NULL ||
+        WN_operator(request->containing_block) != OPR_BLOCK ||
+        !DSL_IR_Block_Contains
+            (request->containing_block, request->replacement_definition) ||
+        !DSL_IR_Block_Contains
+            (request->containing_block, request->retiring_definition) ||
+        !DSL_IR_Definition_Precedes
+            (request->containing_block, request->replacement_definition,
+             request->retiring_definition))
+        return FALSE;
+
+    DSL_IR_VALUE_RECORD replacement;
+    DSL_IR_VALUE_RECORD retiring;
+    if (!DSL_IR_Image_Find_Definition_Value
+            (owner_pu_st, request->replacement_definition, &replacement) ||
+        !DSL_IR_Image_Find_Definition_Value
+            (owner_pu_st, request->retiring_definition, &retiring) ||
+        replacement.id != request->replacement_value_id ||
+        retiring.id != request->retiring_value_id ||
+        replacement.ty != retiring.ty ||
+        !DSL_Tensor_Has_Unique_Ownership(retiring.st))
+        return FALSE;
+
+    DSL_IR_NODE_RECORD retiring_node;
+    DSL_IR_OPCODE_DESCRIPTOR_RECORD retiring_opcode;
+    if (!DSL_IR_Image_Get_Node
+            (retiring.producer_node_id, &retiring_node) ||
+        !DSL_IR_Image_Get_Opcode_Descriptor
+            (retiring_node.opcode_descriptor_id, &retiring_opcode) ||
+        retiring_opcode.logical_operator !=
+            request->expected_retiring_operator ||
+        retiring_opcode.version != request->expected_retiring_version ||
+        retiring_opcode.effect_model != DSL_EFFECT_MODEL_PURE ||
+        request->replacement_operand_ordinal >= retiring_node.operand_count)
+        return FALSE;
+    DSL_IR_VALUE_REFERENCE_RECORD replacement_reference;
+    if (!DSL_IR_Image_Get_Value_Reference
+            (retiring_node.first_operand_reference_id +
+             request->replacement_operand_ordinal,
+             &replacement_reference) ||
+        replacement_reference.value_id != replacement.id)
+        return FALSE;
+    WN *retiring_expression = WN_kid0(request->retiring_definition);
+    WN *replacement_operand = retiring_expression == NULL ||
+        request->replacement_operand_ordinal >=
+            (UINT32)WN_kid_count(retiring_expression) ? NULL :
+        WN_kid(retiring_expression, request->replacement_operand_ordinal);
+    if (replacement_operand == NULL ||
+        WN_operator(replacement_operand) != OPR_LDID ||
+        WN_st_idx(replacement_operand) != replacement.st ||
+        WN_ty(replacement_operand) != replacement.ty)
+        return FALSE;
+
+    for (UINT32 i = 1; i <= DSL_IR_Image_Value_Reference_Count(); ++i) {
+        DSL_IR_VALUE_REFERENCE_RECORD reference;
+        if (!DSL_IR_Image_Get_Value_Reference(i, &reference) ||
+            (reference.owner_node_id == retiring_node.id &&
+             reference.value_id == retiring.id))
+            return FALSE;
+    }
+
+    for (UINT32 i = 1; i <= DSL_Effect_Image_State_Effect_Count(); ++i) {
+        DSL_STATE_EFFECT_RECORD effect;
+        if (!DSL_Effect_Image_Get_State_Effect(i, &effect) ||
+            effect.owner_node_id == retiring_node.id)
+            return FALSE;
+    }
+    for (UINT32 i = 1; i <= DSL_Call_ABI_Image_Argument_Count(); ++i) {
+        DSL_CALL_ARGUMENT_RECORD argument;
+        if (!DSL_Call_ABI_Image_Get_Argument(i, &argument) ||
+            argument.argument_value_id == retiring.id)
+            return FALSE;
+    }
+
+    DSL_IR_RETIRE_USE_SCAN scan;
+    scan.retiring_st = retiring.st;
+    scan.retiring_definition = request->retiring_definition;
+    scan.retiring_seen = FALSE;
+    scan.valid = TRUE;
+    scan.definition_count = 0;
+    DSL_IR_Retire_Scan_Tree(request->containing_block, &scan);
+    if (!scan.valid || !scan.retiring_seen || scan.definition_count != 1 ||
+        DSL_IR_Retire_Has_Use_Outside_Block
+            (request->pu_root, request->containing_block, retiring.st))
+        return FALSE;
+
+    UINT32 region_uses = DSL_Region_Symbol_Use_Count
+                             (Current_PU_Info, retiring.st);
+    if (region_uses != 0 &&
+        !DSL_Region_Can_Redirect_Symbol
+             (Current_PU_Info, retiring.st, replacement.st))
+        return FALSE;
+
+    for (UINT32 i = 0; i < scan.reads.size(); ++i)
+        WN_st_idx(scan.reads[i]) = replacement.st;
+    if (region_uses != 0) {
+        BOOL redirected = DSL_Region_Redirect_Symbol
+                              (Current_PU_Info, retiring.st, replacement.st);
+        FmtAssert(redirected, ("preflighted REGION redirect failed"));
+    }
+    BOOL image_redirected = DSL_IR_Image_Redirect_And_Retire_Value
+        (replacement.id, retiring.id, request->replacement_operand_ordinal);
+    FmtAssert(image_redirected, ("preflighted DSL value redirect failed"));
+    WN *removed = WN_EXTRACT_FromBlock
+                      (request->containing_block,
+                       request->retiring_definition);
+    FmtAssert(removed == request->retiring_definition,
+              ("preflighted DSL definition retirement failed"));
+    WN_DELETE_Tree(removed);
+    FmtAssert(DSL_IR_Image_Validate(NULL) &&
+              DSL_Region_Verify_PU(Current_PU_Info, NULL),
+              ("retired DSL value failed postcondition"));
     return TRUE;
 }

--- a/osprey/common/com/dsl_region.cxx
+++ b/osprey/common/com/dsl_region.cxx
@@ -721,10 +721,9 @@ DSL_Region_Verify_State_Interface
     return TRUE;
 }
 
-BOOL
-DSL_Region_Verify_PU (PU_Info *pu, FILE *diagnostic)
+static BOOL
+DSL_Region_Verify_Store (DSL_REGION_STORE *store, FILE *diagnostic)
 {
-    DSL_REGION_STORE *store = DSL_Region_Find_Store(pu);
     if (store == NULL)
         return TRUE;
 
@@ -847,6 +846,11 @@ DSL_Region_Verify_PU (PU_Info *pu, FILE *diagnostic)
                                         DSL_REGION_VALUE_INOUT |
                                         DSL_REGION_VALUE_RESULT;
             if (previous.region_id == binding.region_id &&
+                previous.st == binding.st)
+                return DSL_Region_Report
+                           (diagnostic, "duplicate interface symbol",
+                            binding.region_id);
+            if (previous.region_id == binding.region_id &&
                 previous.ordinal == binding.ordinal &&
                 (((previous.roles & input_roles) != 0 &&
                   (binding.roles & input_roles) != 0) ||
@@ -856,6 +860,56 @@ DSL_Region_Verify_PU (PU_Info *pu, FILE *diagnostic)
                            (diagnostic, "duplicate interface ordinal",
                             binding.region_id);
         }
+    }
+    return TRUE;
+}
+
+BOOL
+DSL_Region_Verify_PU (PU_Info *pu, FILE *diagnostic)
+{
+    return DSL_Region_Verify_Store(DSL_Region_Find_Store(pu), diagnostic);
+}
+
+UINT32
+DSL_Region_Symbol_Use_Count (PU_Info *pu, ST_IDX st)
+{
+    DSL_REGION_STORE *store = DSL_Region_Find_Store(pu);
+    if (store == NULL || ST_IDX_index(st) == 0)
+        return 0;
+    UINT32 count = 0;
+    for (UINT32 i = 0; i < store->interfaces.size(); ++i) {
+        if (store->interfaces[i].st == st)
+            ++count;
+    }
+    return count;
+}
+
+BOOL
+DSL_Region_Can_Redirect_Symbol (PU_Info *pu, ST_IDX old_st, ST_IDX new_st)
+{
+    DSL_REGION_STORE *store = DSL_Region_Find_Store(pu);
+    if (store == NULL)
+        return TRUE;
+    if (ST_IDX_index(old_st) == 0 || ST_IDX_index(new_st) == 0)
+        return FALSE;
+    DSL_REGION_STORE candidate = *store;
+    for (UINT32 i = 0; i < candidate.interfaces.size(); ++i) {
+        if (candidate.interfaces[i].st == old_st)
+            candidate.interfaces[i].st = new_st;
+    }
+    return DSL_Region_Verify_Store(&candidate, NULL);
+}
+
+BOOL
+DSL_Region_Redirect_Symbol (PU_Info *pu, ST_IDX old_st, ST_IDX new_st)
+{
+    DSL_REGION_STORE *store = DSL_Region_Find_Store(pu);
+    if (store == NULL ||
+        !DSL_Region_Can_Redirect_Symbol(pu, old_st, new_st))
+        return FALSE;
+    for (UINT32 i = 0; i < store->interfaces.size(); ++i) {
+        if (store->interfaces[i].st == old_st)
+            store->interfaces[i].st = new_st;
     }
     return TRUE;
 }

--- a/osprey/common/com/ir_bread.cxx
+++ b/osprey/common/com/ir_bread.cxx
@@ -487,6 +487,21 @@ WN_get_dsl_callsite_image (void *handle)
 }
 
 INT
+WN_get_dsl_call_abi_image (void *handle)
+{
+    OFFSET_AND_SIZE shdr = get_section
+                               (handle, SHT_MIPS_WHIRL,
+                                WT_DSL_CALL_ABI_IMAGE);
+    if (shdr.offset == 0) {
+        DSL_Call_ABI_Image_Reset();
+        return 0;
+    }
+    const void *section_base = (const char *)handle + shdr.offset;
+    return DSL_Call_ABI_Image_Load_Mapped
+               (section_base, shdr.size, stderr) ? 0 : -1;
+}
+
+INT
 WN_get_dsl_fhe_image (void *handle)
 {
     OFFSET_AND_SIZE shdr = get_section
@@ -1670,6 +1685,9 @@ Read_Global_Info (INT32 *p_num_PUs)
     if (WN_get_dsl_callsite_image(global_fhandle) == -1) {
         ErrMsg (EC_IR_Scn_Read, "DSL callsite image", global_ir_file);
     }
+    if (WN_get_dsl_call_abi_image(global_fhandle) == -1) {
+        ErrMsg (EC_IR_Scn_Read, "DSL call ABI image", global_ir_file);
+    }
     if (WN_get_dsl_fhe_image(global_fhandle) == -1) {
         ErrMsg (EC_IR_Scn_Read, "DSL FHE image", global_ir_file);
     }
@@ -1767,6 +1785,8 @@ Read_Local_Info (MEM_POOL *pool, PU_Info *pu)
                   tree_base, tree_size))
             ErrMsg (EC_IR_Scn_Read, "DSL callsites", local_ir_file);
     }
+    if (!DSL_Call_ABI_Image_Validate_PU(pu, stderr))
+        ErrMsg (EC_IR_Scn_Read, "DSL call ABI", local_ir_file);
 
     if (PU_Info_state(pu, WT_REGIONS) == Subsect_Exists) {
         OFFSET_AND_SIZE pu_section = get_section

--- a/osprey/common/com/ir_bread.h
+++ b/osprey/common/com/ir_bread.h
@@ -129,6 +129,8 @@ extern INT WN_get_global_symtab (void *handle);
 extern INT WN_get_strtab (void *handle);
 extern INT WN_get_dsl_ir_image (void *handle);
 extern INT WN_get_dsl_effect_image (void *handle);
+extern INT WN_get_dsl_callsite_image (void *handle);
+extern INT WN_get_dsl_call_abi_image (void *handle);
 extern INT WN_get_dsl_fhe_image (void *handle);
 extern INT WN_get_dsl_fhe_plan_image (void *handle);
 

--- a/osprey/common/com/ir_bwrite.cxx
+++ b/osprey/common/com/ir_bwrite.cxx
@@ -917,6 +917,31 @@ WN_write_dsl_callsite_image (Output_File *fl)
 }
 
 void
+WN_write_dsl_call_abi_image (Output_File *fl)
+{
+    if (!DSL_Call_ABI_Image_Has_Records())
+        return;
+    FmtAssert(DSL_Call_ABI_Image_Validate(stderr),
+              ("invalid DSL call ABI table"));
+    Section *cur_section = get_section
+                               (WT_DSL_CALL_ABI_IMAGE,
+                                MIPS_WHIRL_DSL_CALL_ABI_IMAGE, fl);
+    fl->file_size = ir_b_align(fl->file_size, sizeof(mINT64), 0);
+    cur_section->shdr.sh_offset = fl->file_size;
+    DSL_CALL_ABI_IMAGE_HEADER header;
+    DSL_Call_ABI_Image_Get_Header(&header);
+    ir_b_save_buf(&header, sizeof(header), sizeof(mINT64), 0, fl);
+    for (UINT32 i = 1; i <= header.argument_count; ++i) {
+        DSL_CALL_ARGUMENT_RECORD record;
+        FmtAssert(DSL_Call_ABI_Image_Get_Argument(i, &record),
+                  ("missing DSL call ABI argument %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    cur_section->shdr.sh_size = fl->file_size - cur_section->shdr.sh_offset;
+    cur_section->shdr.sh_addralign = sizeof(mINT64);
+}
+
+void
 WN_write_dsl_fhe_image (Output_File *fl)
 {
     if (!DSL_FHE_Image_Has_Records())
@@ -1844,6 +1869,7 @@ Write_Global_Info (PU_Info *pu_tree)
     WN_write_dsl_ir_image(ir_output);
     WN_write_dsl_effect_image(ir_output);
     WN_write_dsl_callsite_image(ir_output);
+    WN_write_dsl_call_abi_image(ir_output);
     WN_write_dsl_fhe_image(ir_output);
     WN_write_dsl_fhe_plan_image(ir_output);
 

--- a/osprey/common/com/ir_bwrite.h
+++ b/osprey/common/com/ir_bwrite.h
@@ -113,6 +113,8 @@ extern void WN_write_dst (void *dst, Output_File *fl);
 extern void WN_write_strtab (const void *strtab, UINT64 size, Output_File *fl);
 extern void WN_write_dsl_ir_image (Output_File *fl);
 extern void WN_write_dsl_effect_image (Output_File *fl);
+extern void WN_write_dsl_callsite_image (Output_File *fl);
+extern void WN_write_dsl_call_abi_image (Output_File *fl);
 extern void WN_write_dsl_fhe_image (Output_File *fl);
 extern void WN_write_dsl_fhe_plan_image (Output_File *fl);
 extern void WN_write_localmap (void *localmap, Output_File *fl);

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -5306,10 +5306,24 @@ Check_External_Tensor_Materialization(void)
     for (UINT32 i = 0; i < 6; ++i) {
         TY_IDX ty = (i & 1) == 0 ? weight_ty : bias_ty;
         UINT64 byte_length = (i & 1) == 0 ? 16 : 8;
-        sources[i] = Create_External_Rewrite_Source
-                         (source_names[i], ty, source_keys[i],
-                          i * 32, byte_length, contexts[i], checksum,
-                          &position);
+        if (i == 1) {
+            sources[i] = DSL_Builder_Create_Tensor_Constant
+                (source_names[i], ty, "float32", 1, "[2]",
+                 "implicit_zero", "0");
+            DSL_BUILDER_COMPILER_METADATA metadata;
+            metadata.name = "source.instance_path";
+            metadata.value = contexts[i];
+            if (sources[i] != NULL) {
+                DSL_Builder_Set_Value_Source_Position(sources[i], &position);
+                DSL_Builder_Attach_Value_Metadata(sources[i], &metadata, 1);
+            }
+            ++position.line;
+        } else {
+            sources[i] = Create_External_Rewrite_Source
+                             (source_names[i], ty, source_keys[i],
+                              i * 32, byte_length, contexts[i], checksum,
+                              &position);
+        }
     }
     EXTERNAL_REWRITE_CHECK(caller != NULL && caller_file != 0,
                            "caller program unit");
@@ -5345,6 +5359,19 @@ Check_External_Tensor_Materialization(void)
                     &callsite);
     EXTERNAL_REWRITE_CHECK(calls[0] != NULL && calls[1] != NULL,
                            "two shared-callee calls");
+    EXTERNAL_REWRITE_CHECK
+        (DSL_Builder_Set_PU_Call_Argument_Role
+             (calls[0], 0, 0, "cnn.basic_block.conv1.weight") &&
+         DSL_Builder_Set_PU_Call_Argument_Role
+             (calls[0], 1, 1, "cnn.basic_block.conv1.bias") &&
+         DSL_Builder_Set_PU_Call_Argument_Role
+             (calls[1], 0, 0, "cnn.basic_block.conv1.weight") &&
+         DSL_Builder_Set_PU_Call_Argument_Role
+             (calls[1], 1, 1, "cnn.basic_block.conv1.bias") &&
+         !DSL_Builder_Set_PU_Call_Argument_Role
+             (calls[1], 0, 0, "cnn.basic_block.conv2.weight") &&
+         DSL_Call_ABI_Image_Argument_Count() == 4,
+         "structured call ABI argument roles");
     if (failed)
         return failed;
 
@@ -5383,6 +5410,9 @@ Check_External_Tensor_Materialization(void)
         requests[i].byte_offset = i * 32;
         requests[i].byte_length = (i & 1) == 0 ? 16 : 8;
         requests[i].checksum = checksum;
+        if (i == 1)
+            requests[i].source_policy =
+                DSL_IR_MATERIALIZE_SOURCE_EXTERNAL_OR_IMPLICIT_ZERO;
         if (i < 4) {
             requests[i].call = calls[i / 2];
             requests[i].actual_ordinal = i & 1;
@@ -5407,6 +5437,15 @@ Check_External_Tensor_Materialization(void)
          WN_st_idx(WN_kid0(WN_kid(calls[0], 1))) ==
              original_actual_st[1],
          "weight and bias batch rejects without partial mutation");
+    DSL_CALL_ARGUMENT_RECORD argument_record;
+    EXTERNAL_REWRITE_CHECK
+        (DSL_Call_ABI_Image_Find_Argument(calls[0], 0, &argument_record) &&
+         argument_record.argument_value_id ==
+             DSL_Builder_Get_Value_Image_Id(sources[0]) &&
+         DSL_Call_ABI_Image_Find_Argument(calls[0], 1, &argument_record) &&
+         argument_record.argument_value_id ==
+             DSL_Builder_Get_Value_Image_Id(sources[1]),
+         "rejected batch leaves call ABI values unchanged");
 
     memcpy(rejected, requests, sizeof(rejected));
     rejected[1].name = rejected[0].name;
@@ -5491,6 +5530,13 @@ Check_External_Tensor_Materialization(void)
             (WN_st_idx(WN_kid0(WN_kid(calls[i / 2], i & 1))) ==
                  materialized[i].st,
              "caller actual uses the context-owned folded value");
+    for (UINT32 i = 0; i < 4; ++i) {
+        EXTERNAL_REWRITE_CHECK
+            (DSL_Call_ABI_Image_Find_Argument
+                 (calls[i / 2], i & 1, &argument_record) &&
+             argument_record.argument_value_id == materialized[i].value_id,
+             "call ABI follows the materialized actual");
+    }
     EXTERNAL_REWRITE_CHECK
         (DSL_IR_Image_Get_External_Tensor_Reference
              (PU_Info_proc_sym(caller), materialized[0].value_id,
@@ -5516,7 +5562,11 @@ Check_External_Tensor_Materialization(void)
          "source payload remains immutable");
 
     EXTERNAL_REWRITE_CHECK
+        (!DSL_Call_ABI_Image_Validate_PU(callee, NULL),
+         "call ABI rejects a non-active callee local symbol table");
+    EXTERNAL_REWRITE_CHECK
         (DSL_Builder_Select_PU(callee) &&
+         DSL_Call_ABI_Image_Validate_PU(callee, stderr) &&
          WN_num_formals(PU_Info_tree_ptr(callee)) == 3 &&
          strcmp(ST_name(St_Table
                     [WN_st_idx(WN_formal(PU_Info_tree_ptr(callee), 0))]),
@@ -5527,6 +5577,39 @@ Check_External_Tensor_Materialization(void)
          "shared callee signature remains unchanged");
     EXTERNAL_REWRITE_CHECK(DSL_Builder_Select_PU(caller),
                            "restore caller program unit");
+
+    DSL_CALL_ABI_IMAGE_HEADER abi_header;
+    DSL_Call_ABI_Image_Get_Header(&abi_header);
+    UINT64 abi_size = DSL_CALL_ABI_IMAGE_HEADER_SIZE +
+        (UINT64)abi_header.argument_count * DSL_CALL_ARGUMENT_RECORD_SIZE;
+    unsigned char *abi_bytes = new unsigned char[abi_size];
+    memcpy(abi_bytes, &abi_header, sizeof(abi_header));
+    DSL_CALL_ARGUMENT_RECORD *abi_rows =
+        (DSL_CALL_ARGUMENT_RECORD *)
+            (abi_bytes + DSL_CALL_ABI_IMAGE_HEADER_SIZE);
+    for (UINT32 i = 1; i <= abi_header.argument_count; ++i)
+        DSL_Call_ABI_Image_Get_Argument(i, &abi_rows[i - 1]);
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_Call_ABI_Image_Load_Mapped(abi_bytes, abi_size - 1, NULL) &&
+         !DSL_Call_ABI_Image_Load_Mapped(abi_bytes, abi_size + 1, NULL),
+         "truncated and trailing call ABI images reject");
+    abi_rows[0].flags = 1;
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_Call_ABI_Image_Load_Mapped(abi_bytes, abi_size, NULL),
+         "nonzero call ABI flags reject");
+    abi_rows[0].flags = 0;
+    abi_rows[1].callsite_id = abi_rows[0].callsite_id;
+    abi_rows[1].actual_ordinal = abi_rows[0].actual_ordinal;
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_Call_ABI_Image_Load_Mapped(abi_bytes, abi_size, NULL),
+         "duplicate call ABI identity rejects");
+    abi_rows[1].callsite_id = 1;
+    abi_rows[1].actual_ordinal = 1;
+    EXTERNAL_REWRITE_CHECK
+        (DSL_Call_ABI_Image_Load_Mapped(abi_bytes, abi_size, stderr) &&
+         DSL_Call_ABI_Image_Argument_Count() == 4,
+         "valid call ABI image reloads after malformed inputs");
+    delete [] abi_bytes;
 
     memset(&verify, 0, sizeof(verify));
     memset(diagnostic, 0, sizeof(diagnostic));
@@ -6048,6 +6131,384 @@ Check_FHE_SYNC3_Plan_Image(void)
     return failed;
 }
 
+static WN *
+Find_STID_In_Block (WN *block, ST_IDX st)
+{
+    if (block == NULL || WN_operator(block) != OPR_BLOCK)
+        return NULL;
+    for (WN *statement = WN_first(block); statement != NULL;
+         statement = WN_next(statement)) {
+        if (WN_operator(statement) == OPR_STID && WN_st_idx(statement) == st)
+            return statement;
+    }
+    return NULL;
+}
+
+static unsigned char *
+Capture_DSL_IR_Image (UINT64 *image_size)
+{
+    DSL_IR_IMAGE_HEADER header;
+    DSL_IR_Image_Get_Header(&header);
+    UINT64 size = DSL_IR_IMAGE_HEADER_SIZE +
+        (UINT64)header.opcode_descriptor_count *
+            DSL_IR_OPCODE_DESCRIPTOR_RECORD_SIZE +
+        (UINT64)header.node_count * DSL_IR_NODE_RECORD_SIZE +
+        (UINT64)header.attribute_count * DSL_IR_ATTRIBUTE_RECORD_SIZE +
+        (UINT64)header.value_count * DSL_IR_VALUE_RECORD_SIZE +
+        (UINT64)header.value_reference_count *
+            DSL_IR_VALUE_REFERENCE_RECORD_SIZE;
+    unsigned char *bytes = new unsigned char[size];
+    unsigned char *cursor = bytes;
+    memcpy(cursor, &header, sizeof(header));
+    cursor += DSL_IR_IMAGE_HEADER_SIZE;
+    for (UINT32 i = 1; i <= header.opcode_descriptor_count; ++i) {
+        DSL_IR_OPCODE_DESCRIPTOR_RECORD record;
+        DSL_IR_Image_Get_Opcode_Descriptor(i, &record);
+        memcpy(cursor, &record, sizeof(record));
+        cursor += DSL_IR_OPCODE_DESCRIPTOR_RECORD_SIZE;
+    }
+    for (UINT32 i = 1; i <= header.node_count; ++i) {
+        DSL_IR_NODE_RECORD record;
+        DSL_IR_Image_Get_Node(i, &record);
+        memcpy(cursor, &record, sizeof(record));
+        cursor += DSL_IR_NODE_RECORD_SIZE;
+    }
+    for (UINT32 i = 1; i <= header.attribute_count; ++i) {
+        DSL_IR_ATTRIBUTE_RECORD record;
+        DSL_IR_Image_Get_Attribute(i, &record);
+        memcpy(cursor, &record, sizeof(record));
+        cursor += DSL_IR_ATTRIBUTE_RECORD_SIZE;
+    }
+    for (UINT32 i = 1; i <= header.value_count; ++i) {
+        DSL_IR_VALUE_RECORD record;
+        DSL_IR_Image_Get_Value(i, &record);
+        memcpy(cursor, &record, sizeof(record));
+        cursor += DSL_IR_VALUE_RECORD_SIZE;
+    }
+    for (UINT32 i = 1; i <= header.value_reference_count; ++i) {
+        DSL_IR_VALUE_REFERENCE_RECORD record;
+        DSL_IR_Image_Get_Value_Reference(i, &record);
+        memcpy(cursor, &record, sizeof(record));
+        cursor += DSL_IR_VALUE_REFERENCE_RECORD_SIZE;
+    }
+    *image_size = size;
+    return bytes;
+}
+
+static int
+Check_DSL_Value_Retirement(void)
+{
+    const char *artifact = getenv("OPEN64_DSL_VALUE_RETIRE_ARTIFACT");
+    DSL_BUILDER_TENSOR_DESCRIPTOR descriptor;
+    DSL_BUILDER_SOURCE_POSITION position;
+    DSL_BUILDER_PROGRAM_UNIT pu;
+    DSL_BUILDER_VALUE input;
+    DSL_BUILDER_VALUE values[3];
+    DSL_BUILDER_VALUE kid[1];
+    DSL_IR_NATIVE_VALUE_RETIRE_REQUEST request;
+    DSL_IR_NODE_RECORD retired_node;
+    DSL_IR_VALUE_RECORD retired_value;
+    DSL_IR_VALUE_ID target;
+    DSL_BUILDER_MAPPED_IMAGE_REQUEST image_request;
+    WN *body;
+    WN *replacement_definition;
+    WN *retiring_definition;
+    WN *consumer_definition;
+    WN *address_use;
+    WN *nested_block;
+    WN *nested_if;
+    TY_IDX ty;
+    TY_IDX pointer_ty;
+    int failed = 0;
+#define RETIRE_CHECK(condition, message) \
+    do { \
+        if (!(condition)) { \
+            fprintf(stderr, "DSL retirement check failed: %s\n", message); \
+            failed = 1; \
+        } \
+    } while (0)
+
+    RETIRE_CHECK(DSL_Builder_Begin_Program(), "program initialization");
+    DSL_Opcode_Register_Common_Substrate();
+    memset(&descriptor, 0, sizeof(descriptor));
+    descriptor.type_core.kind = "tensor";
+    descriptor.type_core.dtype = "float32";
+    descriptor.type_core.rank = 2;
+    descriptor.type_core.logical_shape = "[2,2]";
+    descriptor.traits.traits = "activation";
+    descriptor.representation.layout = "row_major";
+    descriptor.representation.sharding = "replicated";
+    descriptor.representation.placement = "host";
+    descriptor.representation.memory = "contiguous";
+    descriptor.representation.quantization = "none";
+    ty = DSL_Builder_Intern_Tensor_Type
+             ("retire_f32_2x2", MTYPE_To_TY(MTYPE_F4), &descriptor);
+    pu = DSL_Builder_Create_Minimal_PU("dsl_value_retirement");
+    UINT32 file_id = DSL_Builder_Register_Source_File(pu, __FILE__);
+    input = DSL_Builder_Create_Model_Input("input", ty, 0);
+    kid[0] = input;
+    values[0] = DSL_Builder_Create_Operator_With_Result
+                    (DSL_Opcode_Find(DSL_Domain_Find("common"),
+                                     "common.relu", 2),
+                     2, kid, 1, NULL, 0, "relu_first", ty);
+    kid[0] = values[0];
+    values[1] = DSL_Builder_Create_Operator_With_Result
+                    (DSL_Opcode_Find(DSL_Domain_Find("common"),
+                                     "common.relu", 2),
+                     2, kid, 1, NULL, 0, "relu_retired", ty);
+    kid[0] = values[1];
+    values[2] = DSL_Builder_Create_Operator_With_Result
+                    (DSL_Opcode_Find(DSL_Domain_Find("common"),
+                                     "common.relu", 2),
+                     2, kid, 1, NULL, 0, "relu_consumer", ty);
+    memset(&position, 0, sizeof(position));
+    position.file_id = file_id;
+    position.line = __LINE__ + 1;
+    position.statement_begin = 1;
+    RETIRE_CHECK(ty != TY_IDX_ZERO && pu != NULL && file_id != 0 &&
+                 input != NULL && values[0] != NULL && values[1] != NULL &&
+                 values[2] != NULL,
+                 "retirement fixture creation");
+    DSL_Builder_Set_Value_Source_Position(input, &position);
+    for (UINT32 i = 0; i < 3; ++i) {
+        ++position.line;
+        DSL_Builder_Set_Value_Source_Position(values[i], &position);
+    }
+    RETIRE_CHECK(DSL_Builder_Append_PU_Value(pu, values[2]),
+                 "materialize expression chain");
+
+    body = WN_func_body(PU_Info_tree_ptr(pu));
+    replacement_definition = Find_STID_In_Block
+        (body, DSL_Builder_Get_Value_Result_Symbol(values[0]));
+    retiring_definition = Find_STID_In_Block
+        (body, DSL_Builder_Get_Value_Result_Symbol(values[1]));
+    consumer_definition = Find_STID_In_Block
+        (body, DSL_Builder_Get_Value_Result_Symbol(values[2]));
+    memset(&request, 0, sizeof(request));
+    request.pu_root = PU_Info_tree_ptr(pu);
+    request.containing_block = body;
+    request.replacement_definition = replacement_definition;
+    request.replacement_value_id = DSL_Builder_Get_Value_Image_Id(values[0]);
+    request.retiring_definition = retiring_definition;
+    request.retiring_value_id = DSL_Builder_Get_Value_Image_Id(values[1]);
+    request.expected_retiring_operator = OPR_DSLRELU;
+    request.expected_retiring_version = 2;
+    request.replacement_operand_ordinal = 0;
+    pointer_ty = Make_Pointer_Type(ty);
+    address_use = WN_CreateEval
+        (WN_CreateLda(OPR_LDA, Pointer_Mtype, MTYPE_V, 0, pointer_ty,
+                      DSL_Builder_Get_Value_Result_Symbol(values[1])));
+    WN_INSERT_BlockAfter(body, retiring_definition, address_use);
+    RETIRE_CHECK
+        (!DSL_IR_Redirect_And_Retire_Native_Value
+              (PU_Info_proc_sym(pu), &request) &&
+         Find_STID_In_Block
+             (body, DSL_Builder_Get_Value_Result_Symbol(values[1])) != NULL &&
+         WN_st_idx(WN_kid0(WN_kid0(consumer_definition))) ==
+             DSL_Builder_Get_Value_Result_Symbol(values[1]),
+         "address-taken value rejects without mutation");
+    WN_EXTRACT_FromBlock(body, address_use);
+    WN_DELETE_Tree(address_use);
+    WN_EXTRACT_FromBlock(body, replacement_definition);
+    WN_EXTRACT_FromBlock(body, retiring_definition);
+    nested_block = WN_CreateBlock();
+    WN_INSERT_BlockLast(nested_block, replacement_definition);
+    WN_INSERT_BlockLast(nested_block, retiring_definition);
+    nested_if = WN_CreateIf(WN_Intconst(MTYPE_I4, 1), nested_block,
+                            WN_CreateBlock());
+    WN_INSERT_BlockBefore(body, consumer_definition, nested_if);
+    request.containing_block = nested_block;
+    RETIRE_CHECK
+        (!DSL_IR_Redirect_And_Retire_Native_Value
+              (PU_Info_proc_sym(pu), &request) &&
+         Find_STID_In_Block
+             (nested_block,
+              DSL_Builder_Get_Value_Result_Symbol(values[1])) != NULL &&
+         WN_st_idx(WN_kid0(WN_kid0(consumer_definition))) ==
+             DSL_Builder_Get_Value_Result_Symbol(values[1]),
+         "use outside the defining block rejects without mutation");
+    WN_EXTRACT_FromBlock(nested_block, replacement_definition);
+    WN_EXTRACT_FromBlock(nested_block, retiring_definition);
+    WN_EXTRACT_FromBlock(body, nested_if);
+    WN_DELETE_Tree(nested_if);
+    WN_INSERT_BlockBefore(body, consumer_definition, replacement_definition);
+    WN_INSERT_BlockAfter(body, replacement_definition, retiring_definition);
+    request.containing_block = body;
+    RETIRE_CHECK
+        (replacement_definition != NULL && retiring_definition != NULL &&
+         consumer_definition != NULL &&
+         DSL_IR_Redirect_And_Retire_Native_Value
+             (PU_Info_proc_sym(pu), &request),
+         "redirect and retire pure value");
+    RETIRE_CHECK
+        (Find_STID_In_Block
+             (body, DSL_Builder_Get_Value_Result_Symbol(values[1])) == NULL &&
+         WN_st_idx(WN_kid0(WN_kid0(consumer_definition))) ==
+             DSL_Builder_Get_Value_Result_Symbol(values[0]) &&
+         DSL_IR_Image_Executable_Node_Count() + 1 ==
+             DSL_IR_Image_Node_Count(),
+         "tree use and executable count reflect retirement");
+    RETIRE_CHECK
+        (DSL_IR_Image_Get_Value(request.retiring_value_id, &retired_value) &&
+         DSL_IR_Image_Get_Node(retired_value.producer_node_id, &retired_node) &&
+         (retired_node.flags & DSL_IR_NODE_FLAG_RETIRED) != 0 &&
+         (retired_value.flags & DSL_IR_VALUE_FLAG_REDIRECTED) != 0 &&
+         DSL_IR_Image_Value_Redirect_Target(retired_value.id, &target) &&
+         target == request.replacement_value_id &&
+         DSL_IR_Image_Validate(stderr),
+         "retirement evidence remains mapped-image valid");
+
+    UINT64 image_size = 0;
+    unsigned char *image_bytes = Capture_DSL_IR_Image(&image_size);
+    DSL_IR_IMAGE_HEADER *header = (DSL_IR_IMAGE_HEADER *)image_bytes;
+    DSL_IR_OPCODE_DESCRIPTOR_RECORD *descriptors =
+        (DSL_IR_OPCODE_DESCRIPTOR_RECORD *)
+            (image_bytes + DSL_IR_IMAGE_HEADER_SIZE);
+    DSL_IR_NODE_RECORD *nodes = (DSL_IR_NODE_RECORD *)
+        ((unsigned char *)descriptors +
+         (UINT64)header->opcode_descriptor_count *
+             DSL_IR_OPCODE_DESCRIPTOR_RECORD_SIZE);
+    DSL_IR_ATTRIBUTE_RECORD *attributes = (DSL_IR_ATTRIBUTE_RECORD *)
+        ((unsigned char *)nodes +
+         (UINT64)header->node_count * DSL_IR_NODE_RECORD_SIZE);
+    DSL_IR_VALUE_RECORD *image_values = (DSL_IR_VALUE_RECORD *)
+        ((unsigned char *)attributes +
+         (UINT64)header->attribute_count * DSL_IR_ATTRIBUTE_RECORD_SIZE);
+    DSL_IR_VALUE_REFERENCE_RECORD *references =
+        (DSL_IR_VALUE_REFERENCE_RECORD *)
+            ((unsigned char *)image_values +
+             (UINT64)header->value_count * DSL_IR_VALUE_RECORD_SIZE);
+    DSL_IR_NODE_RECORD &retired_image_node =
+        nodes[retired_value.producer_node_id - 1];
+    UINT32 redirect_ordinal =
+        (retired_image_node.flags & DSL_IR_NODE_REDIRECT_ORDINAL_MASK) >>
+        DSL_IR_NODE_REDIRECT_ORDINAL_SHIFT;
+    DSL_IR_VALUE_REFERENCE_RECORD &redirect_reference =
+        references[retired_image_node.first_operand_reference_id - 1 +
+                   redirect_ordinal];
+    DSL_IR_VALUE_RECORD &redirect_value =
+        image_values[redirect_reference.value_id - 1];
+    DSL_IR_OPCODE_DESCRIPTOR_RECORD &retired_descriptor =
+        descriptors[retired_image_node.opcode_descriptor_id - 1];
+    DSL_IR_VALUE_ID saved_target = redirect_reference.value_id;
+    TY_IDX saved_target_ty = redirect_value.ty;
+    UINT32 saved_target_flags = redirect_value.flags;
+    UINT32 saved_effect_model = retired_descriptor.effect_model;
+
+    redirect_reference.value_id = retired_value.id;
+    RETIRE_CHECK(!DSL_IR_Image_Load_Mapped(image_bytes, image_size, NULL),
+                 "self redirect target rejects on mapped load");
+    redirect_reference.value_id = saved_target;
+    redirect_value.ty = MTYPE_To_TY(MTYPE_I4);
+    RETIRE_CHECK(!DSL_IR_Image_Load_Mapped(image_bytes, image_size, NULL),
+                 "wrong-TY redirect target rejects on mapped load");
+    redirect_value.ty = saved_target_ty;
+    redirect_value.flags = DSL_IR_VALUE_FLAG_REDIRECTED;
+    RETIRE_CHECK(!DSL_IR_Image_Load_Mapped(image_bytes, image_size, NULL),
+                 "redirect chain rejects on mapped load");
+    redirect_value.flags = saved_target_flags;
+    retired_descriptor.effect_model = DSL_EFFECT_MODEL_RUNTIME_EFFECT;
+    RETIRE_CHECK(!DSL_IR_Image_Load_Mapped(image_bytes, image_size, NULL),
+                 "effectful retired node rejects on mapped load");
+    retired_descriptor.effect_model = saved_effect_model;
+    RETIRE_CHECK(DSL_IR_Image_Load_Mapped(image_bytes, image_size, stderr),
+                 "valid retired image reloads after malformed inputs");
+    delete [] image_bytes;
+
+    DSL_BUILDER_VALUE collision[3];
+    kid[0] = input;
+    collision[0] = DSL_Builder_Create_Operator_With_Result
+        (DSL_Opcode_Find(DSL_Domain_Find("common"), "common.relu", 2),
+         2, kid, 1, NULL, 0, "region_collision_first", ty);
+    kid[0] = collision[0];
+    collision[1] = DSL_Builder_Create_Operator_With_Result
+        (DSL_Opcode_Find(DSL_Domain_Find("common"), "common.relu", 2),
+         2, kid, 1, NULL, 0, "region_collision_retired", ty);
+    kid[0] = collision[1];
+    collision[2] = DSL_Builder_Create_Operator_With_Result
+        (DSL_Opcode_Find(DSL_Domain_Find("common"), "common.relu", 2),
+         2, kid, 1, NULL, 0, "region_collision_consumer", ty);
+    RETIRE_CHECK(collision[0] != NULL && collision[1] != NULL &&
+                 collision[2] != NULL &&
+                 DSL_Builder_Append_PU_Value(pu, collision[2]),
+                 "REGION collision fixture values");
+    DSL_REGION collision_region =
+        DSL_Region_Create(pu, NULL, "cnn.basic_block", 1);
+    RETIRE_CHECK
+        (collision_region != NULL &&
+         DSL_Region_Declare_Symbol
+             (collision_region,
+              DSL_Builder_Get_Value_Result_Symbol(collision[0]),
+              DSL_REGION_VALUE_INPUT, 0, DSL_REGION_INTERFACE_FLAG_NONE) &&
+         DSL_Region_Declare_Symbol
+             (collision_region,
+              DSL_Builder_Get_Value_Result_Symbol(collision[1]),
+              DSL_REGION_VALUE_INPUT, 1, DSL_REGION_INTERFACE_FLAG_NONE) &&
+         DSL_Region_Append_To_PU(collision_region) &&
+         DSL_Region_Verify_PU(pu, stderr),
+         "valid REGION interfaces before redirect");
+    char region_before[2048];
+    char region_after[2048];
+    FILE *region_dump = tmpfile();
+    RETIRE_CHECK(region_dump != NULL, "REGION preflight trace creation");
+    size_t region_before_size = 0;
+    if (region_dump != NULL) {
+        DSL_Region_Print_PU(region_dump, pu);
+        rewind(region_dump);
+        region_before_size = fread(region_before, 1,
+                                   sizeof(region_before) - 1, region_dump);
+        region_before[region_before_size] = '\0';
+        fclose(region_dump);
+    }
+    replacement_definition = Find_STID_In_Block
+        (body, DSL_Builder_Get_Value_Result_Symbol(collision[0]));
+    retiring_definition = Find_STID_In_Block
+        (body, DSL_Builder_Get_Value_Result_Symbol(collision[1]));
+    consumer_definition = Find_STID_In_Block
+        (body, DSL_Builder_Get_Value_Result_Symbol(collision[2]));
+    request.replacement_definition = replacement_definition;
+    request.replacement_value_id =
+        DSL_Builder_Get_Value_Image_Id(collision[0]);
+    request.retiring_definition = retiring_definition;
+    request.retiring_value_id = DSL_Builder_Get_Value_Image_Id(collision[1]);
+    UINT32 collision_node_count = DSL_IR_Image_Node_Count();
+    BOOL collision_rejected = !DSL_IR_Redirect_And_Retire_Native_Value
+        (PU_Info_proc_sym(pu), &request);
+    region_dump = tmpfile();
+    size_t region_after_size = 0;
+    if (region_dump != NULL) {
+        DSL_Region_Print_PU(region_dump, pu);
+        rewind(region_dump);
+        region_after_size = fread(region_after, 1,
+                                  sizeof(region_after) - 1, region_dump);
+        region_after[region_after_size] = '\0';
+        fclose(region_dump);
+    }
+    RETIRE_CHECK
+        (collision_rejected && region_dump != NULL &&
+         region_before_size == region_after_size &&
+         strcmp(region_before, region_after) == 0 &&
+         DSL_IR_Image_Node_Count() == collision_node_count &&
+         Find_STID_In_Block
+             (body, DSL_Builder_Get_Value_Result_Symbol(collision[1])) !=
+                 NULL &&
+         WN_st_idx(WN_kid0(WN_kid0(consumer_definition))) ==
+             DSL_Builder_Get_Value_Result_Symbol(collision[1]) &&
+         DSL_Region_Verify_PU(pu, stderr),
+         "REGION redirect collision rejects without mutation");
+    if (!failed && artifact != NULL && artifact[0] != '\0') {
+        image_request.path = artifact;
+        image_request.flags = 0;
+        (void) unlink(artifact);
+        RETIRE_CHECK(DSL_Builder_Finalize_Mapped_Image(&image_request),
+                     "mapped-image finalization");
+    }
+    if (!failed)
+        printf("DSL native value retirement contract passed\n");
+#undef RETIRE_CHECK
+    return failed;
+}
+
 int
 main(void)
 {
@@ -6094,6 +6555,8 @@ main(void)
         return Check_FHE_SYNC3_Native_Rewrite();
     if (getenv("OPEN64_DSL_EXTERNAL_TENSOR_REWRITE_ONLY") != NULL)
         return Check_External_Tensor_Materialization();
+    if (getenv("OPEN64_DSL_VALUE_RETIRE_ONLY") != NULL)
+        return Check_DSL_Value_Retirement();
 
     failed |= Check_Tensor_Type_And_Descriptor();
     failed |= Check_Symbol_Metadata();
@@ -6116,6 +6579,7 @@ main(void)
     failed |= Check_FHE_SYNC3_Plan_Image();
     failed |= Check_FHE_SYNC3_Native_Rewrite();
     failed |= Check_External_Tensor_Materialization();
+    failed |= Check_DSL_Value_Retirement();
     failed |= Check_DSL_Simplifier_Bridge();
 
     return failed;

--- a/osprey/common/com/tests/dsl_external_tensor_rewrite_test.sh
+++ b/osprey/common/com/tests/dsl_external_tensor_rewrite_test.sh
@@ -53,6 +53,9 @@ for evidence in \
   'converted.safetensors#stem.conv.folded_bias' \
   'side_file=converted.safetensors' \
   'dsl.converted_from_value_id' \
+  'DSL Call ABI Argument Table: version=1 entries=4' \
+  'role=cnn.basic_block.conv1.weight' \
+  'role=cnn.basic_block.conv1.bias' \
   'dsl_builder_contract_test.cxx'; do
   if ! grep -Fq "$evidence" "$trace"; then
     echo "missing external tensor rewrite evidence '$evidence' in $trace" >&2

--- a/osprey/common/com/tests/dsl_value_retirement_test.sh
+++ b/osprey/common/com/tests/dsl_value_retirement_test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../../../.." && pwd)"
+contract_test="${OPEN64_DSL_CONTRACT_TEST:-$repo_root/build/osprey/targdir/ir_tools/dsl_builder_contract_test}"
+ir_b2a="${OPEN64_IR_B2A:-$repo_root/build/osprey/targdir/ir_tools/ir_b2a}"
+old_ir_b2a="${OPEN64_PREVIOUS_IR_B2A:-}"
+artifact_dir="${OPEN64_DSL_VALUE_RETIRE_ARTIFACT_DIR:-$repo_root/artifacts/fhe/value-retirement}"
+image="$artifact_dir/value_retirement.B"
+trace="$artifact_dir/value_retirement.T"
+old_trace="$artifact_dir/value_retirement.previous-reader.T"
+validation_log="$artifact_dir/validation.log"
+
+mkdir -p "$artifact_dir"
+find "$artifact_dir" -mindepth 1 -maxdepth 1 -type f -delete
+
+OPEN64_DSL_VALUE_RETIRE_ONLY=1 \
+OPEN64_DSL_VALUE_RETIRE_ARTIFACT="$image" \
+  "$contract_test" >"$validation_log" 2>&1
+"$ir_b2a" -st -src "$image" "$trace" >>"$validation_log" 2>&1
+
+for evidence in \
+  'operator=OPR_DSLRELU version=2' \
+  'status=retired redirected_to=value' \
+  'status=redirected redirected_to=value' \
+  'dsl_builder_contract_test.cxx'; do
+  if ! grep -Fq "$evidence" "$trace"; then
+    echo "missing retirement evidence '$evidence' in $trace" >&2
+    exit 1
+  fi
+done
+if grep -Fq 'OPR_DSL ' "$trace"; then
+  echo "physical DSL escape tag leaked into $trace" >&2
+  exit 1
+fi
+
+if [[ -n "$old_ir_b2a" ]]; then
+  "$old_ir_b2a" -st -src "$image" "$old_trace" >>"$validation_log" 2>&1
+  grep -Fq 'operator=OPR_DSLRELU version=2' "$old_trace"
+fi
+
+echo "DSL value retirement fixture passed"
+echo "review image: $image"
+echo "review trace: $trace"
+if [[ -n "$old_ir_b2a" ]]; then
+  echo "previous-reader trace: $old_trace"
+fi

--- a/osprey/include/sys/elf_whirl.h
+++ b/osprey/include/sys/elf_whirl.h
@@ -85,6 +85,7 @@
 #define WT_DSL_CALLSITE_IMAGE 0x22
 #define WT_DSL_FHE_IMAGE 0x23
 #define WT_DSL_FHE_PLAN 0x24
+#define WT_DSL_CALL_ABI_IMAGE 0x25
 
 /*
  * Special WHIRL section names.
@@ -103,6 +104,7 @@
 #define MIPS_WHIRL_DSL_CALLSITE_IMAGE ".WHIRL.dsl_calls"
 #define MIPS_WHIRL_DSL_FHE_IMAGE ".WHIRL.dsl_fhe"
 #define MIPS_WHIRL_DSL_FHE_PLAN ".WHIRL.dsl_fhe_plan"
+#define MIPS_WHIRL_DSL_CALL_ABI_IMAGE ".WHIRL.dsl_call_abi"
 #if defined(TARG_SL)
 #define MIPS_WHIRL_CALLGRAPH    ".WHIRL.callgraph"
 #endif


### PR DESCRIPTION
## Summary

- add the optional mapped-image call ABI table for stable call-argument/formal semantic roles
- extend external tensor materialization for exact typed implicit-zero bias sources and atomically update call ABI argument identities
- add pure DSL value redirection and retirement, including conservative dominance/use checks and REGION interface preflight
- preserve logical provenance while excluding retired nodes from executable accounting and exposing stable ir_b2a evidence
- keep table-only mutation helpers private so persistent edits pass through reviewed transactional APIs

## Value

This closes the native infrastructure blockers for the FHE ResNet BatchNorm-fold path: 13 physical Conv/BN definitions and 21 call contexts can now be resolved structurally, materialized with caller-owned converted parameters, and retire executable BatchNorm values without parsing names or exposing raw WHIRL storage.

The change is generic DSL infrastructure. ReLU approximation coefficients and policy remain a separate FHE semantic decision.

## Compatibility

- adds optional `WT_DSL_CALL_ABI_IMAGE` / `.WHIRL.dsl_call_abi`; existing WHIRL sections are unchanged
- previous readers reopen the physical WHIRL; retirement-bearing images fail closed at the previous DSL program gatekeeper
- redirect targets are derived from retained operands; no reserved field is repurposed
- mapped-image validation rejects malformed, effectful, self, wrong-TY, chained, and still-referenced retirement rows

## Validation

- native syntax and target layout tests passed
- builder/call-ABI contract tests passed, including wrong-active-PU and colliding local ST indices
- external tensor rewrite roundtrip passed, including two-actual rollback, duplicate rejection, shared-callee context materialization, and implicit-zero bias
- value retirement roundtrip passed with `ir_b2a -st -src`, malformed mapped-image negatives, nested control-flow rejection, and REGION collision rollback
- previous-reader compatibility checks passed
- `git diff --check` and no-tab scan passed

FHE consumer review accepted this contract with no remaining infrastructure blocker.