### PR TITLE
Persist DSL PU formal value identity

### DIFF
--- a/doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md
+++ b/doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md
@@ -155,6 +155,37 @@ unit as the physical call actual. A rejected request array changes neither the
 call nor the ABI table. Original provenance remains in
 `dsl.converted_from_value_id` and does not enter ABI-row identity.
 
+## Durable PU Formal Values
+
+The call-ABI row identifies a callee formal ordinal but does not identify the
+callee-owned DSL value representing that formal. Local `ST_IDX` values may
+collide between PUs, and free-form value metadata is not a structural owner
+relation. Backend consumers must not activate a callee while rewriting a
+caller merely to recover that relation.
+
+The optional `.WHIRL.dsl_pu_interface` image supplies the missing immutable
+relation. Its v1 header is 24 bytes and each formal row is 32 bytes. A row maps
+`(owner_pu_st, formal_ordinal)` to `formal_value_id`, `formal_st`, and the exact
+canonical `formal_ty`. The ordered rows cover the complete physical
+`FUNC_ENTRY` interface: input formals followed by hidden result formals. IDs
+and symbol/type indices are fixed-width existing WHIRL carriers; flags and
+reserved fields are zero in v1. Duplicate owner and ordinal, value, or symbol
+identities are rejected. The owner must resolve to an existing global function
+ST with a valid PU entry, so orphan rows cannot evade per-PU verification.
+
+`DSL_PU_Interface_Image_Find_Formal()` is globally usable after mapped-image
+load and requires no active callee symbol table. Per-PU validation still
+requires the matching `Current_pu` and local symbol table, then proves every
+physical formal is present exactly once and agrees with the `FUNC_ENTRY`
+`IDNAME`, formal or formal-reference storage class, value row, symbol, and
+exact `TY_IDX`. `ir_b2a -st -src` prints the table for review.
+
+The section is append-only and optional. Existing artifacts without it retain
+the v1 call-ABI behavior and load with an empty PU-interface table. Existing
+sections, call-ABI rows, opcode/type encodings, and the WHIRL binary revision
+are unchanged. New producers emit a formal row from the opaque PU-formal
+builder operation before creating call-role rows.
+
 ## Native Value Redirection And Retirement
 
 `DSL_IR_Redirect_And_Retire_Native_Value()` supports the narrow pure-expression

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1937,6 +1937,23 @@ full-sequence causal prompt evaluation with no KV cache.
    reserved fixed-row field. The detailed compatibility and atomicity contract
    is in `doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md`.
 
+42. [x] Publish durable PU-formal value identity.
+
+   Add optional `.WHIRL.dsl_pu_interface` fixed rows mapping each ordered
+   physical formal, including hidden result formals, to its owner PU, DSL
+   value, local symbol, and exact `TY_IDX`.
+   This lets backend passes resolve `(callee_pu_st, formal_ordinal)` without
+   activating the callee, retaining caller-local WN pointers, parsing names,
+   or depending on free-form metadata. Validate the immutable rows globally
+   and prove complete coverage against the active `FUNC_ENTRY` and local symbol
+   table during per-PU verification. Reject orphan owner functions globally.
+   Print stable formal evidence in `ir_b2a -st -src`.
+
+   The section is additive and optional. Older artifacts load with an empty
+   table and preserve the prior call-ABI validation path; no existing row,
+   opcode, type encoding, or binary revision changes. The detailed contract is
+   in `doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md`.
+
 ### Deferred work TODO
 
 Deferred work remains tracked but does not block the active native DSL bring-up

--- a/osprey/common/com/dsl_builder.cxx
+++ b/osprey/common/com/dsl_builder.cxx
@@ -3485,6 +3485,16 @@ DSL_Builder_Declare_PU_Formal
     interface_record->formals.push_back(formal);
     if (!DSL_Builder_Rebuild_PU_Entry(interface_record))
         return NULL;
+    DSL_PU_FORMAL_RECORD image_formal;
+    memset(&image_formal, 0, sizeof(image_formal));
+    image_formal.owner_pu_st = PU_Info_proc_sym(pu);
+    image_formal.formal_value_id = image_value_id;
+    image_formal.formal_ordinal = ordinal;
+    image_formal.formal_st = ST_st_idx(*st);
+    image_formal.formal_ty = ty;
+    if (DSL_PU_Interface_Image_Add_Formal(&image_formal) ==
+        DSL_PU_FORMAL_INVALID_ID)
+        return NULL;
     return value;
 }
 
@@ -3550,6 +3560,16 @@ DSL_Builder_Declare_PU_Result
     result.role = role;
     interface_record->results.push_back(result);
     if (!DSL_Builder_Rebuild_PU_Entry(interface_record))
+        return NULL;
+    DSL_PU_FORMAL_RECORD image_formal;
+    memset(&image_formal, 0, sizeof(image_formal));
+    image_formal.owner_pu_st = PU_Info_proc_sym(pu);
+    image_formal.formal_value_id = image_value_id;
+    image_formal.formal_ordinal = interface_record->formals.size() + ordinal;
+    image_formal.formal_st = ST_st_idx(*st);
+    image_formal.formal_ty = ty;
+    if (DSL_PU_Interface_Image_Add_Formal(&image_formal) ==
+        DSL_PU_FORMAL_INVALID_ID)
         return NULL;
     return value;
 }
@@ -4143,6 +4163,10 @@ DSL_Builder_Verify_Program (DSL_BUILDER_VERIFY_RESULT *result)
             ++gatekeeper_result.error_count;
         }
         if (!DSL_Call_ABI_Image_Validate_PU(pu, diagnostic)) {
+            valid = FALSE;
+            ++gatekeeper_result.error_count;
+        }
+        if (!DSL_PU_Interface_Image_Validate_PU(pu, diagnostic)) {
             valid = FALSE;
             ++gatekeeper_result.error_count;
         }

--- a/osprey/common/com/dsl_ir_image.cxx
+++ b/osprey/common/com/dsl_ir_image.cxx
@@ -30,6 +30,7 @@ typedef SEGMENTED_ARRAY<DSL_PU_SOURCE_IDENTITY_RECORD>
 typedef SEGMENTED_ARRAY<DSL_CALLSITE_METADATA_RECORD>
     DSL_CALLSITE_METADATA_TABLE;
 typedef SEGMENTED_ARRAY<DSL_CALL_ARGUMENT_RECORD> DSL_CALL_ARGUMENT_TABLE;
+typedef SEGMENTED_ARRAY<DSL_PU_FORMAL_RECORD> DSL_PU_FORMAL_TABLE;
 
 static DSL_IR_OPCODE_DESCRIPTOR_TABLE DSL_ir_opcode_descriptor_table;
 static DSL_IR_NODE_TABLE DSL_ir_node_table;
@@ -41,6 +42,7 @@ static DSL_STATE_EFFECT_TABLE DSL_state_effect_table;
 static DSL_PU_SOURCE_IDENTITY_TABLE DSL_pu_source_identity_table;
 static DSL_CALLSITE_METADATA_TABLE DSL_callsite_metadata_table;
 static DSL_CALL_ARGUMENT_TABLE DSL_call_argument_table;
+static DSL_PU_FORMAL_TABLE DSL_pu_formal_table;
 
 typedef struct {
     ST_IDX owner_pu_st;
@@ -94,6 +96,11 @@ typedef char DSL_Call_ABI_Image_Header_Size_Check
     [sizeof(DSL_CALL_ABI_IMAGE_HEADER) == DSL_CALL_ABI_IMAGE_HEADER_SIZE ? 1 : -1];
 typedef char DSL_Call_Argument_Size_Check
     [sizeof(DSL_CALL_ARGUMENT_RECORD) == DSL_CALL_ARGUMENT_RECORD_SIZE ? 1 : -1];
+typedef char DSL_PU_Interface_Image_Header_Size_Check
+    [sizeof(DSL_PU_INTERFACE_IMAGE_HEADER) ==
+        DSL_PU_INTERFACE_IMAGE_HEADER_SIZE ? 1 : -1];
+typedef char DSL_PU_Formal_Size_Check
+    [sizeof(DSL_PU_FORMAL_RECORD) == DSL_PU_FORMAL_RECORD_SIZE ? 1 : -1];
 
 template <typename RECORD>
 static void
@@ -127,6 +134,7 @@ DSL_IR_Image_Reset (void)
     DSL_state_effect_table.Delete_down_to(0);
     DSL_Call_Image_Reset();
     DSL_Call_ABI_Image_Reset();
+    DSL_PU_Interface_Image_Reset();
 }
 
 static BOOL
@@ -633,6 +641,115 @@ DSL_Call_ABI_Image_Load_Mapped
         DSL_call_argument_table.Insert(arguments, header->argument_count);
     if (!DSL_Call_ABI_Image_Validate(diagnostic)) {
         DSL_Call_ABI_Image_Reset();
+        return FALSE;
+    }
+    return TRUE;
+}
+
+static BOOL
+DSL_PU_Interface_Image_Report
+        (FILE *diagnostic, const char *message, UINT32 id)
+{
+    if (diagnostic != NULL)
+        fprintf(diagnostic, "DSL PU interface image error: %s id=%u\n",
+                message, id);
+    return FALSE;
+}
+
+void
+DSL_PU_Interface_Image_Get_Header
+        (DSL_PU_INTERFACE_IMAGE_HEADER *header)
+{
+    if (header == NULL)
+        return;
+    memset(header, 0, sizeof(*header));
+    header->magic = DSL_PU_INTERFACE_IMAGE_MAGIC;
+    header->version = DSL_PU_INTERFACE_IMAGE_VERSION;
+    header->formal_count = DSL_pu_formal_table.Size();
+}
+
+void
+DSL_PU_Interface_Image_Reset (void)
+{
+    DSL_pu_formal_table.Delete_down_to(0);
+}
+
+BOOL
+DSL_PU_Interface_Image_Has_Records (void)
+{
+    return DSL_pu_formal_table.Size() != 0;
+}
+
+DSL_PU_FORMAL_ID
+DSL_PU_Interface_Image_Add_Formal (const DSL_PU_FORMAL_RECORD *record)
+{
+    if (record == NULL)
+        return DSL_PU_FORMAL_INVALID_ID;
+    DSL_PU_FORMAL_RECORD copy = *record;
+    UINT32 index = DSL_pu_formal_table.Insert(copy);
+    DSL_pu_formal_table[index].id = index + 1;
+    if (!DSL_PU_Interface_Image_Validate(NULL)) {
+        DSL_pu_formal_table.Delete_down_to(index);
+        return DSL_PU_FORMAL_INVALID_ID;
+    }
+    return index + 1;
+}
+
+UINT32
+DSL_PU_Interface_Image_Formal_Count (void)
+{
+    return DSL_pu_formal_table.Size();
+}
+
+BOOL
+DSL_PU_Interface_Image_Get_Formal
+        (DSL_PU_FORMAL_ID id, DSL_PU_FORMAL_RECORD *record)
+{
+    return DSL_IR_Table_Get(DSL_pu_formal_table, id, record);
+}
+
+BOOL
+DSL_PU_Interface_Image_Find_Formal
+        (ST_IDX owner_pu_st, UINT32 formal_ordinal,
+         DSL_PU_FORMAL_RECORD *record)
+{
+    for (UINT32 i = 0; i < DSL_pu_formal_table.Size(); ++i) {
+        const DSL_PU_FORMAL_RECORD &formal = DSL_pu_formal_table[i];
+        if (formal.owner_pu_st == owner_pu_st &&
+            formal.formal_ordinal == formal_ordinal)
+            return DSL_IR_Table_Get(DSL_pu_formal_table, i + 1, record);
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_PU_Interface_Image_Load_Mapped
+        (const void *section_base, UINT64 section_size, FILE *diagnostic)
+{
+    if (section_base == NULL ||
+        section_size < DSL_PU_INTERFACE_IMAGE_HEADER_SIZE)
+        return DSL_PU_Interface_Image_Report
+                   (diagnostic, "section is truncated", 0);
+    const DSL_PU_INTERFACE_IMAGE_HEADER *header =
+        (const DSL_PU_INTERFACE_IMAGE_HEADER *)section_base;
+    UINT64 expected = DSL_PU_INTERFACE_IMAGE_HEADER_SIZE +
+        (UINT64)header->formal_count * DSL_PU_FORMAL_RECORD_SIZE;
+    if (header->magic != DSL_PU_INTERFACE_IMAGE_MAGIC ||
+        header->version != DSL_PU_INTERFACE_IMAGE_VERSION ||
+        header->flags != 0 || header->reserved0 != 0 ||
+        header->reserved1 != 0 || expected != section_size)
+        return DSL_PU_Interface_Image_Report
+                   (diagnostic, "invalid header", 0);
+
+    const DSL_PU_FORMAL_RECORD *formals =
+        (const DSL_PU_FORMAL_RECORD *)
+            ((const char *)section_base +
+             DSL_PU_INTERFACE_IMAGE_HEADER_SIZE);
+    DSL_PU_Interface_Image_Reset();
+    if (header->formal_count != 0)
+        DSL_pu_formal_table.Insert(formals, header->formal_count);
+    if (!DSL_PU_Interface_Image_Validate(diagnostic)) {
+        DSL_PU_Interface_Image_Reset();
         return FALSE;
     }
     return TRUE;

--- a/osprey/common/com/dsl_ir_image.h
+++ b/osprey/common/com/dsl_ir_image.h
@@ -56,6 +56,11 @@ typedef INT32 WN_MAP;
 #define DSL_CALL_ABI_IMAGE_HEADER_SIZE      24
 #define DSL_CALL_ARGUMENT_RECORD_SIZE       32
 
+#define DSL_PU_INTERFACE_IMAGE_MAGIC        0x44535049
+#define DSL_PU_INTERFACE_IMAGE_VERSION      1
+#define DSL_PU_INTERFACE_IMAGE_HEADER_SIZE  24
+#define DSL_PU_FORMAL_RECORD_SIZE           32
+
 #define DSL_IR_OPCODE_DESCRIPTOR_INVALID_ID 0
 #define DSL_IR_NODE_INVALID_ID              0
 #define DSL_IR_ATTRIBUTE_INVALID_ID         0
@@ -72,6 +77,7 @@ typedef UINT32 DSL_STATE_EFFECT_ID;
 typedef UINT32 DSL_PU_SOURCE_IDENTITY_ID;
 typedef UINT32 DSL_CALLSITE_METADATA_ID;
 typedef UINT32 DSL_CALL_ARGUMENT_ID;
+typedef UINT32 DSL_PU_FORMAL_ID;
 
 #define DSL_STATE_OBJECT_INVALID_ID 0
 #define DSL_STATE_EFFECT_INVALID_ID 0
@@ -79,6 +85,8 @@ typedef UINT32 DSL_CALL_ARGUMENT_ID;
 #define DSL_CALLSITE_METADATA_INVALID_ID 0
 #define DSL_CALL_ARGUMENT_INVALID_ID 0
 #define DSL_CALL_ARGUMENT_INVALID_ORDINAL ((UINT32)-1)
+#define DSL_PU_FORMAL_INVALID_ID 0
+#define DSL_PU_FORMAL_INVALID_ORDINAL ((UINT32)-1)
 
 typedef struct {
     UINT32 magic;
@@ -130,6 +138,26 @@ typedef struct {
     UINT32 flags;
     STR_IDX semantic_role;
 } DSL_CALL_ARGUMENT_RECORD;
+
+typedef struct {
+    UINT32 magic;
+    UINT32 version;
+    UINT32 formal_count;
+    UINT32 flags;
+    UINT32 reserved0;
+    UINT32 reserved1;
+} DSL_PU_INTERFACE_IMAGE_HEADER;
+
+typedef struct {
+    DSL_PU_FORMAL_ID id;
+    ST_IDX owner_pu_st;
+    DSL_IR_VALUE_ID formal_value_id;
+    UINT32 formal_ordinal;
+    ST_IDX formal_st;
+    TY_IDX formal_ty;
+    UINT32 flags;
+    UINT32 reserved;
+} DSL_PU_FORMAL_RECORD;
 
 typedef enum {
     DSL_IR_IMAGE_RECORD_UNKNOWN = 0,
@@ -498,6 +526,28 @@ extern BOOL DSL_Call_ABI_Image_Get_Callee_Formal_Argument
                                  UINT32 index,
                                  DSL_CALL_ARGUMENT_RECORD *record);
 extern BOOL DSL_Call_ABI_Image_Validate_PU
+                                (PU_Info *pu, FILE *diagnostic);
+
+extern void DSL_PU_Interface_Image_Get_Header
+                                (DSL_PU_INTERFACE_IMAGE_HEADER *header);
+extern void DSL_PU_Interface_Image_Reset (void);
+extern BOOL DSL_PU_Interface_Image_Has_Records (void);
+extern BOOL DSL_PU_Interface_Image_Validate (FILE *diagnostic);
+extern BOOL DSL_PU_Interface_Image_Load_Mapped
+                                (const void *section_base,
+                                 UINT64 section_size,
+                                 FILE *diagnostic);
+extern DSL_PU_FORMAL_ID DSL_PU_Interface_Image_Add_Formal
+                                (const DSL_PU_FORMAL_RECORD *record);
+extern UINT32 DSL_PU_Interface_Image_Formal_Count (void);
+extern BOOL DSL_PU_Interface_Image_Get_Formal
+                                (DSL_PU_FORMAL_ID id,
+                                 DSL_PU_FORMAL_RECORD *record);
+extern BOOL DSL_PU_Interface_Image_Find_Formal
+                                (ST_IDX owner_pu_st,
+                                 UINT32 formal_ordinal,
+                                 DSL_PU_FORMAL_RECORD *record);
+extern BOOL DSL_PU_Interface_Image_Validate_PU
                                 (PU_Info *pu, FILE *diagnostic);
 
 extern void DSL_Effect_Image_Get_Header (DSL_EFFECT_IMAGE_HEADER *header);

--- a/osprey/common/com/dsl_ir_print.cxx
+++ b/osprey/common/com/dsl_ir_print.cxx
@@ -267,6 +267,21 @@ DSL_IR_Image_Print (FILE *file)
                 DSL_IR_String(record.context_identity),
                 record.source_call_ordinal, record.flags);
     }
+    DSL_PU_INTERFACE_IMAGE_HEADER pu_interface_header;
+    DSL_PU_Interface_Image_Get_Header(&pu_interface_header);
+    fprintf(file, "DSL PU Interface Formal Table: version=%u entries=%u\n",
+            pu_interface_header.version, pu_interface_header.formal_count);
+    for (UINT32 i = 1; i <= pu_interface_header.formal_count; ++i) {
+        DSL_PU_FORMAL_RECORD record;
+        DSL_PU_Interface_Image_Get_Formal(i, &record);
+        fprintf(file, "  [%u] owner_pu=<%u,%u> formal=%u value=%u "
+                "st=<%u,%u> ty=%u flags=0x%x\n", record.id,
+                ST_IDX_level(record.owner_pu_st),
+                ST_IDX_index(record.owner_pu_st), record.formal_ordinal,
+                record.formal_value_id, ST_IDX_level(record.formal_st),
+                ST_IDX_index(record.formal_st), (UINT32)record.formal_ty,
+                record.flags);
+    }
     DSL_CALL_ABI_IMAGE_HEADER call_abi_header;
     DSL_Call_ABI_Image_Get_Header(&call_abi_header);
     fprintf(file, "DSL Call ABI Argument Table: version=%u entries=%u\n",

--- a/osprey/common/com/dsl_ir_rewrite.cxx
+++ b/osprey/common/com/dsl_ir_rewrite.cxx
@@ -118,13 +118,117 @@ DSL_Call_ABI_Image_Validate_PU (PU_Info *pu, FILE *diagnostic)
             ST_IDX formal_st =
                 WN_st_idx(WN_formal(entry, argument.callee_formal_ordinal));
             DSL_IR_VALUE_RECORD value;
+            DSL_PU_FORMAL_RECORD formal;
             if (!DSL_IR_Image_Get_Value(argument.argument_value_id, &value) ||
-                value.ty != ST_type(St_Table[formal_st]))
+                value.ty != ST_type(St_Table[formal_st]) ||
+                (DSL_PU_Interface_Image_Has_Records() &&
+                 (!DSL_PU_Interface_Image_Find_Formal
+                      (owner_pu_st, argument.callee_formal_ordinal, &formal) ||
+                  formal.formal_st != formal_st ||
+                  formal.formal_ty != value.ty)))
                 return DSL_Call_ABI_PU_Report
                            (diagnostic, "actual/formal type mismatch",
                             argument.id);
         }
     }
+    return TRUE;
+}
+
+static BOOL
+DSL_PU_Interface_PU_Report
+        (FILE *diagnostic, const char *message, UINT32 id)
+{
+    if (diagnostic != NULL)
+        fprintf(diagnostic, "DSL PU interface error: %s id=%u\n",
+                message, id);
+    return FALSE;
+}
+
+BOOL
+DSL_PU_Interface_Image_Validate (FILE *diagnostic)
+{
+    for (UINT32 i = 1; i <= DSL_PU_Interface_Image_Formal_Count(); ++i) {
+        DSL_PU_FORMAL_RECORD record;
+        DSL_IR_VALUE_RECORD value;
+        if (!DSL_PU_Interface_Image_Get_Formal(i, &record) ||
+            record.id != i ||
+            !DSL_IR_Image_PU_ST_Valid(record.owner_pu_st) ||
+            record.formal_value_id == DSL_IR_VALUE_INVALID_ID ||
+            !DSL_IR_Image_Get_Value(record.formal_value_id, &value) ||
+            record.formal_ordinal == DSL_PU_FORMAL_INVALID_ORDINAL ||
+            ST_IDX_level(record.formal_st) <= GLOBAL_SYMTAB ||
+            ST_IDX_index(record.formal_st) == 0 ||
+            TY_IDX_index(record.formal_ty) == 0 ||
+            record.flags != 0 || record.reserved != 0 ||
+            value.value_kind != DSL_IR_VALUE_SYMBOL ||
+            value.producer_node_id != DSL_IR_NODE_INVALID_ID ||
+            value.st != record.formal_st || value.ty != record.formal_ty)
+            return DSL_PU_Interface_PU_Report
+                       (diagnostic, "invalid image formal", i);
+        for (UINT32 j = 1; j < i; ++j) {
+            DSL_PU_FORMAL_RECORD previous;
+            if (!DSL_PU_Interface_Image_Get_Formal(j, &previous))
+                return DSL_PU_Interface_PU_Report
+                           (diagnostic, "missing image formal", j);
+            if (previous.owner_pu_st == record.owner_pu_st &&
+                (previous.formal_ordinal == record.formal_ordinal ||
+                 previous.formal_value_id == record.formal_value_id ||
+                 previous.formal_st == record.formal_st))
+                return DSL_PU_Interface_PU_Report
+                           (diagnostic, "duplicate image formal", i);
+        }
+    }
+    return TRUE;
+}
+
+BOOL
+DSL_PU_Interface_Image_Validate_PU (PU_Info *pu, FILE *diagnostic)
+{
+    if (!DSL_PU_Interface_Image_Has_Records())
+        return TRUE;
+    if (pu == NULL || PU_Info_tree_ptr(pu) == NULL ||
+        ST_IDX_index(PU_Info_proc_sym(pu)) == 0 ||
+        !DSL_IR_Image_Current_PU_Is(PU_Info_proc_sym(pu)))
+        return DSL_PU_Interface_PU_Report
+                   (diagnostic, "missing program unit", 0);
+
+    ST_IDX owner_pu_st = PU_Info_proc_sym(pu);
+    WN *entry = PU_Info_tree_ptr(pu);
+    UINT32 expected_ordinal = 0;
+    if (WN_operator(entry) != OPR_FUNC_ENTRY)
+        return DSL_PU_Interface_PU_Report
+                   (diagnostic, "invalid function entry", 0);
+
+    for (UINT32 i = 1; i <= DSL_PU_Interface_Image_Formal_Count(); ++i) {
+        DSL_PU_FORMAL_RECORD formal;
+        if (!DSL_PU_Interface_Image_Get_Formal(i, &formal))
+            return DSL_PU_Interface_PU_Report
+                       (diagnostic, "missing formal", i);
+        if (formal.owner_pu_st != owner_pu_st)
+            continue;
+        if (formal.formal_ordinal != expected_ordinal ||
+            formal.formal_ordinal >= WN_num_formals(entry))
+            return DSL_PU_Interface_PU_Report
+                       (diagnostic, "formal ordinal mismatch", formal.id);
+        WN *idname = WN_formal(entry, formal.formal_ordinal);
+        DSL_IR_VALUE_RECORD value;
+        if (idname == NULL || WN_operator(idname) != OPR_IDNAME ||
+            WN_st_idx(idname) != formal.formal_st ||
+            ST_IDX_level(formal.formal_st) != CURRENT_SYMTAB ||
+            ST_IDX_index(formal.formal_st) >= ST_Table_Size(CURRENT_SYMTAB) ||
+            (ST_sclass(St_Table[formal.formal_st]) != SCLASS_FORMAL &&
+             ST_sclass(St_Table[formal.formal_st]) != SCLASS_FORMAL_REF) ||
+            ST_type(St_Table[formal.formal_st]) != formal.formal_ty ||
+            !DSL_IR_Image_Get_Value(formal.formal_value_id, &value) ||
+            !DSL_Call_ABI_Value_Matches_ST
+                 (value, owner_pu_st, formal.formal_st))
+            return DSL_PU_Interface_PU_Report
+                       (diagnostic, "formal value mismatch", formal.id);
+        ++expected_ordinal;
+    }
+    if (expected_ordinal != WN_num_formals(entry))
+        return DSL_PU_Interface_PU_Report
+                   (diagnostic, "incomplete formal interface", 0);
     return TRUE;
 }
 

--- a/osprey/common/com/ir_bread.cxx
+++ b/osprey/common/com/ir_bread.cxx
@@ -502,6 +502,21 @@ WN_get_dsl_call_abi_image (void *handle)
 }
 
 INT
+WN_get_dsl_pu_interface_image (void *handle)
+{
+    OFFSET_AND_SIZE shdr = get_section
+                               (handle, SHT_MIPS_WHIRL,
+                                WT_DSL_PU_INTERFACE_IMAGE);
+    if (shdr.offset == 0) {
+        DSL_PU_Interface_Image_Reset();
+        return 0;
+    }
+    const void *section_base = (const char *)handle + shdr.offset;
+    return DSL_PU_Interface_Image_Load_Mapped
+               (section_base, shdr.size, stderr) ? 0 : -1;
+}
+
+INT
 WN_get_dsl_fhe_image (void *handle)
 {
     OFFSET_AND_SIZE shdr = get_section
@@ -1685,6 +1700,9 @@ Read_Global_Info (INT32 *p_num_PUs)
     if (WN_get_dsl_callsite_image(global_fhandle) == -1) {
         ErrMsg (EC_IR_Scn_Read, "DSL callsite image", global_ir_file);
     }
+    if (WN_get_dsl_pu_interface_image(global_fhandle) == -1) {
+        ErrMsg (EC_IR_Scn_Read, "DSL PU interface image", global_ir_file);
+    }
     if (WN_get_dsl_call_abi_image(global_fhandle) == -1) {
         ErrMsg (EC_IR_Scn_Read, "DSL call ABI image", global_ir_file);
     }
@@ -1785,6 +1803,8 @@ Read_Local_Info (MEM_POOL *pool, PU_Info *pu)
                   tree_base, tree_size))
             ErrMsg (EC_IR_Scn_Read, "DSL callsites", local_ir_file);
     }
+    if (!DSL_PU_Interface_Image_Validate_PU(pu, stderr))
+        ErrMsg (EC_IR_Scn_Read, "DSL PU interface", local_ir_file);
     if (!DSL_Call_ABI_Image_Validate_PU(pu, stderr))
         ErrMsg (EC_IR_Scn_Read, "DSL call ABI", local_ir_file);
 

--- a/osprey/common/com/ir_bread.h
+++ b/osprey/common/com/ir_bread.h
@@ -131,6 +131,7 @@ extern INT WN_get_dsl_ir_image (void *handle);
 extern INT WN_get_dsl_effect_image (void *handle);
 extern INT WN_get_dsl_callsite_image (void *handle);
 extern INT WN_get_dsl_call_abi_image (void *handle);
+extern INT WN_get_dsl_pu_interface_image (void *handle);
 extern INT WN_get_dsl_fhe_image (void *handle);
 extern INT WN_get_dsl_fhe_plan_image (void *handle);
 

--- a/osprey/common/com/ir_bwrite.cxx
+++ b/osprey/common/com/ir_bwrite.cxx
@@ -942,6 +942,31 @@ WN_write_dsl_call_abi_image (Output_File *fl)
 }
 
 void
+WN_write_dsl_pu_interface_image (Output_File *fl)
+{
+    if (!DSL_PU_Interface_Image_Has_Records())
+        return;
+    FmtAssert(DSL_PU_Interface_Image_Validate(stderr),
+              ("invalid DSL PU interface table"));
+    Section *cur_section = get_section
+                               (WT_DSL_PU_INTERFACE_IMAGE,
+                                MIPS_WHIRL_DSL_PU_INTERFACE_IMAGE, fl);
+    fl->file_size = ir_b_align(fl->file_size, sizeof(mINT64), 0);
+    cur_section->shdr.sh_offset = fl->file_size;
+    DSL_PU_INTERFACE_IMAGE_HEADER header;
+    DSL_PU_Interface_Image_Get_Header(&header);
+    ir_b_save_buf(&header, sizeof(header), sizeof(mINT64), 0, fl);
+    for (UINT32 i = 1; i <= header.formal_count; ++i) {
+        DSL_PU_FORMAL_RECORD record;
+        FmtAssert(DSL_PU_Interface_Image_Get_Formal(i, &record),
+                  ("missing DSL PU formal %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    cur_section->shdr.sh_size = fl->file_size - cur_section->shdr.sh_offset;
+    cur_section->shdr.sh_addralign = sizeof(mINT64);
+}
+
+void
 WN_write_dsl_fhe_image (Output_File *fl)
 {
     if (!DSL_FHE_Image_Has_Records())
@@ -1869,6 +1894,7 @@ Write_Global_Info (PU_Info *pu_tree)
     WN_write_dsl_ir_image(ir_output);
     WN_write_dsl_effect_image(ir_output);
     WN_write_dsl_callsite_image(ir_output);
+    WN_write_dsl_pu_interface_image(ir_output);
     WN_write_dsl_call_abi_image(ir_output);
     WN_write_dsl_fhe_image(ir_output);
     WN_write_dsl_fhe_plan_image(ir_output);

--- a/osprey/common/com/ir_bwrite.h
+++ b/osprey/common/com/ir_bwrite.h
@@ -115,6 +115,7 @@ extern void WN_write_dsl_ir_image (Output_File *fl);
 extern void WN_write_dsl_effect_image (Output_File *fl);
 extern void WN_write_dsl_callsite_image (Output_File *fl);
 extern void WN_write_dsl_call_abi_image (Output_File *fl);
+extern void WN_write_dsl_pu_interface_image (Output_File *fl);
 extern void WN_write_dsl_fhe_image (Output_File *fl);
 extern void WN_write_dsl_fhe_plan_image (Output_File *fl);
 extern void WN_write_localmap (void *localmap, Output_File *fl);

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -5200,6 +5200,7 @@ Check_External_Tensor_Materialization(void)
     DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_REQUEST rejected[2];
     DSL_IR_EXTERNAL_TENSOR_MATERIALIZATION_RESULT materialized[6];
     DSL_IR_EXTERNAL_TENSOR_REFERENCE observed;
+    DSL_PU_FORMAL_RECORD formal_record;
     TCON_IDX folded_tcons[6];
     TY_IDX weight_ty;
     TY_IDX bias_ty;
@@ -5372,6 +5373,30 @@ Check_External_Tensor_Materialization(void)
              (calls[1], 0, 0, "cnn.basic_block.conv2.weight") &&
          DSL_Call_ABI_Image_Argument_Count() == 4,
          "structured call ABI argument roles");
+    EXTERNAL_REWRITE_CHECK
+        (DSL_PU_Interface_Image_Formal_Count() == 3 &&
+         DSL_PU_Interface_Image_Find_Formal
+             (PU_Info_proc_sym(callee), 0, &formal_record) &&
+         formal_record.formal_value_id ==
+             DSL_Builder_Get_Value_Image_Id(formals[0]) &&
+         formal_record.formal_st ==
+             DSL_Builder_Get_Value_Result_Symbol(formals[0]) &&
+         formal_record.formal_ty == weight_ty &&
+         DSL_PU_Interface_Image_Find_Formal
+             (PU_Info_proc_sym(callee), 1, &formal_record) &&
+         formal_record.formal_value_id ==
+             DSL_Builder_Get_Value_Image_Id(formals[1]) &&
+         formal_record.formal_st ==
+             DSL_Builder_Get_Value_Result_Symbol(formals[1]) &&
+         formal_record.formal_ty == bias_ty &&
+         DSL_PU_Interface_Image_Find_Formal
+             (PU_Info_proc_sym(callee), 2, &formal_record) &&
+         formal_record.formal_value_id ==
+             DSL_Builder_Get_Value_Image_Id(result) &&
+         formal_record.formal_st ==
+             DSL_Builder_Get_Value_Result_Symbol(result) &&
+         formal_record.formal_ty == weight_ty,
+         "global callee formal value query");
     if (failed)
         return failed;
 
@@ -5562,10 +5587,12 @@ Check_External_Tensor_Materialization(void)
          "source payload remains immutable");
 
     EXTERNAL_REWRITE_CHECK
-        (!DSL_Call_ABI_Image_Validate_PU(callee, NULL),
-         "call ABI rejects a non-active callee local symbol table");
+        (!DSL_Call_ABI_Image_Validate_PU(callee, NULL) &&
+         !DSL_PU_Interface_Image_Validate_PU(callee, NULL),
+         "ABI tables reject a non-active callee local symbol table");
     EXTERNAL_REWRITE_CHECK
         (DSL_Builder_Select_PU(callee) &&
+         DSL_PU_Interface_Image_Validate_PU(callee, stderr) &&
          DSL_Call_ABI_Image_Validate_PU(callee, stderr) &&
          WN_num_formals(PU_Info_tree_ptr(callee)) == 3 &&
          strcmp(ST_name(St_Table
@@ -5610,6 +5637,95 @@ Check_External_Tensor_Materialization(void)
          DSL_Call_ABI_Image_Argument_Count() == 4,
          "valid call ABI image reloads after malformed inputs");
     delete [] abi_bytes;
+
+    DSL_PU_INTERFACE_IMAGE_HEADER interface_header;
+    DSL_PU_Interface_Image_Get_Header(&interface_header);
+    UINT64 interface_size = DSL_PU_INTERFACE_IMAGE_HEADER_SIZE +
+        (UINT64)interface_header.formal_count * DSL_PU_FORMAL_RECORD_SIZE;
+    unsigned char *interface_bytes = new unsigned char[interface_size];
+    memcpy(interface_bytes, &interface_header, sizeof(interface_header));
+    DSL_PU_FORMAL_RECORD *interface_rows =
+        (DSL_PU_FORMAL_RECORD *)
+            (interface_bytes + DSL_PU_INTERFACE_IMAGE_HEADER_SIZE);
+    for (UINT32 i = 1; i <= interface_header.formal_count; ++i)
+        DSL_PU_Interface_Image_Get_Formal(i, &interface_rows[i - 1]);
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_PU_Interface_Image_Load_Mapped
+              (interface_bytes, interface_size - 1, NULL) &&
+         !DSL_PU_Interface_Image_Load_Mapped
+              (interface_bytes, interface_size + 1, NULL),
+         "truncated and trailing PU interface images reject");
+    interface_rows[1].formal_ordinal = interface_rows[0].formal_ordinal;
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_PU_Interface_Image_Load_Mapped
+              (interface_bytes, interface_size, NULL),
+         "duplicate PU formal ordinal rejects");
+    interface_rows[1].formal_ordinal = 1;
+    interface_rows[1].formal_value_id =
+        interface_rows[0].formal_value_id;
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_PU_Interface_Image_Load_Mapped
+              (interface_bytes, interface_size, NULL),
+         "duplicate PU formal value rejects");
+    interface_rows[1].formal_value_id =
+        DSL_Builder_Get_Value_Image_Id(formals[1]);
+    interface_rows[1].formal_ty = weight_ty;
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_PU_Interface_Image_Load_Mapped
+              (interface_bytes, interface_size, NULL),
+         "PU formal value and type mismatch rejects");
+    interface_rows[1].formal_ty = bias_ty;
+    ST_IDX valid_owner = interface_rows[0].owner_pu_st;
+    interface_rows[0].owner_pu_st =
+        make_ST_IDX(ST_Table_Size(GLOBAL_SYMTAB) + 1, GLOBAL_SYMTAB);
+    EXTERNAL_REWRITE_CHECK
+        (!DSL_PU_Interface_Image_Load_Mapped
+              (interface_bytes, interface_size, NULL),
+         "orphan PU formal owner rejects");
+    interface_rows[0].owner_pu_st = valid_owner;
+    EXTERNAL_REWRITE_CHECK
+        (DSL_PU_Interface_Image_Load_Mapped
+             (interface_bytes, interface_size, stderr) &&
+         DSL_PU_Interface_Image_Find_Formal
+             (PU_Info_proc_sym(callee), 1, &formal_record) &&
+         formal_record.formal_value_id ==
+             DSL_Builder_Get_Value_Image_Id(formals[1]) &&
+         formal_record.formal_ty == bias_ty,
+         "global formal query survives mapped reload");
+    DSL_PU_INTERFACE_IMAGE_HEADER shortened_header = interface_header;
+    shortened_header.formal_count = interface_header.formal_count - 1;
+    memcpy(interface_bytes, &shortened_header, sizeof(shortened_header));
+    EXTERNAL_REWRITE_CHECK
+        (DSL_PU_Interface_Image_Load_Mapped
+             (interface_bytes,
+              DSL_PU_INTERFACE_IMAGE_HEADER_SIZE +
+                  (UINT64)shortened_header.formal_count *
+                      DSL_PU_FORMAL_RECORD_SIZE,
+              stderr) &&
+         DSL_Builder_Select_PU(callee) &&
+         !DSL_PU_Interface_Image_Validate_PU(callee, NULL),
+         "per-PU validation rejects a shortened formal interface");
+    memcpy(interface_bytes, &interface_header, sizeof(interface_header));
+    EXTERNAL_REWRITE_CHECK
+        (DSL_PU_Interface_Image_Load_Mapped
+             (interface_bytes, interface_size, stderr) &&
+         DSL_Builder_Select_PU(caller),
+         "restore complete PU interface image");
+    ST_IDX callee_owner = interface_rows[0].owner_pu_st;
+    interface_rows[0].owner_pu_st = PU_Info_proc_sym(caller);
+    EXTERNAL_REWRITE_CHECK
+        (DSL_PU_Interface_Image_Load_Mapped
+             (interface_bytes, interface_size, stderr) &&
+         DSL_Builder_Select_PU(callee) &&
+         !DSL_PU_Interface_Image_Validate_PU(callee, NULL),
+         "per-PU validation rejects a mismatched formal owner");
+    interface_rows[0].owner_pu_st = callee_owner;
+    EXTERNAL_REWRITE_CHECK
+        (DSL_PU_Interface_Image_Load_Mapped
+             (interface_bytes, interface_size, stderr) &&
+         DSL_Builder_Select_PU(caller),
+         "restore valid PU interface image and caller");
+    delete [] interface_bytes;
 
     memset(&verify, 0, sizeof(verify));
     memset(diagnostic, 0, sizeof(diagnostic));

--- a/osprey/common/com/tests/dsl_external_tensor_rewrite_test.sh
+++ b/osprey/common/com/tests/dsl_external_tensor_rewrite_test.sh
@@ -54,6 +54,10 @@ for evidence in \
   'side_file=converted.safetensors' \
   'dsl.converted_from_value_id' \
   'DSL Call ABI Argument Table: version=1 entries=4' \
+  'DSL PU Interface Formal Table: version=1 entries=3' \
+  'formal=0 value=' \
+  'formal=1 value=' \
+  'formal=2 value=' \
   'role=cnn.basic_block.conv1.weight' \
   'role=cnn.basic_block.conv1.bias' \
   'dsl_builder_contract_test.cxx'; do

--- a/osprey/include/sys/elf_whirl.h
+++ b/osprey/include/sys/elf_whirl.h
@@ -86,6 +86,7 @@
 #define WT_DSL_FHE_IMAGE 0x23
 #define WT_DSL_FHE_PLAN 0x24
 #define WT_DSL_CALL_ABI_IMAGE 0x25
+#define WT_DSL_PU_INTERFACE_IMAGE 0x26
 
 /*
  * Special WHIRL section names.
@@ -105,6 +106,7 @@
 #define MIPS_WHIRL_DSL_FHE_IMAGE ".WHIRL.dsl_fhe"
 #define MIPS_WHIRL_DSL_FHE_PLAN ".WHIRL.dsl_fhe_plan"
 #define MIPS_WHIRL_DSL_CALL_ABI_IMAGE ".WHIRL.dsl_call_abi"
+#define MIPS_WHIRL_DSL_PU_INTERFACE_IMAGE ".WHIRL.dsl_pu_interface"
 #if defined(TARG_SL)
 #define MIPS_WHIRL_CALLGRAPH    ".WHIRL.callgraph"
 #endif


### PR DESCRIPTION
## Summary

- add the optional `.WHIRL.dsl_pu_interface` mapped-image section
- map each physical PU formal to its owner PU, formal ordinal, DSL value, local symbol, and exact tensor `TY_IDX`
- expose an immutable global query by `(callee_pu_st, formal_ordinal)` without activating the callee or parsing names
- cover input formals and appended hidden result formals while preserving existing call-ABI input ordinals
- validate rows globally and against the active `FUNC_ENTRY` and local symbol table per PU
- print stable PU-interface evidence through `ir_b2a -st -src`

## Value

This closes the remaining native cross-PU lookup blocker for FHE SYNC-3 BatchNorm folding. A call-ABI semantic role can now resolve the callee-owned formal `DSL_IR_VALUE_ID`, after which existing node/value-reference records identify the Conv/BatchNorm operands and the actual BatchNorm `epsilon`. No FHE-specific query or name parsing is required.

## Compatibility

- adds optional section `WT_DSL_PU_INTERFACE_IMAGE` (`0x26`) with a 24-byte v1 header and 32-byte fixed rows
- changes no existing image row, call-ABI v1 record, opcode, type encoding, or WHIRL binary revision
- older artifacts without the section load with an empty table and retain the previous call-ABI path
- the PR #120 reader reopens new artifacts and safely ignores the optional section

## Validation

- full native syntax and target operator-layout matrix passed
- two-PU shared-callee producer and mapped-image roundtrip passed
- global query works while the caller PU is active despite colliding local symbol indices
- shortened interfaces, orphan owners, duplicates, wrong value/type, malformed size, and wrong-active-PU cases reject
- new reader reopened a PR #120 call-ABI artifact without the new section
- PR #120 reader reopened the new artifact
- `git diff --check` and no-tab scan passed

The FHE consumer reviewed the corrected contract and accepted it with no remaining blocker.