### PR TITLE
Publish composite FHE approximation profiles

### DIFF
--- a/doc/FHE-SYNC-C-COMPOSITE-APPROXIMATION-CONTRACT.md
+++ b/doc/FHE-SYNC-C-COMPOSITE-APPROXIMATION-CONTRACT.md
@@ -1,0 +1,131 @@
+# FHE SYNC-C Composite Approximation Image Contract
+
+Status: main/common implementation in progress; FHE consumer contract reviewed.
+
+## Purpose
+
+The selected ResNet ReLU policy is an ordered composition of polynomial
+stages. The existing version-1 `DSL_FHE_APPROXIMATION_CONTRACT_RECORD`
+describes exactly one polynomial and remains unchanged. It must not be
+expanded, overloaded, or populated with a fake summary polynomial.
+
+SYNC-C adds the optional `.WHIRL.dsl_fhe_approx_profile` mapped-image section.
+Its records preserve composite profile identity, ordered machine-verifiable
+stage policy, an explicit disposition-to-profile association, and exact
+source/context range bindings. The section contains fixed-width rows, no
+pointers, and no STL objects. Rows and the ELF section use 8-byte alignment.
+
+## Compatibility
+
+- `WT_DSL_FHE_APPROX_PROFILE` is `0x27` and does not alter existing sections.
+- Absence of the optional section preserves legacy behavior.
+- Disposition values `1` through `5` retain their published meanings.
+- `DSL_FHE_DISPOSITION_REQUIRE_COMPOSITE_APPROXIMATION` is append-only value
+  `6`. Its existing `approximation_contract_id` field is a tagged reference to
+  a composite profile. For value `5`, that field continues to reference the
+  version-1 single-polynomial table.
+- A previous reader rejects disposition value `6` rather than interpreting the
+  profile as a version-1 polynomial.
+- The binary WHIRL revision, WN representation, opcode encoding, TY encoding,
+  and existing FHE image layouts do not change.
+
+## Fixed Rows
+
+| Row | Bytes | Required semantics |
+| --- | ---: | --- |
+| Header | 64 | Magic, version, header size, four capabilities, flags, four counts, and zero reserved fields. |
+| Composite profile | 80 | Config, stable name/version, reconstruction, total depth, normalization, pre-refresh policy, source revision, manifest SHA-256, and one immutable contiguous stage range. |
+| Ordered stage | 80 | Profile and dense ordinal, family, basis, degree, evaluation scheme, symbolic input requirements, level consumption, symbolic output policy, minimum precision, coefficient TCON, and coefficient-byte SHA-256. |
+| Profile association | 32 | Exact disposition, source ReLU value, profile, and owning PU. |
+| Context range | 64 | Profile, exact source ReLU value, owner PU, PU identity, optional callsite, positive bound, observed extrema, provenance, and reject-on-out-of-range policy. |
+
+Stage state is symbolic policy. It does not reference
+`DSL_FHE_CKKS_VALUE_STATE_ID`, because that identity belongs to an actual value,
+context, and state version. SYNC-4 binds materialized stage values to concrete
+CKKS state rows.
+
+The stage evaluator is an algorithm contract (`clenshaw`,
+`paterson_stockmeyer`, or `addition_chain`), not the stage's role in the
+composition. Profile membership and order already carry that role. Input scale
+is either any compatible scale or the profile-normalized scale; output scale
+either preserves the input scale or uses the configured default rescale.
+Version 1 has no scale-bit field and therefore does not admit an unresolved
+`explicit` scale policy.
+
+## Construction
+
+`DSL_FHE_Approx_Profile_Intern_Complete(profile, stages, count)` prevalidates
+the complete profile and all ordered stages before changing any table. Stage
+ordinals are assigned densely from zero and their rows remain contiguous.
+Contexts are not part of this range because they are discovered across PUs.
+Profile identity and lookup use `(config_id, profile_name, profile_version)`;
+the same mathematical profile may therefore have independently verified
+realizations under different FHE compilation configurations without renaming
+the algorithm or changing its version.
+
+`DSL_FHE_Plan_Add_Composite_Disposition(disposition, profile_id)` atomically
+adds the value-6 disposition and its explicit association. The ordinary
+single-record disposition API rejects value `6`, preventing a transient
+unassociated composite disposition.
+
+`DSL_FHE_Approx_Profile_Bind_Context_Range(record)` appends an independently
+keyed context. Its key is:
+
+```text
+(profile_id,
+ source_relu_value_id,
+ context_pu_identity_id,
+ context_callsite_id)
+```
+
+For a root context, `context_callsite_id` is zero and the PU identity owner
+must equal `owner_pu_st`. For a called context, the callsite must name
+`owner_pu_st` as callee and its caller must equal the PU identity owner. The
+current SecureResNet contract expects one root and eighteen called contexts.
+
+## Validation
+
+Validation proves:
+
+1. Every profile and stage identity is dense and every profile owns exactly
+   its declared ordered stage range.
+2. Checksums are lowercase 64-character hexadecimal strings and referenced
+   coefficient TCONs are rank-1 floating tensors with exactly `degree + 1`
+   elements.
+3. Stage state fields use known enums and valid signed-level conventions.
+   The sum of stage level consumption equals the profile's declared total
+   multiplicative depth. The final stage's consumption includes any
+   normalization or reconstruction multiplication assigned to the profile,
+   so the declared depth has one unambiguous accounting scope.
+4. Every association resolves to one value-6 disposition and the same live
+   `common.relu` result, profile, owner PU, and FHE compilation config selected
+   by the result CKKS state.
+5. Every context resolves to exactly one association and a live
+   `common.relu` result.
+6. Context keys are unique; bounds are positive and contain the recorded
+   observed extrema; missing or out-of-range evidence rejects.
+7. Every value-6 disposition has exactly one association and at least one
+   context before binary WHIRL publication.
+8. Unknown flags, reserved fields, enums, record sizes, section sizes, and
+   capabilities reject before pass use.
+
+## Inspection
+
+`ir_b2a -st -src` prints logical evidence under:
+
+- `FHE Composite Approximation Profile Image`
+- `FHE Composite Profile Table`
+- `FHE Ordered Approximation Stage Table`
+- `FHE Composite Approximation Association Table`
+- `FHE ReLU Context Range Table`
+
+Disposition value `6` prints `composite_profile=<id>`. The private WN escape
+representation remains hidden.
+
+## Staging Boundary
+
+This infrastructure commit defines representation, mapped-image movement,
+validation, lookup, and inspection. It does not encode ACE coefficients,
+approve range evidence, insert bootstrap, evaluate polynomial stages, or lower
+to OpenFHE. Until the FHE task completes those certification gates, full
+SecureResNet conversion remains fail-closed at `CFHECNN-RELU-002`.

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1954,6 +1954,32 @@ full-sequence causal prompt evaluation with no KV cache.
    opcode, type encoding, or binary revision changes. The detailed contract is
    in `doc/FHE-SYNC3-EXTERNAL-TENSOR-REWRITE-CONTRACT.md`.
 
+43. [x] Publish the SYNC-C composite FHE approximation profile image.
+
+   Add optional `.WHIRL.dsl_fhe_approx_profile` fixed rows for one composite
+   profile, its immutable ordered polynomial stages, an explicit tagged
+   disposition association, and independently keyed source/context range
+   evidence. Preserve the version-1 single-polynomial approximation table
+   unchanged. Append disposition value `6` for composite approximation;
+   previous readers fail closed on that unknown value instead of confusing a
+   profile identity with a version-1 approximation identity.
+
+   Represent stage input and output state as machine-verifiable symbolic
+   policy, not free-form strings or concrete CKKS value-state IDs. Intern a
+   complete profile and all contiguous stages atomically, require each
+   coefficient tensor to contain `degree + 1` elements, and require the sum of
+   stage level consumption to equal the declared profile depth. Bind contexts
+   separately with the established owner-PU, PU-identity, and callsite
+   semantics; the current SecureResNet profile expects one root and eighteen
+   called ReLU contexts.
+
+   Reader, writer, validation, and `ir_b2a -st -src` support land together.
+   This stage defines representation and inspection only: it does not invent
+   coefficients, approve range evidence, create stage values, insert
+   bootstrap, or lower the composite to OpenFHE. The exact compatibility and
+   API contract is in
+   `doc/FHE-SYNC-C-COMPOSITE-APPROXIMATION-CONTRACT.md`.
+
 ### Deferred work TODO
 
 Deferred work remains tracked but does not block the active native DSL bring-up

--- a/osprey/common/com/dsl_fhe_plan.cxx
+++ b/osprey/common/com/dsl_fhe_plan.cxx
@@ -22,11 +22,25 @@ typedef SEGMENTED_ARRAY<DSL_FHE_CKKS_VALUE_STATE_RECORD>
     DSL_FHE_CKKS_STATE_TABLE;
 typedef SEGMENTED_ARRAY<DSL_FHE_BN_FOLD_PROVENANCE_RECORD>
     DSL_FHE_BN_FOLD_TABLE;
+typedef SEGMENTED_ARRAY<DSL_FHE_COMPOSITE_PROFILE_RECORD>
+    DSL_FHE_COMPOSITE_PROFILE_TABLE;
+typedef SEGMENTED_ARRAY<DSL_FHE_APPROX_STAGE_RECORD>
+    DSL_FHE_APPROX_STAGE_TABLE;
+typedef SEGMENTED_ARRAY<DSL_FHE_APPROX_ASSOCIATION_RECORD>
+    DSL_FHE_APPROX_ASSOCIATION_TABLE;
+typedef SEGMENTED_ARRAY<DSL_FHE_CONTEXT_RANGE_RECORD>
+    DSL_FHE_CONTEXT_RANGE_TABLE;
 
 static DSL_FHE_DISPOSITION_TABLE DSL_fhe_disposition_table;
 static DSL_FHE_APPROXIMATION_TABLE DSL_fhe_approximation_table;
 static DSL_FHE_CKKS_STATE_TABLE DSL_fhe_ckks_state_table;
 static DSL_FHE_BN_FOLD_TABLE DSL_fhe_bn_fold_table;
+static DSL_FHE_COMPOSITE_PROFILE_TABLE DSL_fhe_composite_profile_table;
+static DSL_FHE_APPROX_STAGE_TABLE DSL_fhe_approx_stage_table;
+static DSL_FHE_APPROX_ASSOCIATION_TABLE DSL_fhe_approx_association_table;
+static DSL_FHE_CONTEXT_RANGE_TABLE DSL_fhe_context_range_table;
+
+static BOOL DSL_FHE_Approx_Profile_Cross_Validate (FILE *diagnostic);
 
 typedef struct {
     const DSL_FHE_PLAN_IMAGE_HEADER *header;
@@ -35,6 +49,14 @@ typedef struct {
     const DSL_FHE_CKKS_VALUE_STATE_RECORD *ckks_states;
     const DSL_FHE_BN_FOLD_PROVENANCE_RECORD *bn_folds;
 } DSL_FHE_PLAN_IMAGE_VIEW;
+
+typedef struct {
+    const DSL_FHE_APPROX_PROFILE_IMAGE_HEADER *header;
+    const DSL_FHE_COMPOSITE_PROFILE_RECORD *profiles;
+    const DSL_FHE_APPROX_STAGE_RECORD *stages;
+    const DSL_FHE_APPROX_ASSOCIATION_RECORD *associations;
+    const DSL_FHE_CONTEXT_RANGE_RECORD *context_ranges;
+} DSL_FHE_APPROX_PROFILE_IMAGE_VIEW;
 
 typedef char DSL_FHE_Plan_TY_IDX_Width_Check
     [sizeof(TY_IDX) == 4 ? 1 : -1];
@@ -59,6 +81,21 @@ typedef char DSL_FHE_Plan_CKKS_State_Size_Check
 typedef char DSL_FHE_Plan_BN_Fold_Size_Check
     [sizeof(DSL_FHE_BN_FOLD_PROVENANCE_RECORD) ==
         DSL_FHE_PLAN_BN_FOLD_RECORD_SIZE ? 1 : -1];
+typedef char DSL_FHE_Approx_Profile_Header_Size_Check
+    [sizeof(DSL_FHE_APPROX_PROFILE_IMAGE_HEADER) ==
+        DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE ? 1 : -1];
+typedef char DSL_FHE_Composite_Profile_Size_Check
+    [sizeof(DSL_FHE_COMPOSITE_PROFILE_RECORD) ==
+        DSL_FHE_COMPOSITE_PROFILE_RECORD_SIZE ? 1 : -1];
+typedef char DSL_FHE_Approx_Stage_Size_Check
+    [sizeof(DSL_FHE_APPROX_STAGE_RECORD) ==
+        DSL_FHE_APPROX_STAGE_RECORD_SIZE ? 1 : -1];
+typedef char DSL_FHE_Approx_Association_Size_Check
+    [sizeof(DSL_FHE_APPROX_ASSOCIATION_RECORD) ==
+        DSL_FHE_APPROX_ASSOCIATION_RECORD_SIZE ? 1 : -1];
+typedef char DSL_FHE_Context_Range_Size_Check
+    [sizeof(DSL_FHE_CONTEXT_RANGE_RECORD) ==
+        DSL_FHE_CONTEXT_RANGE_RECORD_SIZE ? 1 : -1];
 
 template <typename RECORD>
 static void
@@ -415,7 +452,8 @@ DSL_FHE_Plan_Disposition_Valid
         value.producer_node_id != record.source_node_id ||
         !DSL_FHE_Plan_Value_Belongs_To_PU(value, record.owner_pu_st) ||
         record.disposition < DSL_FHE_DISPOSITION_PRESERVE ||
-        record.disposition > DSL_FHE_DISPOSITION_REQUIRE_APPROXIMATION ||
+        record.disposition >
+            DSL_FHE_DISPOSITION_REQUIRE_COMPOSITE_APPROXIMATION ||
         (record.flags & ~known_flags) != 0 || record.reserved != 0 ||
         !DSL_FHE_Plan_Range_Valid
             (record.first_bn_fold_id, record.bn_fold_count,
@@ -434,6 +472,10 @@ DSL_FHE_Plan_Disposition_Valid
         if (record.approximation_contract_id == 0 ||
             record.approximation_contract_id >
                 DSL_FHE_Plan_View_Approximation_Count(view))
+            return FALSE;
+    } else if (record.disposition ==
+                   DSL_FHE_DISPOSITION_REQUIRE_COMPOSITE_APPROXIMATION) {
+        if (record.approximation_contract_id == 0)
             return FALSE;
     } else if (record.approximation_contract_id != 0) {
         return FALSE;
@@ -521,6 +563,7 @@ DSL_FHE_Plan_Image_Reset (void)
     DSL_fhe_approximation_table.Delete_down_to(0);
     DSL_fhe_ckks_state_table.Delete_down_to(0);
     DSL_fhe_bn_fold_table.Delete_down_to(0);
+    DSL_FHE_Approx_Profile_Image_Reset();
 }
 
 void
@@ -658,7 +701,8 @@ DSL_FHE_Plan_View_Validate
 BOOL
 DSL_FHE_Plan_Image_Validate (FILE *diagnostic)
 {
-    return DSL_FHE_Plan_View_Validate(NULL, diagnostic);
+    return DSL_FHE_Plan_View_Validate(NULL, diagnostic) &&
+           DSL_FHE_Approx_Profile_Cross_Validate(diagnostic);
 }
 
 static BOOL
@@ -810,7 +854,9 @@ DSL_FHE_CONVERSION_DISPOSITION_ID
 DSL_FHE_Plan_Add_Conversion_Disposition
         (const DSL_FHE_CONVERSION_DISPOSITION_RECORD *record)
 {
-    if (record == NULL || !DSL_FHE_Plan_Disposition_Valid(*record, NULL))
+    if (record == NULL || record->disposition ==
+            DSL_FHE_DISPOSITION_REQUIRE_COMPOSITE_APPROXIMATION ||
+        !DSL_FHE_Plan_Disposition_Valid(*record, NULL))
         return DSL_FHE_CONVERSION_DISPOSITION_INVALID_ID;
     for (UINT32 i = 0; i < DSL_fhe_disposition_table.Size(); ++i) {
         if (DSL_fhe_disposition_table[i].source_node_id ==
@@ -903,6 +949,762 @@ DSL_FHE_Plan_Find_BN_Fold_Provenance
             fold.context_callsite_id == context_callsite_id)
             return DSL_FHE_Plan_Table_Get
                        (DSL_fhe_bn_fold_table, i + 1, record);
+    }
+    return FALSE;
+}
+
+static BOOL
+DSL_FHE_Approx_Profile_Report
+        (FILE *diagnostic, const char *message, UINT32 id)
+{
+    if (diagnostic != NULL)
+        fprintf(diagnostic, "FHE approximation profile image error: "
+                "%s id=%u\n", message, id);
+    return FALSE;
+}
+
+static BOOL
+DSL_FHE_Approx_Profile_SHA256_Valid (STR_IDX id)
+{
+    if (!DSL_FHE_Plan_String_Id_Valid(id, TRUE))
+        return FALSE;
+    const char *value = Index_To_Str(id);
+    if (strlen(value) != 64)
+        return FALSE;
+    for (UINT32 i = 0; i < 64; ++i) {
+        if (!((value[i] >= '0' && value[i] <= '9') ||
+              (value[i] >= 'a' && value[i] <= 'f')))
+            return FALSE;
+    }
+    return TRUE;
+}
+
+static BOOL
+DSL_FHE_Composite_Profile_Basic_Valid
+        (const DSL_FHE_COMPOSITE_PROFILE_RECORD &record,
+         UINT32 stage_limit)
+{
+    DSL_FHE_COMPILATION_CONFIG_RECORD config;
+    return DSL_FHE_Get_Compilation_Config(record.config_id, &config) &&
+           DSL_FHE_Plan_String_Id_Valid(record.profile_name, TRUE) &&
+           record.profile_version != 0 &&
+           record.reconstruction ==
+               DSL_FHE_RECONSTRUCTION_RELU_FROM_NORMALIZED_SIGN &&
+           record.total_multiplicative_depth != 0 &&
+           record.normalization_policy ==
+               DSL_FHE_NORMALIZATION_POSITIVE_CONTEXT_BOUND &&
+           record.pre_refresh_policy >= DSL_FHE_PRE_REFRESH_INHERIT &&
+           record.pre_refresh_policy <=
+               DSL_FHE_PRE_REFRESH_PROVEN_EXISTING &&
+           DSL_FHE_Plan_String_Id_Valid(record.source_revision, TRUE) &&
+           DSL_FHE_Approx_Profile_SHA256_Valid(record.manifest_sha256) &&
+           record.stage_count != 0 &&
+           DSL_FHE_Plan_Range_Valid
+               (record.first_stage_id, record.stage_count, stage_limit) &&
+           record.flags == 0 && record.reserved0 == 0 &&
+           record.reserved1 == 0 && record.reserved2 == 0 &&
+           record.reserved3 == 0;
+}
+
+static BOOL
+DSL_FHE_Approx_Stage_Basic_Valid
+        (const DSL_FHE_APPROX_STAGE_RECORD &record, UINT32 profile_limit)
+{
+    DSL_TENSOR_TCON_RECORD coefficients;
+    if (record.profile_id == 0 || record.profile_id > profile_limit ||
+        record.approximation_family < DSL_FHE_APPROXIMATION_MINIMAX ||
+        record.approximation_family > DSL_FHE_APPROXIMATION_TAYLOR ||
+        record.basis < DSL_FHE_APPROX_BASIS_CHEBYSHEV ||
+        record.basis > DSL_FHE_APPROX_BASIS_MONOMIAL ||
+        record.degree == 0 ||
+        record.evaluation_scheme < DSL_FHE_APPROX_EVAL_CLENSHAW ||
+        record.evaluation_scheme >
+            DSL_FHE_APPROX_EVAL_ADDITION_CHAIN ||
+        record.required_input_value_class <
+            DSL_FHE_VALUE_CLASS_CIPHERTEXT ||
+        record.required_input_value_class > DSL_FHE_VALUE_CLASS_CLEAR ||
+        record.input_scale_policy <
+            DSL_FHE_APPROX_INPUT_SCALE_ANY_COMPATIBLE ||
+        record.input_scale_policy >
+            DSL_FHE_APPROX_INPUT_SCALE_PROFILE_NORMALIZED ||
+        record.input_level_policy < DSL_FHE_APPROX_LEVEL_ANY_SUFFICIENT ||
+        record.input_level_policy > DSL_FHE_APPROX_LEVEL_EXACT ||
+        record.level_consumption < 0 ||
+        record.output_scale_policy <
+            DSL_FHE_APPROX_OUTPUT_SCALE_PRESERVE_INPUT ||
+        record.output_scale_policy >
+            DSL_FHE_APPROX_OUTPUT_SCALE_DEFAULT_RESCALE ||
+        record.output_component_policy <
+            DSL_FHE_APPROX_COMPONENT_PRESERVE ||
+        record.output_component_policy > DSL_FHE_APPROX_COMPONENT_MAY_GROW ||
+        record.minimum_precision_bits <= 0 ||
+        !DSL_Tensor_TCON_Get(record.coefficient_tensor_tcon, &coefficients) ||
+        TY_tensor_rank(coefficients.descriptor_ty) != 1 ||
+        (coefficients.element_mtype != MTYPE_F4 &&
+         coefficients.element_mtype != MTYPE_F8) ||
+        coefficients.element_count != (UINT64)record.degree + 1 ||
+        !DSL_FHE_Approx_Profile_SHA256_Valid(record.coefficient_sha256) ||
+        record.flags != 0 || record.reserved != 0)
+        return FALSE;
+    if (record.input_level_policy == DSL_FHE_APPROX_LEVEL_ANY_SUFFICIENT)
+        return record.required_input_level == -1;
+    return record.required_input_level >= 0;
+}
+
+static BOOL
+DSL_FHE_Approx_Profile_Value_Is_Live_Relu
+        (DSL_IR_VALUE_ID value_id, ST_IDX owner_pu_st)
+{
+    DSL_IR_VALUE_RECORD value;
+    DSL_OPERATOR dsl_operator;
+    if (!DSL_IR_Image_Get_Value(value_id, &value) ||
+        (value.flags & DSL_IR_VALUE_FLAG_REDIRECTED) != 0 ||
+        value.producer_node_id == DSL_IR_NODE_INVALID_ID ||
+        !DSL_FHE_Plan_Value_Belongs_To_PU(value, owner_pu_st) ||
+        !DSL_FHE_Plan_Node_Operator
+            (value.producer_node_id, &dsl_operator, NULL))
+        return FALSE;
+    return dsl_operator == OPR_DSLRELU;
+}
+
+static BOOL
+DSL_FHE_Context_Range_Basic_Valid
+        (const DSL_FHE_CONTEXT_RANGE_RECORD &record, UINT32 profile_limit)
+{
+    DSL_PU_SOURCE_IDENTITY_RECORD identity;
+    DSL_CALLSITE_METADATA_RECORD callsite;
+    double bound;
+    double observed_min;
+    double observed_max;
+    if (record.profile_id == 0 || record.profile_id > profile_limit ||
+        !DSL_FHE_Approx_Profile_Value_Is_Live_Relu
+            (record.source_relu_value_id, record.owner_pu_st) ||
+        !DSL_Call_Image_Get_PU_Identity
+            (record.context_pu_identity_id, &identity) ||
+        !DSL_FHE_Plan_Scalar_TCON_Value
+            (record.positive_bound_tcon, &bound) || bound <= 0.0 ||
+        !DSL_FHE_Plan_Scalar_TCON_Value
+            (record.observed_min_tcon, &observed_min) ||
+        !DSL_FHE_Plan_Scalar_TCON_Value
+            (record.observed_max_tcon, &observed_max) ||
+        observed_min > observed_max || observed_min < -bound ||
+        observed_max > bound ||
+        record.out_of_range_policy != DSL_FHE_CONTEXT_RANGE_REJECT ||
+        !DSL_FHE_Plan_String_Id_Valid(record.provenance, TRUE) ||
+        record.flags != 0 || record.reserved0 != 0 ||
+        record.reserved1 != 0 || record.reserved2 != 0)
+        return FALSE;
+
+    if (record.context_callsite_id == DSL_CALLSITE_METADATA_INVALID_ID)
+        return identity.owner_pu_st == record.owner_pu_st;
+    return DSL_Call_Image_Get_Callsite(record.context_callsite_id, &callsite) &&
+           callsite.callee_pu_st == record.owner_pu_st &&
+           callsite.owner_pu_st == identity.owner_pu_st;
+}
+
+static UINT32
+DSL_FHE_Approx_Profile_View_Profile_Count
+        (const DSL_FHE_APPROX_PROFILE_IMAGE_VIEW *view)
+{
+    return view == NULL ? DSL_fhe_composite_profile_table.Size() :
+                          view->header->profile_count;
+}
+
+static UINT32
+DSL_FHE_Approx_Profile_View_Stage_Count
+        (const DSL_FHE_APPROX_PROFILE_IMAGE_VIEW *view)
+{
+    return view == NULL ? DSL_fhe_approx_stage_table.Size() :
+                          view->header->stage_count;
+}
+
+static UINT32
+DSL_FHE_Approx_Profile_View_Association_Count
+        (const DSL_FHE_APPROX_PROFILE_IMAGE_VIEW *view)
+{
+    return view == NULL ? DSL_fhe_approx_association_table.Size() :
+                          view->header->association_count;
+}
+
+static UINT32
+DSL_FHE_Approx_Profile_View_Context_Count
+        (const DSL_FHE_APPROX_PROFILE_IMAGE_VIEW *view)
+{
+    return view == NULL ? DSL_fhe_context_range_table.Size() :
+                          view->header->context_range_count;
+}
+
+static const DSL_FHE_COMPOSITE_PROFILE_RECORD &
+DSL_FHE_Approx_Profile_View_Profile
+        (const DSL_FHE_APPROX_PROFILE_IMAGE_VIEW *view, UINT32 ordinal)
+{
+    return view == NULL ? DSL_fhe_composite_profile_table[ordinal] :
+                          view->profiles[ordinal];
+}
+
+static const DSL_FHE_APPROX_STAGE_RECORD &
+DSL_FHE_Approx_Profile_View_Stage
+        (const DSL_FHE_APPROX_PROFILE_IMAGE_VIEW *view, UINT32 ordinal)
+{
+    return view == NULL ? DSL_fhe_approx_stage_table[ordinal] :
+                          view->stages[ordinal];
+}
+
+static const DSL_FHE_APPROX_ASSOCIATION_RECORD &
+DSL_FHE_Approx_Profile_View_Association
+        (const DSL_FHE_APPROX_PROFILE_IMAGE_VIEW *view, UINT32 ordinal)
+{
+    return view == NULL ? DSL_fhe_approx_association_table[ordinal] :
+                          view->associations[ordinal];
+}
+
+static const DSL_FHE_CONTEXT_RANGE_RECORD &
+DSL_FHE_Approx_Profile_View_Context
+        (const DSL_FHE_APPROX_PROFILE_IMAGE_VIEW *view, UINT32 ordinal)
+{
+    return view == NULL ? DSL_fhe_context_range_table[ordinal] :
+                          view->context_ranges[ordinal];
+}
+
+static BOOL
+DSL_FHE_Approx_Profile_View_Validate
+        (const DSL_FHE_APPROX_PROFILE_IMAGE_VIEW *view, FILE *diagnostic)
+{
+    DSL_FHE_APPROX_PROFILE_IMAGE_HEADER header;
+    if (view == NULL)
+        DSL_FHE_Approx_Profile_Image_Get_Header(&header);
+    else
+        header = *view->header;
+    const UINT32 capabilities = DSL_FHE_APPROX_PROFILE_CAP_PROFILE |
+                                DSL_FHE_APPROX_PROFILE_CAP_STAGE |
+                                DSL_FHE_APPROX_PROFILE_CAP_ASSOCIATION |
+                                DSL_FHE_APPROX_PROFILE_CAP_CONTEXT_RANGE;
+    if (header.magic != DSL_FHE_APPROX_PROFILE_IMAGE_MAGIC ||
+        header.version != DSL_FHE_APPROX_PROFILE_IMAGE_VERSION ||
+        header.header_size != DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE ||
+        header.record_kind_count != 4 ||
+        header.capabilities != capabilities || header.flags != 0 ||
+        header.reserved0 != 0 || header.reserved1 != 0 ||
+        header.reserved2 != 0 || header.reserved3 != 0 ||
+        header.reserved4 != 0 || header.reserved5 != 0)
+        return DSL_FHE_Approx_Profile_Report
+                   (diagnostic, "invalid header", 0);
+
+    for (UINT32 i = 0;
+         i < DSL_FHE_Approx_Profile_View_Profile_Count(view); ++i) {
+        const DSL_FHE_COMPOSITE_PROFILE_RECORD &profile =
+            DSL_FHE_Approx_Profile_View_Profile(view, i);
+        UINT64 total_level_consumption = 0;
+        if (profile.id != i + 1 ||
+            !DSL_FHE_Composite_Profile_Basic_Valid
+                (profile, DSL_FHE_Approx_Profile_View_Stage_Count(view)))
+            return DSL_FHE_Approx_Profile_Report
+                       (diagnostic, "invalid composite profile", i + 1);
+        for (UINT32 j = 0; j < i; ++j) {
+            const DSL_FHE_COMPOSITE_PROFILE_RECORD &prior =
+                DSL_FHE_Approx_Profile_View_Profile(view, j);
+            if (prior.config_id == profile.config_id &&
+                prior.profile_name == profile.profile_name &&
+                prior.profile_version == profile.profile_version)
+                return DSL_FHE_Approx_Profile_Report
+                           (diagnostic, "duplicate composite profile", i + 1);
+        }
+        for (UINT32 j = 0; j < profile.stage_count; ++j) {
+            const DSL_FHE_APPROX_STAGE_RECORD &stage =
+                DSL_FHE_Approx_Profile_View_Stage
+                    (view, profile.first_stage_id - 1 + j);
+            if (stage.profile_id != profile.id ||
+                stage.stage_ordinal != j)
+                return DSL_FHE_Approx_Profile_Report
+                           (diagnostic, "noncontiguous profile stages", i + 1);
+            total_level_consumption += (UINT32)stage.level_consumption;
+        }
+        if (total_level_consumption !=
+                profile.total_multiplicative_depth)
+            return DSL_FHE_Approx_Profile_Report
+                       (diagnostic, "profile depth does not match stages",
+                        i + 1);
+    }
+    for (UINT32 i = 0;
+         i < DSL_FHE_Approx_Profile_View_Stage_Count(view); ++i) {
+        const DSL_FHE_APPROX_STAGE_RECORD &stage =
+            DSL_FHE_Approx_Profile_View_Stage(view, i);
+        if (stage.id != i + 1 ||
+            !DSL_FHE_Approx_Stage_Basic_Valid
+                (stage, DSL_FHE_Approx_Profile_View_Profile_Count(view)))
+            return DSL_FHE_Approx_Profile_Report
+                       (diagnostic, "invalid approximation stage", i + 1);
+        UINT32 owners = 0;
+        for (UINT32 j = 0;
+             j < DSL_FHE_Approx_Profile_View_Profile_Count(view); ++j) {
+            const DSL_FHE_COMPOSITE_PROFILE_RECORD &profile =
+                DSL_FHE_Approx_Profile_View_Profile(view, j);
+            if (stage.id >= profile.first_stage_id &&
+                stage.id < profile.first_stage_id + profile.stage_count)
+                ++owners;
+        }
+        if (owners != 1)
+            return DSL_FHE_Approx_Profile_Report
+                       (diagnostic, "orphaned approximation stage", i + 1);
+    }
+    for (UINT32 i = 0;
+         i < DSL_FHE_Approx_Profile_View_Association_Count(view); ++i) {
+        const DSL_FHE_APPROX_ASSOCIATION_RECORD &association =
+            DSL_FHE_Approx_Profile_View_Association(view, i);
+        DSL_FHE_CONVERSION_DISPOSITION_RECORD disposition;
+        DSL_FHE_CKKS_VALUE_STATE_RECORD state;
+        DSL_FHE_ENCRYPTION_DESCRIPTOR_RECORD encryption;
+        if (association.id != i + 1 || association.profile_id == 0 ||
+            association.profile_id >
+                DSL_FHE_Approx_Profile_View_Profile_Count(view))
+            return DSL_FHE_Approx_Profile_Report
+                       (diagnostic, "invalid profile association", i + 1);
+        const DSL_FHE_COMPOSITE_PROFILE_RECORD &profile =
+            DSL_FHE_Approx_Profile_View_Profile
+                (view, association.profile_id - 1);
+        if (!DSL_FHE_Plan_Get_Conversion_Disposition
+                (association.disposition_id, &disposition) ||
+            disposition.disposition !=
+                DSL_FHE_DISPOSITION_REQUIRE_COMPOSITE_APPROXIMATION ||
+            disposition.approximation_contract_id != association.profile_id ||
+            disposition.result_value_id != association.source_relu_value_id ||
+            disposition.owner_pu_st != association.owner_pu_st ||
+            !DSL_FHE_Plan_Get_CKKS_Value_State
+                (disposition.result_ckks_value_state_id, &state) ||
+            !DSL_FHE_Get_Encryption_Descriptor
+                (state.encryption_descriptor_id, &encryption) ||
+            profile.config_id != encryption.config_id ||
+            !DSL_FHE_Approx_Profile_Value_Is_Live_Relu
+                (association.source_relu_value_id, association.owner_pu_st) ||
+            association.flags != 0 || association.reserved0 != 0 ||
+            association.reserved1 != 0)
+            return DSL_FHE_Approx_Profile_Report
+                       (diagnostic, "invalid profile association", i + 1);
+        for (UINT32 j = 0; j < i; ++j) {
+            const DSL_FHE_APPROX_ASSOCIATION_RECORD &prior =
+                DSL_FHE_Approx_Profile_View_Association(view, j);
+            if (prior.disposition_id == association.disposition_id ||
+                prior.source_relu_value_id ==
+                    association.source_relu_value_id)
+                return DSL_FHE_Approx_Profile_Report
+                           (diagnostic, "duplicate profile association", i + 1);
+        }
+    }
+    for (UINT32 i = 0;
+         i < DSL_FHE_Approx_Profile_View_Context_Count(view); ++i) {
+        const DSL_FHE_CONTEXT_RANGE_RECORD &context =
+            DSL_FHE_Approx_Profile_View_Context(view, i);
+        if (context.id != i + 1 ||
+            !DSL_FHE_Context_Range_Basic_Valid
+                (context, DSL_FHE_Approx_Profile_View_Profile_Count(view)))
+            return DSL_FHE_Approx_Profile_Report
+                       (diagnostic, "invalid context range", i + 1);
+        UINT32 associations = 0;
+        for (UINT32 j = 0;
+             j < DSL_FHE_Approx_Profile_View_Association_Count(view); ++j) {
+            const DSL_FHE_APPROX_ASSOCIATION_RECORD &association =
+                DSL_FHE_Approx_Profile_View_Association(view, j);
+            if (association.profile_id == context.profile_id &&
+                association.source_relu_value_id ==
+                    context.source_relu_value_id)
+                ++associations;
+        }
+        if (associations != 1)
+            return DSL_FHE_Approx_Profile_Report
+                       (diagnostic, "unassociated context range", i + 1);
+        for (UINT32 j = 0; j < i; ++j) {
+            const DSL_FHE_CONTEXT_RANGE_RECORD &prior =
+                DSL_FHE_Approx_Profile_View_Context(view, j);
+            if (prior.profile_id == context.profile_id &&
+                prior.source_relu_value_id == context.source_relu_value_id &&
+                prior.context_pu_identity_id ==
+                    context.context_pu_identity_id &&
+                prior.context_callsite_id == context.context_callsite_id)
+                return DSL_FHE_Approx_Profile_Report
+                           (diagnostic, "duplicate context range", i + 1);
+        }
+    }
+    for (UINT32 i = 0; i < DSL_fhe_disposition_table.Size(); ++i) {
+        const DSL_FHE_CONVERSION_DISPOSITION_RECORD &disposition =
+            DSL_fhe_disposition_table[i];
+        if (disposition.disposition !=
+            DSL_FHE_DISPOSITION_REQUIRE_COMPOSITE_APPROXIMATION)
+            continue;
+        UINT32 associations = 0;
+        UINT32 contexts = 0;
+        for (UINT32 j = 0;
+             j < DSL_FHE_Approx_Profile_View_Association_Count(view); ++j) {
+            const DSL_FHE_APPROX_ASSOCIATION_RECORD &association =
+                DSL_FHE_Approx_Profile_View_Association(view, j);
+            if (association.disposition_id == disposition.id)
+                ++associations;
+        }
+        for (UINT32 j = 0;
+             j < DSL_FHE_Approx_Profile_View_Context_Count(view); ++j) {
+            const DSL_FHE_CONTEXT_RANGE_RECORD &context =
+                DSL_FHE_Approx_Profile_View_Context(view, j);
+            if (context.profile_id ==
+                    disposition.approximation_contract_id &&
+                context.source_relu_value_id == disposition.result_value_id)
+                ++contexts;
+        }
+        if (associations != 1 || contexts == 0)
+            return DSL_FHE_Approx_Profile_Report
+                       (diagnostic, "incomplete composite disposition",
+                        disposition.id);
+    }
+    return TRUE;
+}
+
+static BOOL
+DSL_FHE_Approx_Profile_Cross_Validate (FILE *diagnostic)
+{
+    return DSL_FHE_Approx_Profile_View_Validate(NULL, diagnostic);
+}
+
+void
+DSL_FHE_Approx_Profile_Image_Reset (void)
+{
+    DSL_fhe_composite_profile_table.Delete_down_to(0);
+    DSL_fhe_approx_stage_table.Delete_down_to(0);
+    DSL_fhe_approx_association_table.Delete_down_to(0);
+    DSL_fhe_context_range_table.Delete_down_to(0);
+}
+
+void
+DSL_FHE_Approx_Profile_Image_Get_Header
+        (DSL_FHE_APPROX_PROFILE_IMAGE_HEADER *header)
+{
+    if (header == NULL)
+        return;
+    memset(header, 0, sizeof(*header));
+    header->magic = DSL_FHE_APPROX_PROFILE_IMAGE_MAGIC;
+    header->version = DSL_FHE_APPROX_PROFILE_IMAGE_VERSION;
+    header->header_size = DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE;
+    header->record_kind_count = 4;
+    header->capabilities = DSL_FHE_APPROX_PROFILE_CAP_PROFILE |
+                           DSL_FHE_APPROX_PROFILE_CAP_STAGE |
+                           DSL_FHE_APPROX_PROFILE_CAP_ASSOCIATION |
+                           DSL_FHE_APPROX_PROFILE_CAP_CONTEXT_RANGE;
+    header->profile_count = DSL_fhe_composite_profile_table.Size();
+    header->stage_count = DSL_fhe_approx_stage_table.Size();
+    header->association_count = DSL_fhe_approx_association_table.Size();
+    header->context_range_count = DSL_fhe_context_range_table.Size();
+}
+
+BOOL
+DSL_FHE_Approx_Profile_Image_Has_Records (void)
+{
+    return DSL_fhe_composite_profile_table.Size() != 0 ||
+           DSL_fhe_approx_stage_table.Size() != 0 ||
+           DSL_fhe_approx_association_table.Size() != 0 ||
+           DSL_fhe_context_range_table.Size() != 0;
+}
+
+BOOL
+DSL_FHE_Approx_Profile_Image_Validate (FILE *diagnostic)
+{
+    return DSL_FHE_Approx_Profile_Cross_Validate(diagnostic);
+}
+
+BOOL
+DSL_FHE_Approx_Profile_Image_Load_Mapped
+        (const void *section_base, UINT64 section_size, FILE *diagnostic)
+{
+    if (section_base == NULL ||
+        section_size < DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE)
+        return DSL_FHE_Approx_Profile_Report
+                   (diagnostic, "section is truncated", 0);
+    const char *cursor = (const char *)section_base;
+    const DSL_FHE_APPROX_PROFILE_IMAGE_HEADER *header =
+        (const DSL_FHE_APPROX_PROFILE_IMAGE_HEADER *)cursor;
+    UINT64 expected_size = DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE;
+    if (!DSL_FHE_Plan_Add_Section_Size
+             (&expected_size, header->profile_count,
+              DSL_FHE_COMPOSITE_PROFILE_RECORD_SIZE) ||
+        !DSL_FHE_Plan_Add_Section_Size
+             (&expected_size, header->stage_count,
+              DSL_FHE_APPROX_STAGE_RECORD_SIZE) ||
+        !DSL_FHE_Plan_Add_Section_Size
+             (&expected_size, header->association_count,
+              DSL_FHE_APPROX_ASSOCIATION_RECORD_SIZE) ||
+        !DSL_FHE_Plan_Add_Section_Size
+             (&expected_size, header->context_range_count,
+              DSL_FHE_CONTEXT_RANGE_RECORD_SIZE) ||
+        expected_size != section_size)
+        return DSL_FHE_Approx_Profile_Report
+                   (diagnostic, "section size mismatch", 0);
+
+    DSL_FHE_APPROX_PROFILE_IMAGE_VIEW view;
+    view.header = header;
+    cursor += DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE;
+    view.profiles = (const DSL_FHE_COMPOSITE_PROFILE_RECORD *)cursor;
+    cursor += (UINT64)header->profile_count *
+              DSL_FHE_COMPOSITE_PROFILE_RECORD_SIZE;
+    view.stages = (const DSL_FHE_APPROX_STAGE_RECORD *)cursor;
+    cursor += (UINT64)header->stage_count *
+              DSL_FHE_APPROX_STAGE_RECORD_SIZE;
+    view.associations = (const DSL_FHE_APPROX_ASSOCIATION_RECORD *)cursor;
+    cursor += (UINT64)header->association_count *
+              DSL_FHE_APPROX_ASSOCIATION_RECORD_SIZE;
+    view.context_ranges = (const DSL_FHE_CONTEXT_RANGE_RECORD *)cursor;
+    if (!DSL_FHE_Approx_Profile_View_Validate(&view, diagnostic))
+        return FALSE;
+
+    DSL_FHE_Approx_Profile_Image_Reset();
+    if (header->profile_count != 0)
+        DSL_fhe_composite_profile_table.Insert
+            (view.profiles, header->profile_count);
+    if (header->stage_count != 0)
+        DSL_fhe_approx_stage_table.Insert(view.stages, header->stage_count);
+    if (header->association_count != 0)
+        DSL_fhe_approx_association_table.Insert
+            (view.associations, header->association_count);
+    if (header->context_range_count != 0)
+        DSL_fhe_context_range_table.Insert
+            (view.context_ranges, header->context_range_count);
+    return DSL_FHE_Approx_Profile_Cross_Validate(diagnostic);
+}
+
+void DSL_FHE_Composite_Profile_Record_Init
+        (DSL_FHE_COMPOSITE_PROFILE_RECORD *record)
+{ DSL_FHE_Plan_Record_Init(record); }
+void DSL_FHE_Approx_Stage_Record_Init
+        (DSL_FHE_APPROX_STAGE_RECORD *record)
+{
+    DSL_FHE_Plan_Record_Init(record);
+    if (record != NULL)
+        record->required_input_level = -1;
+}
+void DSL_FHE_Approx_Association_Record_Init
+        (DSL_FHE_APPROX_ASSOCIATION_RECORD *record)
+{ DSL_FHE_Plan_Record_Init(record); }
+void DSL_FHE_Context_Range_Record_Init
+        (DSL_FHE_CONTEXT_RANGE_RECORD *record)
+{ DSL_FHE_Plan_Record_Init(record); }
+
+DSL_FHE_COMPOSITE_PROFILE_ID
+DSL_FHE_Approx_Profile_Intern_Complete
+        (const DSL_FHE_COMPOSITE_PROFILE_RECORD *profile,
+         const DSL_FHE_APPROX_STAGE_RECORD *stages, UINT32 stage_count)
+{
+    if (profile == NULL || stages == NULL || stage_count == 0 ||
+        profile->stage_count != stage_count)
+        return DSL_FHE_COMPOSITE_PROFILE_INVALID_ID;
+    for (UINT32 i = 0; i < DSL_fhe_composite_profile_table.Size(); ++i) {
+        const DSL_FHE_COMPOSITE_PROFILE_RECORD &prior =
+            DSL_fhe_composite_profile_table[i];
+        if (prior.config_id != profile->config_id ||
+            prior.profile_name != profile->profile_name ||
+            prior.profile_version != profile->profile_version)
+            continue;
+        if (prior.stage_count != stage_count)
+            return DSL_FHE_COMPOSITE_PROFILE_INVALID_ID;
+        DSL_FHE_COMPOSITE_PROFILE_RECORD candidate = *profile;
+        candidate.id = prior.id;
+        candidate.first_stage_id = prior.first_stage_id;
+        if (memcmp(&candidate, &prior, sizeof(candidate)) != 0)
+            return DSL_FHE_COMPOSITE_PROFILE_INVALID_ID;
+        for (UINT32 j = 0; j < stage_count; ++j) {
+            DSL_FHE_APPROX_STAGE_RECORD candidate_stage = stages[j];
+            candidate_stage.id = prior.first_stage_id + j;
+            candidate_stage.profile_id = prior.id;
+            candidate_stage.stage_ordinal = j;
+            if (memcmp(&candidate_stage,
+                       &DSL_fhe_approx_stage_table
+                            [prior.first_stage_id - 1 + j],
+                       sizeof(candidate_stage)) != 0)
+                return DSL_FHE_COMPOSITE_PROFILE_INVALID_ID;
+        }
+        return prior.id;
+    }
+
+    const UINT32 profile_id = DSL_fhe_composite_profile_table.Size() + 1;
+    const UINT32 first_stage_id = DSL_fhe_approx_stage_table.Size() + 1;
+    DSL_FHE_COMPOSITE_PROFILE_RECORD profile_copy = *profile;
+    profile_copy.id = profile_id;
+    profile_copy.first_stage_id = first_stage_id;
+    profile_copy.stage_count = stage_count;
+    if (!DSL_FHE_Composite_Profile_Basic_Valid
+            (profile_copy, first_stage_id + stage_count - 1))
+        return DSL_FHE_COMPOSITE_PROFILE_INVALID_ID;
+    UINT64 total_level_consumption = 0;
+    for (UINT32 i = 0; i < stage_count; ++i) {
+        DSL_FHE_APPROX_STAGE_RECORD stage = stages[i];
+        stage.id = first_stage_id + i;
+        stage.profile_id = profile_id;
+        stage.stage_ordinal = i;
+        if (!DSL_FHE_Approx_Stage_Basic_Valid(stage, profile_id))
+            return DSL_FHE_COMPOSITE_PROFILE_INVALID_ID;
+        total_level_consumption += (UINT32)stage.level_consumption;
+    }
+    if (total_level_consumption !=
+            profile_copy.total_multiplicative_depth)
+        return DSL_FHE_COMPOSITE_PROFILE_INVALID_ID;
+    DSL_fhe_composite_profile_table.Insert(profile_copy);
+    for (UINT32 i = 0; i < stage_count; ++i) {
+        DSL_FHE_APPROX_STAGE_RECORD stage = stages[i];
+        stage.id = first_stage_id + i;
+        stage.profile_id = profile_id;
+        stage.stage_ordinal = i;
+        DSL_fhe_approx_stage_table.Insert(stage);
+    }
+    return profile_id;
+}
+
+DSL_FHE_CONVERSION_DISPOSITION_ID
+DSL_FHE_Plan_Add_Composite_Disposition
+        (const DSL_FHE_CONVERSION_DISPOSITION_RECORD *disposition,
+         DSL_FHE_COMPOSITE_PROFILE_ID profile_id)
+{
+    if (disposition == NULL || profile_id == 0 ||
+        profile_id > DSL_fhe_composite_profile_table.Size() ||
+        disposition->disposition !=
+            DSL_FHE_DISPOSITION_REQUIRE_COMPOSITE_APPROXIMATION ||
+        disposition->approximation_contract_id != profile_id ||
+        !DSL_FHE_Plan_Disposition_Valid(*disposition, NULL))
+        return DSL_FHE_CONVERSION_DISPOSITION_INVALID_ID;
+    for (UINT32 i = 0; i < DSL_fhe_disposition_table.Size(); ++i) {
+        if (DSL_fhe_disposition_table[i].source_node_id ==
+            disposition->source_node_id)
+            return DSL_FHE_CONVERSION_DISPOSITION_INVALID_ID;
+    }
+    DSL_FHE_CONVERSION_DISPOSITION_RECORD disposition_copy = *disposition;
+    disposition_copy.id = DSL_fhe_disposition_table.Size() + 1;
+    DSL_FHE_APPROX_ASSOCIATION_RECORD association;
+    DSL_FHE_Approx_Association_Record_Init(&association);
+    association.id = DSL_fhe_approx_association_table.Size() + 1;
+    association.disposition_id = disposition_copy.id;
+    association.source_relu_value_id = disposition_copy.result_value_id;
+    association.profile_id = profile_id;
+    association.owner_pu_st = disposition_copy.owner_pu_st;
+    DSL_fhe_disposition_table.Insert(disposition_copy);
+    DSL_fhe_approx_association_table.Insert(association);
+    return disposition_copy.id;
+}
+
+DSL_FHE_CONTEXT_RANGE_ID
+DSL_FHE_Approx_Profile_Bind_Context_Range
+        (const DSL_FHE_CONTEXT_RANGE_RECORD *record)
+{
+    if (record == NULL || !DSL_FHE_Context_Range_Basic_Valid
+            (*record, DSL_fhe_composite_profile_table.Size()))
+        return DSL_FHE_CONTEXT_RANGE_INVALID_ID;
+    BOOL associated = FALSE;
+    for (UINT32 i = 0; i < DSL_fhe_approx_association_table.Size(); ++i) {
+        const DSL_FHE_APPROX_ASSOCIATION_RECORD &association =
+            DSL_fhe_approx_association_table[i];
+        if (association.profile_id == record->profile_id &&
+            association.source_relu_value_id ==
+                record->source_relu_value_id)
+            associated = TRUE;
+    }
+    if (!associated)
+        return DSL_FHE_CONTEXT_RANGE_INVALID_ID;
+    for (UINT32 i = 0; i < DSL_fhe_context_range_table.Size(); ++i) {
+        const DSL_FHE_CONTEXT_RANGE_RECORD &prior =
+            DSL_fhe_context_range_table[i];
+        if (prior.profile_id == record->profile_id &&
+            prior.source_relu_value_id == record->source_relu_value_id &&
+            prior.context_pu_identity_id == record->context_pu_identity_id &&
+            prior.context_callsite_id == record->context_callsite_id)
+            return DSL_FHE_CONTEXT_RANGE_INVALID_ID;
+    }
+    DSL_FHE_CONTEXT_RANGE_RECORD copy = *record;
+    UINT32 index = DSL_fhe_context_range_table.Insert(copy);
+    DSL_fhe_context_range_table[index].id = index + 1;
+    return index + 1;
+}
+
+UINT32 DSL_FHE_Approx_Profile_Count (void)
+{ return DSL_fhe_composite_profile_table.Size(); }
+UINT32 DSL_FHE_Approx_Stage_Count (void)
+{ return DSL_fhe_approx_stage_table.Size(); }
+UINT32 DSL_FHE_Approx_Association_Count (void)
+{ return DSL_fhe_approx_association_table.Size(); }
+UINT32 DSL_FHE_Context_Range_Count (void)
+{ return DSL_fhe_context_range_table.Size(); }
+
+BOOL DSL_FHE_Approx_Profile_Get
+        (DSL_FHE_COMPOSITE_PROFILE_ID id,
+         DSL_FHE_COMPOSITE_PROFILE_RECORD *record)
+{ return DSL_FHE_Plan_Table_Get
+             (DSL_fhe_composite_profile_table, id, record); }
+BOOL DSL_FHE_Approx_Stage_Get
+        (DSL_FHE_APPROX_STAGE_ID id, DSL_FHE_APPROX_STAGE_RECORD *record)
+{ return DSL_FHE_Plan_Table_Get(DSL_fhe_approx_stage_table, id, record); }
+BOOL DSL_FHE_Approx_Association_Get
+        (DSL_FHE_APPROX_ASSOCIATION_ID id,
+         DSL_FHE_APPROX_ASSOCIATION_RECORD *record)
+{ return DSL_FHE_Plan_Table_Get
+             (DSL_fhe_approx_association_table, id, record); }
+BOOL DSL_FHE_Context_Range_Get
+        (DSL_FHE_CONTEXT_RANGE_ID id, DSL_FHE_CONTEXT_RANGE_RECORD *record)
+{ return DSL_FHE_Plan_Table_Get(DSL_fhe_context_range_table, id, record); }
+
+BOOL
+DSL_FHE_Approx_Profile_Find
+        (DSL_FHE_CONFIG_ID config_id, const char *profile_name,
+         UINT32 profile_version,
+         DSL_FHE_COMPOSITE_PROFILE_RECORD *record)
+{
+    if (profile_name == NULL)
+        return FALSE;
+    for (UINT32 i = 0; i < DSL_fhe_composite_profile_table.Size(); ++i) {
+        const DSL_FHE_COMPOSITE_PROFILE_RECORD &profile =
+            DSL_fhe_composite_profile_table[i];
+        if (profile.config_id == config_id &&
+            profile.profile_version == profile_version &&
+            strcmp(Index_To_Str(profile.profile_name), profile_name) == 0)
+            return DSL_FHE_Approx_Profile_Get(i + 1, record);
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_FHE_Approx_Stage_Find
+        (DSL_FHE_COMPOSITE_PROFILE_ID profile_id, UINT32 stage_ordinal,
+         DSL_FHE_APPROX_STAGE_RECORD *record)
+{
+    for (UINT32 i = 0; i < DSL_fhe_approx_stage_table.Size(); ++i) {
+        const DSL_FHE_APPROX_STAGE_RECORD &stage =
+            DSL_fhe_approx_stage_table[i];
+        if (stage.profile_id == profile_id &&
+            stage.stage_ordinal == stage_ordinal)
+            return DSL_FHE_Approx_Stage_Get(i + 1, record);
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_FHE_Approx_Association_Find
+        (DSL_FHE_CONVERSION_DISPOSITION_ID disposition_id,
+         DSL_FHE_APPROX_ASSOCIATION_RECORD *record)
+{
+    for (UINT32 i = 0; i < DSL_fhe_approx_association_table.Size(); ++i) {
+        if (DSL_fhe_approx_association_table[i].disposition_id ==
+            disposition_id)
+            return DSL_FHE_Approx_Association_Get(i + 1, record);
+    }
+    return FALSE;
+}
+
+BOOL
+DSL_FHE_Context_Range_Find
+        (DSL_FHE_COMPOSITE_PROFILE_ID profile_id,
+         DSL_IR_VALUE_ID source_relu_value_id,
+         DSL_PU_SOURCE_IDENTITY_ID context_pu_identity_id,
+         DSL_CALLSITE_METADATA_ID context_callsite_id,
+         DSL_FHE_CONTEXT_RANGE_RECORD *record)
+{
+    for (UINT32 i = 0; i < DSL_fhe_context_range_table.Size(); ++i) {
+        const DSL_FHE_CONTEXT_RANGE_RECORD &context =
+            DSL_fhe_context_range_table[i];
+        if (context.profile_id == profile_id &&
+            context.source_relu_value_id == source_relu_value_id &&
+            context.context_pu_identity_id == context_pu_identity_id &&
+            context.context_callsite_id == context_callsite_id)
+            return DSL_FHE_Context_Range_Get(i + 1, record);
     }
     return FALSE;
 }

--- a/osprey/common/com/dsl_fhe_plan.h
+++ b/osprey/common/com/dsl_fhe_plan.h
@@ -21,6 +21,14 @@
 #define DSL_FHE_PLAN_CKKS_STATE_RECORD_SIZE     64
 #define DSL_FHE_PLAN_BN_FOLD_RECORD_SIZE        64
 
+#define DSL_FHE_APPROX_PROFILE_IMAGE_MAGIC        0x46415031
+#define DSL_FHE_APPROX_PROFILE_IMAGE_VERSION      1
+#define DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE  64
+#define DSL_FHE_COMPOSITE_PROFILE_RECORD_SIZE     80
+#define DSL_FHE_APPROX_STAGE_RECORD_SIZE           80
+#define DSL_FHE_APPROX_ASSOCIATION_RECORD_SIZE     32
+#define DSL_FHE_CONTEXT_RANGE_RECORD_SIZE          64
+
 #define DSL_FHE_WRAPPER_CNN_CONV2D \
     "fhe.cnn.conv2d"
 #define DSL_FHE_WRAPPER_CNN_RESIDUAL_ADD \
@@ -41,10 +49,18 @@
 typedef UINT32 DSL_FHE_CONVERSION_DISPOSITION_ID;
 typedef UINT32 DSL_FHE_APPROXIMATION_CONTRACT_ID;
 typedef UINT32 DSL_FHE_BN_FOLD_PROVENANCE_ID;
+typedef UINT32 DSL_FHE_COMPOSITE_PROFILE_ID;
+typedef UINT32 DSL_FHE_APPROX_STAGE_ID;
+typedef UINT32 DSL_FHE_APPROX_ASSOCIATION_ID;
+typedef UINT32 DSL_FHE_CONTEXT_RANGE_ID;
 
 #define DSL_FHE_CONVERSION_DISPOSITION_INVALID_ID 0
 #define DSL_FHE_APPROXIMATION_CONTRACT_INVALID_ID 0
 #define DSL_FHE_BN_FOLD_PROVENANCE_INVALID_ID     0
+#define DSL_FHE_COMPOSITE_PROFILE_INVALID_ID       0
+#define DSL_FHE_APPROX_STAGE_INVALID_ID             0
+#define DSL_FHE_APPROX_ASSOCIATION_INVALID_ID       0
+#define DSL_FHE_CONTEXT_RANGE_INVALID_ID            0
 
 typedef enum {
     DSL_FHE_PLAN_RECORD_UNKNOWN = 0,
@@ -67,8 +83,77 @@ typedef enum {
     DSL_FHE_DISPOSITION_DOMAIN_WRAPPER = 2,
     DSL_FHE_DISPOSITION_FOLD_INTO_PRODUCER = 3,
     DSL_FHE_DISPOSITION_LAYOUT_REINTERPRET = 4,
-    DSL_FHE_DISPOSITION_REQUIRE_APPROXIMATION = 5
+    DSL_FHE_DISPOSITION_REQUIRE_APPROXIMATION = 5,
+    DSL_FHE_DISPOSITION_REQUIRE_COMPOSITE_APPROXIMATION = 6
 } DSL_FHE_CONVERSION_DISPOSITION;
+
+typedef enum {
+    DSL_FHE_APPROX_PROFILE_CAP_PROFILE = 0x00000001,
+    DSL_FHE_APPROX_PROFILE_CAP_STAGE = 0x00000002,
+    DSL_FHE_APPROX_PROFILE_CAP_ASSOCIATION = 0x00000004,
+    DSL_FHE_APPROX_PROFILE_CAP_CONTEXT_RANGE = 0x00000008
+} DSL_FHE_APPROX_PROFILE_CAPABILITY;
+
+typedef enum {
+    DSL_FHE_RECONSTRUCTION_UNKNOWN = 0,
+    DSL_FHE_RECONSTRUCTION_RELU_FROM_NORMALIZED_SIGN = 1
+} DSL_FHE_APPROX_RECONSTRUCTION;
+
+typedef enum {
+    DSL_FHE_NORMALIZATION_UNKNOWN = 0,
+    DSL_FHE_NORMALIZATION_POSITIVE_CONTEXT_BOUND = 1
+} DSL_FHE_APPROX_NORMALIZATION_POLICY;
+
+typedef enum {
+    DSL_FHE_PRE_REFRESH_UNKNOWN = 0,
+    DSL_FHE_PRE_REFRESH_INHERIT = 1,
+    DSL_FHE_PRE_REFRESH_REQUIRED = 2,
+    DSL_FHE_PRE_REFRESH_PROVEN_EXISTING = 3
+} DSL_FHE_APPROX_PRE_REFRESH_POLICY;
+
+typedef enum {
+    DSL_FHE_APPROX_BASIS_UNKNOWN = 0,
+    DSL_FHE_APPROX_BASIS_CHEBYSHEV = 1,
+    DSL_FHE_APPROX_BASIS_MONOMIAL = 2
+} DSL_FHE_APPROX_BASIS;
+
+typedef enum {
+    DSL_FHE_APPROX_EVAL_UNKNOWN = 0,
+    DSL_FHE_APPROX_EVAL_CLENSHAW = 1,
+    DSL_FHE_APPROX_EVAL_PATERSON_STOCKMEYER = 2,
+    DSL_FHE_APPROX_EVAL_ADDITION_CHAIN = 3
+} DSL_FHE_APPROX_EVALUATION_SCHEME;
+
+typedef enum {
+    DSL_FHE_APPROX_INPUT_SCALE_UNKNOWN = 0,
+    DSL_FHE_APPROX_INPUT_SCALE_ANY_COMPATIBLE = 1,
+    DSL_FHE_APPROX_INPUT_SCALE_PROFILE_NORMALIZED = 2
+} DSL_FHE_APPROX_INPUT_SCALE_POLICY;
+
+typedef enum {
+    DSL_FHE_APPROX_OUTPUT_SCALE_UNKNOWN = 0,
+    DSL_FHE_APPROX_OUTPUT_SCALE_PRESERVE_INPUT = 1,
+    DSL_FHE_APPROX_OUTPUT_SCALE_DEFAULT_RESCALE = 2
+} DSL_FHE_APPROX_OUTPUT_SCALE_POLICY;
+
+typedef enum {
+    DSL_FHE_APPROX_LEVEL_UNKNOWN = 0,
+    DSL_FHE_APPROX_LEVEL_ANY_SUFFICIENT = 1,
+    DSL_FHE_APPROX_LEVEL_MINIMUM = 2,
+    DSL_FHE_APPROX_LEVEL_EXACT = 3
+} DSL_FHE_APPROX_LEVEL_POLICY;
+
+typedef enum {
+    DSL_FHE_APPROX_COMPONENT_UNKNOWN = 0,
+    DSL_FHE_APPROX_COMPONENT_PRESERVE = 1,
+    DSL_FHE_APPROX_COMPONENT_RELINEARIZED_TWO = 2,
+    DSL_FHE_APPROX_COMPONENT_MAY_GROW = 3
+} DSL_FHE_APPROX_COMPONENT_POLICY;
+
+typedef enum {
+    DSL_FHE_CONTEXT_RANGE_UNKNOWN = 0,
+    DSL_FHE_CONTEXT_RANGE_REJECT = 1
+} DSL_FHE_CONTEXT_OUT_OF_RANGE_POLICY;
 
 typedef enum {
     DSL_FHE_DISPOSITION_FLAG_NONE = 0,
@@ -202,6 +287,96 @@ typedef struct {
     UINT32 reserved;
 } DSL_FHE_BN_FOLD_PROVENANCE_RECORD;
 
+typedef struct {
+    UINT32 magic;
+    UINT32 version;
+    UINT32 header_size;
+    UINT32 record_kind_count;
+    UINT32 capabilities;
+    UINT32 flags;
+    UINT32 profile_count;
+    UINT32 stage_count;
+    UINT32 association_count;
+    UINT32 context_range_count;
+    UINT32 reserved0;
+    UINT32 reserved1;
+    UINT32 reserved2;
+    UINT32 reserved3;
+    UINT32 reserved4;
+    UINT32 reserved5;
+} DSL_FHE_APPROX_PROFILE_IMAGE_HEADER;
+
+typedef struct {
+    DSL_FHE_COMPOSITE_PROFILE_ID id;
+    DSL_FHE_CONFIG_ID config_id;
+    STR_IDX profile_name;
+    STR_IDX source_revision;
+    STR_IDX manifest_sha256;
+    UINT32 profile_version;
+    UINT32 reconstruction;
+    UINT32 total_multiplicative_depth;
+    UINT32 normalization_policy;
+    UINT32 pre_refresh_policy;
+    DSL_FHE_APPROX_STAGE_ID first_stage_id;
+    UINT32 stage_count;
+    UINT32 flags;
+    UINT32 reserved0;
+    UINT32 reserved1;
+    UINT32 reserved2;
+    UINT32 reserved3;
+} DSL_FHE_COMPOSITE_PROFILE_RECORD;
+
+typedef struct {
+    DSL_FHE_APPROX_STAGE_ID id;
+    DSL_FHE_COMPOSITE_PROFILE_ID profile_id;
+    UINT32 stage_ordinal;
+    UINT32 approximation_family;
+    UINT32 basis;
+    UINT32 degree;
+    UINT32 evaluation_scheme;
+    UINT32 required_input_value_class;
+    UINT32 input_scale_policy;
+    UINT32 input_level_policy;
+    INT32 required_input_level;
+    INT32 level_consumption;
+    UINT32 output_scale_policy;
+    UINT32 output_component_policy;
+    INT32 minimum_precision_bits;
+    TCON_IDX coefficient_tensor_tcon;
+    STR_IDX coefficient_sha256;
+    UINT32 flags;
+    UINT32 reserved;
+} DSL_FHE_APPROX_STAGE_RECORD;
+
+typedef struct {
+    DSL_FHE_APPROX_ASSOCIATION_ID id;
+    DSL_FHE_CONVERSION_DISPOSITION_ID disposition_id;
+    DSL_IR_VALUE_ID source_relu_value_id;
+    DSL_FHE_COMPOSITE_PROFILE_ID profile_id;
+    ST_IDX owner_pu_st;
+    UINT32 flags;
+    UINT32 reserved0;
+    UINT32 reserved1;
+} DSL_FHE_APPROX_ASSOCIATION_RECORD;
+
+typedef struct {
+    DSL_FHE_CONTEXT_RANGE_ID id;
+    DSL_FHE_COMPOSITE_PROFILE_ID profile_id;
+    DSL_IR_VALUE_ID source_relu_value_id;
+    DSL_PU_SOURCE_IDENTITY_ID context_pu_identity_id;
+    DSL_CALLSITE_METADATA_ID context_callsite_id;
+    ST_IDX owner_pu_st;
+    TCON_IDX positive_bound_tcon;
+    TCON_IDX observed_min_tcon;
+    TCON_IDX observed_max_tcon;
+    UINT32 out_of_range_policy;
+    STR_IDX provenance;
+    UINT32 flags;
+    UINT32 reserved0;
+    UINT32 reserved1;
+    UINT32 reserved2;
+} DSL_FHE_CONTEXT_RANGE_RECORD;
+
 /* Producer-runtime inputs. No pointer in these records enters the IR image. */
 typedef struct {
     UINT32 disposition;
@@ -328,5 +503,77 @@ extern BOOL DSL_FHE_Plan_Find_BN_Fold_Provenance
                                      context_pu_identity_id,
                                  DSL_CALLSITE_METADATA_ID context_callsite_id,
                                  DSL_FHE_BN_FOLD_PROVENANCE_RECORD *record);
+
+extern void DSL_FHE_Approx_Profile_Image_Reset (void);
+extern void DSL_FHE_Approx_Profile_Image_Get_Header
+                                (DSL_FHE_APPROX_PROFILE_IMAGE_HEADER *header);
+extern BOOL DSL_FHE_Approx_Profile_Image_Has_Records (void);
+extern BOOL DSL_FHE_Approx_Profile_Image_Validate (FILE *diagnostic);
+extern BOOL DSL_FHE_Approx_Profile_Image_Load_Mapped
+                                (const void *section_base,
+                                 UINT64 section_size,
+                                 FILE *diagnostic);
+extern void DSL_FHE_Approx_Profile_Image_Print (FILE *file);
+
+extern void DSL_FHE_Composite_Profile_Record_Init
+                                (DSL_FHE_COMPOSITE_PROFILE_RECORD *record);
+extern void DSL_FHE_Approx_Stage_Record_Init
+                                (DSL_FHE_APPROX_STAGE_RECORD *record);
+extern void DSL_FHE_Approx_Association_Record_Init
+                                (DSL_FHE_APPROX_ASSOCIATION_RECORD *record);
+extern void DSL_FHE_Context_Range_Record_Init
+                                (DSL_FHE_CONTEXT_RANGE_RECORD *record);
+
+extern DSL_FHE_COMPOSITE_PROFILE_ID
+    DSL_FHE_Approx_Profile_Intern_Complete
+                                (const DSL_FHE_COMPOSITE_PROFILE_RECORD
+                                     *profile,
+                                 const DSL_FHE_APPROX_STAGE_RECORD *stages,
+                                 UINT32 stage_count);
+extern DSL_FHE_CONVERSION_DISPOSITION_ID
+    DSL_FHE_Plan_Add_Composite_Disposition
+                                (const DSL_FHE_CONVERSION_DISPOSITION_RECORD
+                                     *disposition,
+                                 DSL_FHE_COMPOSITE_PROFILE_ID profile_id);
+extern DSL_FHE_CONTEXT_RANGE_ID
+    DSL_FHE_Approx_Profile_Bind_Context_Range
+                                (const DSL_FHE_CONTEXT_RANGE_RECORD *record);
+
+extern UINT32 DSL_FHE_Approx_Profile_Count (void);
+extern UINT32 DSL_FHE_Approx_Stage_Count (void);
+extern UINT32 DSL_FHE_Approx_Association_Count (void);
+extern UINT32 DSL_FHE_Context_Range_Count (void);
+extern BOOL DSL_FHE_Approx_Profile_Get
+                                (DSL_FHE_COMPOSITE_PROFILE_ID id,
+                                 DSL_FHE_COMPOSITE_PROFILE_RECORD *record);
+extern BOOL DSL_FHE_Approx_Stage_Get
+                                (DSL_FHE_APPROX_STAGE_ID id,
+                                 DSL_FHE_APPROX_STAGE_RECORD *record);
+extern BOOL DSL_FHE_Approx_Association_Get
+                                (DSL_FHE_APPROX_ASSOCIATION_ID id,
+                                 DSL_FHE_APPROX_ASSOCIATION_RECORD *record);
+extern BOOL DSL_FHE_Context_Range_Get
+                                (DSL_FHE_CONTEXT_RANGE_ID id,
+                                 DSL_FHE_CONTEXT_RANGE_RECORD *record);
+extern BOOL DSL_FHE_Approx_Profile_Find
+                                (DSL_FHE_CONFIG_ID config_id,
+                                 const char *profile_name,
+                                 UINT32 profile_version,
+                                 DSL_FHE_COMPOSITE_PROFILE_RECORD *record);
+extern BOOL DSL_FHE_Approx_Stage_Find
+                                (DSL_FHE_COMPOSITE_PROFILE_ID profile_id,
+                                 UINT32 stage_ordinal,
+                                 DSL_FHE_APPROX_STAGE_RECORD *record);
+extern BOOL DSL_FHE_Approx_Association_Find
+                                (DSL_FHE_CONVERSION_DISPOSITION_ID
+                                     disposition_id,
+                                 DSL_FHE_APPROX_ASSOCIATION_RECORD *record);
+extern BOOL DSL_FHE_Context_Range_Find
+                                (DSL_FHE_COMPOSITE_PROFILE_ID profile_id,
+                                 DSL_IR_VALUE_ID source_relu_value_id,
+                                 DSL_PU_SOURCE_IDENTITY_ID
+                                     context_pu_identity_id,
+                                 DSL_CALLSITE_METADATA_ID context_callsite_id,
+                                 DSL_FHE_CONTEXT_RANGE_RECORD *record);
 
 #endif /* dsl_fhe_plan_INCLUDED */

--- a/osprey/common/com/dsl_fhe_plan_print.cxx
+++ b/osprey/common/com/dsl_fhe_plan_print.cxx
@@ -18,7 +18,8 @@ DSL_FHE_Plan_Disposition_Name (UINT32 value)
 {
     static const char *names[] = {
         "unknown", "preserve", "domain_wrapper", "fold_into_producer",
-        "layout_reinterpret", "require_approximation"
+        "layout_reinterpret", "require_approximation",
+        "require_composite_approximation"
     };
     return DSL_FHE_Plan_Name
                (value, names, sizeof(names) / sizeof(names[0]));
@@ -112,9 +113,15 @@ DSL_FHE_Plan_Image_Print (FILE *file)
             fprintf(file, " wrapper=%s.v%u",
                     Index_To_Str(record.wrapper_name),
                     record.wrapper_version);
-        if (record.approximation_contract_id != 0)
-            fprintf(file, " approximation=%u",
-                    record.approximation_contract_id);
+        if (record.approximation_contract_id != 0) {
+            if (record.disposition ==
+                DSL_FHE_DISPOSITION_REQUIRE_COMPOSITE_APPROXIMATION)
+                fprintf(file, " composite_profile=%u",
+                        record.approximation_contract_id);
+            else
+                fprintf(file, " approximation=%u",
+                        record.approximation_contract_id);
+        }
         fprintf(file, " ckks_state=%u bn_folds=[%u,%u] flags=0x%x\n",
                 record.result_ckks_value_state_id,
                 record.first_bn_fold_id, record.bn_fold_count, record.flags);
@@ -194,5 +201,197 @@ DSL_FHE_Plan_Image_Print (FILE *file)
                     (record.source_bn_variance_value_id),
                 (UINT32)record.folded_weight_tcon,
                 (UINT32)record.folded_bias_tcon, record.flags);
+    }
+}
+
+static const char *
+DSL_FHE_Approx_Reconstruction_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "relu_from_normalized_sign"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Approx_Normalization_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "positive_context_bound"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Approx_Pre_Refresh_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "inherit", "required", "proven_existing"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Approx_Basis_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "chebyshev", "monomial"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Approx_Evaluation_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "clenshaw", "paterson_stockmeyer", "addition_chain"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Approx_Input_Scale_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "any_compatible", "profile_normalized"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Approx_Output_Scale_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "preserve_input", "default_rescale"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Approx_Input_Class_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "ciphertext", "plaintext", "clear"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Approx_Level_Policy_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "any_sufficient", "minimum", "exact"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+static const char *
+DSL_FHE_Approx_Component_Policy_Name (UINT32 value)
+{
+    static const char *names[] = {
+        "unknown", "preserve", "relinearized_two", "may_grow"
+    };
+    return DSL_FHE_Plan_Name
+               (value, names, sizeof(names) / sizeof(names[0]));
+}
+
+void
+DSL_FHE_Approx_Profile_Image_Print (FILE *file)
+{
+    if (file == NULL || !DSL_FHE_Approx_Profile_Image_Has_Records())
+        return;
+    DSL_FHE_APPROX_PROFILE_IMAGE_HEADER header;
+    DSL_FHE_Approx_Profile_Image_Get_Header(&header);
+    fprintf(file, "\nFHE Composite Approximation Profile Image: "
+            "version=%u capabilities=0x%08x\n",
+            header.version, header.capabilities);
+
+    fprintf(file, "FHE Composite Profile Table:\n");
+    for (UINT32 i = 1; i <= header.profile_count; ++i) {
+        DSL_FHE_COMPOSITE_PROFILE_RECORD record;
+        DSL_FHE_Approx_Profile_Get(i, &record);
+        fprintf(file, "  [%u] config=%u profile=%s.v%u "
+                "reconstruction=%s depth=%u normalization=%s "
+                "pre_refresh=%s source_revision=%s manifest_sha256=%s "
+                "stages=[%u,%u] flags=0x%x\n", record.id,
+                record.config_id, Index_To_Str(record.profile_name),
+                record.profile_version,
+                DSL_FHE_Approx_Reconstruction_Name(record.reconstruction),
+                record.total_multiplicative_depth,
+                DSL_FHE_Approx_Normalization_Name
+                    (record.normalization_policy),
+                DSL_FHE_Approx_Pre_Refresh_Name(record.pre_refresh_policy),
+                Index_To_Str(record.source_revision),
+                Index_To_Str(record.manifest_sha256),
+                record.first_stage_id, record.stage_count, record.flags);
+    }
+
+    fprintf(file, "FHE Ordered Approximation Stage Table:\n");
+    for (UINT32 i = 1; i <= header.stage_count; ++i) {
+        DSL_FHE_APPROX_STAGE_RECORD record;
+        DSL_FHE_Approx_Stage_Get(i, &record);
+        fprintf(file, "  [%u] profile=%u ordinal=%u family=%s basis=%s "
+                "degree=%u evaluation=%s input_class=%s "
+                "input_scale=%s input_level_policy=%s "
+                "required_level=%d level_consumption=%d "
+                "output_scale=%s output_components=%s "
+                "minimum_precision=%d coefficients=tcon%u "
+                "coefficient_sha256=%s flags=0x%x\n", record.id,
+                record.profile_id, record.stage_ordinal,
+                DSL_FHE_Plan_Approximation_Name
+                    (record.approximation_family),
+                DSL_FHE_Approx_Basis_Name(record.basis), record.degree,
+                DSL_FHE_Approx_Evaluation_Name(record.evaluation_scheme),
+                DSL_FHE_Approx_Input_Class_Name
+                    (record.required_input_value_class),
+                DSL_FHE_Approx_Input_Scale_Name(record.input_scale_policy),
+                DSL_FHE_Approx_Level_Policy_Name(record.input_level_policy),
+                record.required_input_level,
+                record.level_consumption,
+                DSL_FHE_Approx_Output_Scale_Name(record.output_scale_policy),
+                DSL_FHE_Approx_Component_Policy_Name
+                    (record.output_component_policy),
+                record.minimum_precision_bits,
+                (UINT32)record.coefficient_tensor_tcon,
+                Index_To_Str(record.coefficient_sha256), record.flags);
+    }
+
+    fprintf(file, "FHE Composite Approximation Association Table:\n");
+    for (UINT32 i = 1; i <= header.association_count; ++i) {
+        DSL_FHE_APPROX_ASSOCIATION_RECORD record;
+        DSL_FHE_Approx_Association_Get(i, &record);
+        fprintf(file, "  [%u] disposition=%u source_relu=value%u(%s) "
+                "profile=%u owner_pu=%s flags=0x%x\n", record.id,
+                record.disposition_id, record.source_relu_value_id,
+                DSL_FHE_Plan_Value_Name(record.source_relu_value_id),
+                record.profile_id, ST_name(St_Table[record.owner_pu_st]),
+                record.flags);
+    }
+
+    fprintf(file, "FHE ReLU Context Range Table:\n");
+    for (UINT32 i = 1; i <= header.context_range_count; ++i) {
+        DSL_FHE_CONTEXT_RANGE_RECORD record;
+        DSL_FHE_Context_Range_Get(i, &record);
+        fprintf(file, "  [%u] profile=%u source_relu=value%u(%s) "
+                "owner_pu=%s context_identity=%u callsite=%u "
+                "positive_bound=tcon%u observed=[tcon%u,tcon%u] "
+                "out_of_range=reject provenance=%s flags=0x%x\n",
+                record.id, record.profile_id, record.source_relu_value_id,
+                DSL_FHE_Plan_Value_Name(record.source_relu_value_id),
+                ST_name(St_Table[record.owner_pu_st]),
+                record.context_pu_identity_id, record.context_callsite_id,
+                (UINT32)record.positive_bound_tcon,
+                (UINT32)record.observed_min_tcon,
+                (UINT32)record.observed_max_tcon,
+                Index_To_Str(record.provenance), record.flags);
     }
 }

--- a/osprey/common/com/dsl_ir_print.cxx
+++ b/osprey/common/com/dsl_ir_print.cxx
@@ -301,4 +301,5 @@ DSL_IR_Image_Print (FILE *file)
     }
     DSL_FHE_Image_Print(file);
     DSL_FHE_Plan_Image_Print(file);
+    DSL_FHE_Approx_Profile_Image_Print(file);
 }

--- a/osprey/common/com/ir_bread.cxx
+++ b/osprey/common/com/ir_bread.cxx
@@ -546,6 +546,21 @@ WN_get_dsl_fhe_plan_image (void *handle)
                (section_base, shdr.size, stderr) ? 0 : -1;
 }
 
+INT
+WN_get_dsl_fhe_approx_profile_image (void *handle)
+{
+    OFFSET_AND_SIZE shdr = get_section
+                               (handle, SHT_MIPS_WHIRL,
+                                WT_DSL_FHE_APPROX_PROFILE);
+    if (shdr.offset == 0) {
+        DSL_FHE_Approx_Profile_Image_Reset();
+        return DSL_FHE_Plan_Image_Validate(stderr) ? 0 : -1;
+    }
+    const void *section_base = (const char *)handle + shdr.offset;
+    return DSL_FHE_Approx_Profile_Image_Load_Mapped
+               (section_base, shdr.size, stderr) ? 0 : -1;
+}
+
 /*
  *  Note: get SSA info from file into memory 
  */
@@ -1711,6 +1726,10 @@ Read_Global_Info (INT32 *p_num_PUs)
     }
     if (WN_get_dsl_fhe_plan_image(global_fhandle) == -1) {
         ErrMsg (EC_IR_Scn_Read, "DSL FHE plan image", global_ir_file);
+    }
+    if (WN_get_dsl_fhe_approx_profile_image(global_fhandle) == -1) {
+        ErrMsg (EC_IR_Scn_Read, "DSL FHE approximation profile image",
+                global_ir_file);
     }
 
 #if defined(KEY) && defined(BACK_END)

--- a/osprey/common/com/ir_bread.h
+++ b/osprey/common/com/ir_bread.h
@@ -134,6 +134,7 @@ extern INT WN_get_dsl_call_abi_image (void *handle);
 extern INT WN_get_dsl_pu_interface_image (void *handle);
 extern INT WN_get_dsl_fhe_image (void *handle);
 extern INT WN_get_dsl_fhe_plan_image (void *handle);
+extern INT WN_get_dsl_fhe_approx_profile_image (void *handle);
 
 
 extern INT WN_get_dst (void *handle);

--- a/osprey/common/com/ir_bwrite.cxx
+++ b/osprey/common/com/ir_bwrite.cxx
@@ -1070,6 +1070,51 @@ WN_write_dsl_fhe_plan_image (Output_File *fl)
     cur_section->shdr.sh_addralign = sizeof(mINT64);
 }
 
+void
+WN_write_dsl_fhe_approx_profile_image (Output_File *fl)
+{
+    if (!DSL_FHE_Approx_Profile_Image_Has_Records())
+        return;
+
+    FmtAssert(DSL_FHE_Approx_Profile_Image_Validate(stderr),
+              ("invalid FHE approximation profile image tables"));
+    Section *cur_section = get_section
+                               (WT_DSL_FHE_APPROX_PROFILE,
+                                MIPS_WHIRL_DSL_FHE_APPROX_PROFILE, fl);
+    fl->file_size = ir_b_align(fl->file_size, sizeof(mINT64), 0);
+    cur_section->shdr.sh_offset = fl->file_size;
+
+    DSL_FHE_APPROX_PROFILE_IMAGE_HEADER header;
+    DSL_FHE_Approx_Profile_Image_Get_Header(&header);
+    ir_b_save_buf(&header, sizeof(header), sizeof(mINT64), 0, fl);
+    for (UINT32 i = 1; i <= header.profile_count; ++i) {
+        DSL_FHE_COMPOSITE_PROFILE_RECORD record;
+        FmtAssert(DSL_FHE_Approx_Profile_Get(i, &record),
+                  ("missing FHE composite profile %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    for (UINT32 i = 1; i <= header.stage_count; ++i) {
+        DSL_FHE_APPROX_STAGE_RECORD record;
+        FmtAssert(DSL_FHE_Approx_Stage_Get(i, &record),
+                  ("missing FHE approximation stage %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    for (UINT32 i = 1; i <= header.association_count; ++i) {
+        DSL_FHE_APPROX_ASSOCIATION_RECORD record;
+        FmtAssert(DSL_FHE_Approx_Association_Get(i, &record),
+                  ("missing FHE approximation association %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    for (UINT32 i = 1; i <= header.context_range_count; ++i) {
+        DSL_FHE_CONTEXT_RANGE_RECORD record;
+        FmtAssert(DSL_FHE_Context_Range_Get(i, &record),
+                  ("missing FHE context range %u", i));
+        ir_b_save_buf(&record, sizeof(record), sizeof(mINT64), 0, fl);
+    }
+    cur_section->shdr.sh_size = fl->file_size - cur_section->shdr.sh_offset;
+    cur_section->shdr.sh_addralign = sizeof(mINT64);
+}
+
 
 /*
  * Write out the debug symbol table (dst).  The DST gets its own Elf
@@ -1898,6 +1943,7 @@ Write_Global_Info (PU_Info *pu_tree)
     WN_write_dsl_call_abi_image(ir_output);
     WN_write_dsl_fhe_image(ir_output);
     WN_write_dsl_fhe_plan_image(ir_output);
+    WN_write_dsl_fhe_approx_profile_image(ir_output);
 
     WN_write_strtab(Index_To_Str (0), STR_Table_Size (), ir_output);
 

--- a/osprey/common/com/ir_bwrite.h
+++ b/osprey/common/com/ir_bwrite.h
@@ -118,6 +118,7 @@ extern void WN_write_dsl_call_abi_image (Output_File *fl);
 extern void WN_write_dsl_pu_interface_image (Output_File *fl);
 extern void WN_write_dsl_fhe_image (Output_File *fl);
 extern void WN_write_dsl_fhe_plan_image (Output_File *fl);
+extern void WN_write_dsl_fhe_approx_profile_image (Output_File *fl);
 extern void WN_write_localmap (void *localmap, Output_File *fl);
 extern void IPA_write_summary (void (*IPA_irb_write_summary) (Output_File*),
 			      Output_File *fl);

--- a/osprey/common/com/tests/dsl_builder_contract_test.cxx
+++ b/osprey/common/com/tests/dsl_builder_contract_test.cxx
@@ -5767,6 +5767,7 @@ Check_FHE_SYNC3_Plan_Image(void)
     DSL_BUILDER_VALUE conv;
     DSL_BUILDER_VALUE batch_norm;
     DSL_BUILDER_VALUE relu;
+    DSL_BUILDER_VALUE composite_relu;
     DSL_BUILDER_VALUE conv_kids[3];
     DSL_BUILDER_VALUE bn_kids[5];
     DSL_BUILDER_VALUE unary_kid[1];
@@ -5788,6 +5789,7 @@ Check_FHE_SYNC3_Plan_Image(void)
     };
     DSL_IR_VALUE_RECORD conv_value;
     DSL_IR_VALUE_RECORD relu_value;
+    DSL_IR_VALUE_RECORD composite_relu_value;
     DSL_PU_SOURCE_IDENTITY_RECORD pu_identity;
     DSL_FHE_COMPILATION_CONFIG_RECORD config;
     DSL_FHE_ENCRYPTION_DESCRIPTOR_RECORD encrypted;
@@ -5799,14 +5801,25 @@ Check_FHE_SYNC3_Plan_Image(void)
     DSL_FHE_CONVERSION_DISPOSITION_RECORD disposition;
     DSL_FHE_CONVERSION_DISPOSITION_INFO disposition_info;
     DSL_FHE_PLAN_IMAGE_HEADER header;
+    DSL_FHE_APPROX_PROFILE_IMAGE_HEADER profile_header;
+    DSL_FHE_COMPOSITE_PROFILE_RECORD composite_profile;
+    DSL_FHE_APPROX_STAGE_RECORD composite_stages[3];
+    DSL_FHE_APPROX_ASSOCIATION_RECORD composite_association;
+    DSL_FHE_CONTEXT_RANGE_RECORD context_range;
     DSL_TENSOR_TCON_CREATE_INFO tcon_info;
     DSL_FHE_APPROXIMATION_CONTRACT_ID approximation_id;
     DSL_FHE_CKKS_VALUE_STATE_ID conv_state_id;
     DSL_FHE_CKKS_VALUE_STATE_ID relu_state_id;
+    DSL_FHE_CKKS_VALUE_STATE_ID composite_relu_state_id;
+    DSL_FHE_COMPOSITE_PROFILE_ID composite_profile_id;
+    DSL_FHE_CONVERSION_DISPOSITION_ID composite_disposition_id;
+    DSL_FHE_CONTEXT_RANGE_ID context_range_id;
     DSL_FHE_BN_FOLD_PROVENANCE_ID bn_fold_id;
     DSL_FHE_CONFIG_ID config_id;
+    DSL_FHE_CONFIG_ID alternate_config_id;
     DSL_FHE_ENCRYPTION_DESCRIPTOR_ID encrypted_id;
     TCON_IDX coefficients_tcon;
+    TCON_IDX composite_coefficients_tcon[3];
     TCON_IDX folded_weight_tcon;
     TCON_IDX folded_bias_tcon;
     TCON_IDX range_min_tcon;
@@ -5816,6 +5829,7 @@ Check_FHE_SYNC3_Plan_Image(void)
     TY_IDX conv_weight_ty;
     TY_IDX channel_parameter_ty;
     TY_IDX coefficient_ty;
+    TY_IDX composite_coefficient_ty[3];
     DSL_DOMAIN_ID cnn_id;
     DSL_DOMAIN_ID common_id;
     DSL_DOMAIN_ID fhe_cnn_id;
@@ -5842,7 +5856,12 @@ Check_FHE_SYNC3_Plan_Image(void)
          sizeof(DSL_FHE_CONVERSION_DISPOSITION_RECORD) == 56 &&
          sizeof(DSL_FHE_APPROXIMATION_CONTRACT_RECORD) == 64 &&
          sizeof(DSL_FHE_CKKS_VALUE_STATE_RECORD) == 64 &&
-         sizeof(DSL_FHE_BN_FOLD_PROVENANCE_RECORD) == 64,
+         sizeof(DSL_FHE_BN_FOLD_PROVENANCE_RECORD) == 64 &&
+         sizeof(DSL_FHE_APPROX_PROFILE_IMAGE_HEADER) == 64 &&
+         sizeof(DSL_FHE_COMPOSITE_PROFILE_RECORD) == 80 &&
+         sizeof(DSL_FHE_APPROX_STAGE_RECORD) == 80 &&
+         sizeof(DSL_FHE_APPROX_ASSOCIATION_RECORD) == 32 &&
+         sizeof(DSL_FHE_CONTEXT_RANGE_RECORD) == 64,
          "fixed record sizes");
     if (!DSL_Builder_Begin_Program())
         return 1;
@@ -5908,6 +5927,19 @@ Check_FHE_SYNC3_Plan_Image(void)
     coefficient_ty = DSL_Builder_Create_Tensor_Type_Core
                          ("fhe_sync3_coeff_f32_4", MTYPE_To_TY(MTYPE_F4),
                           &coefficient_core);
+    const char *composite_coefficient_shape[3] = { "[8]", "[16]", "[14]" };
+    const char *composite_coefficient_name[3] = {
+        "fhe_sync_c_coeff_f32_8",
+        "fhe_sync_c_coeff_f32_16",
+        "fhe_sync_c_coeff_f32_14"
+    };
+    for (UINT32 i = 0; i < 3; ++i) {
+        coefficient_core.logical_shape = composite_coefficient_shape[i];
+        composite_coefficient_ty[i] = DSL_Builder_Create_Tensor_Type_Core
+                                          (composite_coefficient_name[i],
+                                           MTYPE_To_TY(MTYPE_F4),
+                                           &coefficient_core);
+    }
     pu = DSL_Builder_Create_Minimal_PU("fhe_sync3_plan");
     file_id = DSL_Builder_Register_Source_File(pu, __FILE__);
     memset(&source_identity, 0, sizeof(source_identity));
@@ -5920,6 +5952,12 @@ Check_FHE_SYNC3_Plan_Image(void)
          channel_parameter_ty != TY_IDX_ZERO &&
          coefficient_ty != TY_IDX_ZERO &&
          TY_tensor_seal(coefficient_ty) &&
+         composite_coefficient_ty[0] != TY_IDX_ZERO &&
+         composite_coefficient_ty[1] != TY_IDX_ZERO &&
+         composite_coefficient_ty[2] != TY_IDX_ZERO &&
+         TY_tensor_seal(composite_coefficient_ty[0]) &&
+         TY_tensor_seal(composite_coefficient_ty[1]) &&
+         TY_tensor_seal(composite_coefficient_ty[2]) &&
          pu != NULL && file_id != 0 && cnn_id != DSL_DOMAIN_INVALID_ID &&
          DSL_Builder_Set_PU_Source_Identity(pu, &source_identity),
          "program, tensor types, and source identity");
@@ -5948,6 +5986,11 @@ Check_FHE_SYNC3_Plan_Image(void)
                (DSL_Opcode_Find(DSL_Domain_Find("common"),
                                 "common.relu", 2),
                 2, unary_kid, 1, NULL, 0, "relu_result", tensor_ty);
+    composite_relu = DSL_Builder_Create_Operator_With_Result
+               (DSL_Opcode_Find(DSL_Domain_Find("common"),
+                                "common.relu", 2),
+                2, unary_kid, 1, NULL, 0, "composite_relu_result",
+                tensor_ty);
     memset(&source_position, 0, sizeof(source_position));
     source_position.file_id = file_id;
     source_position.line = __LINE__ + 1;
@@ -5955,7 +5998,8 @@ Check_FHE_SYNC3_Plan_Image(void)
     source_position.statement_begin = 1;
     positions_set = input != NULL && conv_weight != NULL &&
                     channel_parameter != NULL && conv != NULL &&
-                    batch_norm != NULL && relu != NULL;
+                    batch_norm != NULL && relu != NULL &&
+                    composite_relu != NULL;
     if (positions_set) {
         positions_set = DSL_Builder_Set_Value_Source_Position
                             (input, &source_position);
@@ -5979,17 +6023,23 @@ Check_FHE_SYNC3_Plan_Image(void)
         positions_set = positions_set &&
                         DSL_Builder_Set_Value_Source_Position
                             (relu, &source_position);
+        ++source_position.line;
+        positions_set = positions_set &&
+                        DSL_Builder_Set_Value_Source_Position
+                            (composite_relu, &source_position);
     }
     FHE_SYNC3_CHECK
         (input != NULL && conv_weight != NULL && channel_parameter != NULL &&
          conv != NULL && batch_norm != NULL && relu != NULL &&
+         composite_relu != NULL &&
          positions_set &&
          DSL_Builder_Append_PU_Value(pu, input) &&
          DSL_Builder_Append_PU_Value(pu, conv_weight) &&
          DSL_Builder_Append_PU_Value(pu, channel_parameter) &&
          DSL_Builder_Append_PU_Value(pu, conv) &&
          DSL_Builder_Append_PU_Value(pu, batch_norm) &&
-         DSL_Builder_Append_PU_Value(pu, relu),
+         DSL_Builder_Append_PU_Value(pu, relu) &&
+         DSL_Builder_Append_PU_Value(pu, composite_relu),
          "source-semantic CNN values");
 
     FHE_SYNC3_CHECK
@@ -5997,6 +6047,9 @@ Check_FHE_SYNC3_Plan_Image(void)
                                 &conv_value) &&
          DSL_IR_Image_Get_Value(DSL_Builder_Get_Value_Image_Id(relu),
                                 &relu_value) &&
+         DSL_IR_Image_Get_Value
+             (DSL_Builder_Get_Value_Image_Id(composite_relu),
+              &composite_relu_value) &&
          DSL_Call_Image_Find_PU_Identity(PU_Info_proc_sym(pu), &pu_identity),
          "stable source image identities");
 
@@ -6013,6 +6066,9 @@ Check_FHE_SYNC3_Plan_Image(void)
     config.bootstrap_policy = DSL_FHE_BOOTSTRAP_AUTO;
     config.backend_policy = DSL_FHE_BACKEND_OPENFHE;
     config_id = DSL_FHE_Intern_Compilation_Config(&config);
+    config.ring_dimension = 32768;
+    alternate_config_id = DSL_FHE_Intern_Compilation_Config(&config);
+    config.ring_dimension = 65536;
     DSL_FHE_Encryption_Descriptor_Record_Init(&encrypted);
     encrypted.value_class = DSL_FHE_VALUE_CLASS_CIPHERTEXT;
     encrypted.scheme = DSL_FHE_SCHEME_CKKS;
@@ -6023,7 +6079,8 @@ Check_FHE_SYNC3_Plan_Image(void)
     encrypted.packing_policy = DSL_FHE_PACKING_AUTO;
     encrypted_id = DSL_FHE_Intern_Encryption_Descriptor(&encrypted);
     FHE_SYNC3_CHECK
-        (config_id != 0 && encrypted_id != 0,
+        (config_id != 0 && alternate_config_id != 0 &&
+         alternate_config_id != config_id && encrypted_id != 0,
          "FHE configuration and encryption descriptor");
 
     memset(&tcon_info, 0, sizeof(tcon_info));
@@ -6040,9 +6097,100 @@ Check_FHE_SYNC3_Plan_Image(void)
          "coefficient and folded tensor constants");
     folded_weight_tcon = coefficients_tcon;
     folded_bias_tcon = coefficients_tcon;
+    const UINT64 composite_coefficient_count[3] = { 8, 16, 14 };
+    for (UINT32 i = 0; i < 3; ++i) {
+        tcon_info.descriptor_ty = composite_coefficient_ty[i];
+        tcon_info.element_count = composite_coefficient_count[i];
+        tcon_info.logical_bytes = composite_coefficient_count[i] * 4;
+        FHE_SYNC3_CHECK
+            (DSL_Tensor_TCON_Create_Zero
+                 (&tcon_info, &composite_coefficients_tcon[i], NULL),
+             "composite coefficient tensor constant");
+    }
     range_min_tcon = Enter_tcon(Host_To_Targ_Float(MTYPE_F4, -3.0));
     range_max_tcon = Enter_tcon(Host_To_Targ_Float(MTYPE_F4, 3.0));
     max_error_tcon = Enter_tcon(Host_To_Targ_Float(MTYPE_F4, 0.01));
+
+    DSL_FHE_Composite_Profile_Record_Init(&composite_profile);
+    composite_profile.config_id = config_id;
+    composite_profile.profile_name =
+        Save_Str("ace.chebyshev.sign.7x15x13.depth11");
+    composite_profile.profile_version = 1;
+    composite_profile.reconstruction =
+        DSL_FHE_RECONSTRUCTION_RELU_FROM_NORMALIZED_SIGN;
+    composite_profile.total_multiplicative_depth = 11;
+    composite_profile.normalization_policy =
+        DSL_FHE_NORMALIZATION_POSITIVE_CONTEXT_BOUND;
+    composite_profile.pre_refresh_policy = DSL_FHE_PRE_REFRESH_REQUIRED;
+    composite_profile.source_revision = Save_Str("ace-test-revision");
+    composite_profile.manifest_sha256 = Save_Str
+        ("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+    composite_profile.stage_count = 3;
+    const UINT32 composite_degrees[3] = { 7, 15, 13 };
+    for (UINT32 i = 0; i < 3; ++i) {
+        DSL_FHE_Approx_Stage_Record_Init(&composite_stages[i]);
+        composite_stages[i].approximation_family =
+            DSL_FHE_APPROXIMATION_CHEBYSHEV;
+        composite_stages[i].basis = DSL_FHE_APPROX_BASIS_CHEBYSHEV;
+        composite_stages[i].degree = composite_degrees[i];
+        composite_stages[i].evaluation_scheme =
+            DSL_FHE_APPROX_EVAL_CLENSHAW;
+        composite_stages[i].required_input_value_class =
+            DSL_FHE_VALUE_CLASS_CIPHERTEXT;
+        composite_stages[i].input_scale_policy =
+            DSL_FHE_APPROX_INPUT_SCALE_PROFILE_NORMALIZED;
+        composite_stages[i].input_level_policy =
+            DSL_FHE_APPROX_LEVEL_ANY_SUFFICIENT;
+        composite_stages[i].level_consumption = i == 0 ? 3 : 4;
+        composite_stages[i].output_scale_policy =
+            DSL_FHE_APPROX_OUTPUT_SCALE_PRESERVE_INPUT;
+        composite_stages[i].output_component_policy =
+            DSL_FHE_APPROX_COMPONENT_RELINEARIZED_TWO;
+        composite_stages[i].minimum_precision_bits = 30;
+        composite_stages[i].coefficient_tensor_tcon =
+            composite_coefficients_tcon[i];
+        composite_stages[i].coefficient_sha256 = Save_Str
+            (i == 0 ?
+             "1111111111111111111111111111111111111111111111111111111111111111" :
+             i == 1 ?
+             "2222222222222222222222222222222222222222222222222222222222222222" :
+             "3333333333333333333333333333333333333333333333333333333333333333");
+    }
+    ++composite_profile.total_multiplicative_depth;
+    FHE_SYNC3_CHECK
+        (DSL_FHE_Approx_Profile_Intern_Complete
+             (&composite_profile, composite_stages, 3) == 0 &&
+         DSL_FHE_Approx_Profile_Count() == 0 &&
+         DSL_FHE_Approx_Stage_Count() == 0,
+         "invalid profile depth rejects before atomic insertion");
+    --composite_profile.total_multiplicative_depth;
+    composite_profile_id = DSL_FHE_Approx_Profile_Intern_Complete
+                               (&composite_profile, composite_stages, 3);
+    FHE_SYNC3_CHECK
+        (composite_profile_id != 0 &&
+         DSL_FHE_Approx_Profile_Intern_Complete
+             (&composite_profile, composite_stages, 3) ==
+                 composite_profile_id,
+         "atomic composite profile and ordered-stage interning");
+    composite_profile.config_id = alternate_config_id;
+    DSL_FHE_COMPOSITE_PROFILE_ID alternate_profile_id =
+        DSL_FHE_Approx_Profile_Intern_Complete
+            (&composite_profile, composite_stages, 3);
+    DSL_FHE_COMPOSITE_PROFILE_RECORD found_profile;
+    FHE_SYNC3_CHECK
+        (alternate_profile_id != 0 &&
+         alternate_profile_id != composite_profile_id &&
+         DSL_FHE_Approx_Profile_Find
+             (config_id, "ace.chebyshev.sign.7x15x13.depth11", 1,
+              &found_profile) &&
+         found_profile.id == composite_profile_id &&
+         DSL_FHE_Approx_Profile_Find
+             (alternate_config_id,
+              "ace.chebyshev.sign.7x15x13.depth11", 1,
+              &found_profile) &&
+         found_profile.id == alternate_profile_id,
+         "same profile name and version coexist across configurations");
+    composite_profile.config_id = config_id;
 
     DSL_FHE_Approximation_Contract_Record_Init(&approximation);
     approximation.config_id = config_id;
@@ -6089,6 +6237,11 @@ Check_FHE_SYNC3_Plan_Image(void)
     relu_state_id =
         DSL_Builder_Bind_FHE_Value_CKKS_State(relu, &ckks_info);
     FHE_SYNC3_CHECK(relu_state_id != 0, "ReLU CKKS pending state");
+    composite_relu_state_id =
+        DSL_Builder_Bind_FHE_Value_CKKS_State(composite_relu, &ckks_info);
+    FHE_SYNC3_CHECK
+        (composite_relu_state_id != 0,
+         "composite ReLU CKKS pending state");
 
     memset(&bn_fold_info, 0, sizeof(bn_fold_info));
     bn_fold_info.context_pu_identity_id = pu_identity.id;
@@ -6127,13 +6280,63 @@ Check_FHE_SYNC3_Plan_Image(void)
              (relu, &disposition_info) != 0,
          "ReLU approximation disposition");
 
+    DSL_FHE_Conversion_Disposition_Record_Init(&disposition);
+    disposition.source_node_id = composite_relu_value.producer_node_id;
+    disposition.result_value_id = composite_relu_value.id;
+    disposition.disposition =
+        DSL_FHE_DISPOSITION_REQUIRE_COMPOSITE_APPROXIMATION;
+    disposition.owner_pu_st = PU_Info_proc_sym(pu);
+    disposition.approximation_contract_id = composite_profile_id;
+    disposition.result_ckks_value_state_id = composite_relu_state_id;
+    disposition.flags = DSL_FHE_DISPOSITION_OUTPUT_ENCRYPTED;
+    FHE_SYNC3_CHECK
+        (DSL_FHE_Plan_Add_Conversion_Disposition(&disposition) == 0,
+         "ordinary disposition API rejects unassociated composite row");
+    composite_disposition_id =
+        DSL_FHE_Plan_Add_Composite_Disposition
+            (&disposition, composite_profile_id);
+    FHE_SYNC3_CHECK
+        (composite_disposition_id != 0 &&
+         DSL_FHE_Approx_Association_Find
+             (composite_disposition_id, &composite_association) &&
+         composite_association.source_relu_value_id ==
+             composite_relu_value.id,
+         "atomic composite disposition association");
+
+    DSL_FHE_Context_Range_Record_Init(&context_range);
+    context_range.profile_id = composite_profile_id;
+    context_range.source_relu_value_id = composite_relu_value.id;
+    context_range.context_pu_identity_id = pu_identity.id;
+    context_range.owner_pu_st = PU_Info_proc_sym(pu);
+    context_range.positive_bound_tcon = range_max_tcon;
+    context_range.observed_min_tcon = range_min_tcon;
+    context_range.observed_max_tcon = range_max_tcon;
+    context_range.out_of_range_policy = DSL_FHE_CONTEXT_RANGE_REJECT;
+    context_range.provenance = Save_Str("fhe.sync-c.root-range.v1");
+    context_range_id =
+        DSL_FHE_Approx_Profile_Bind_Context_Range(&context_range);
+    FHE_SYNC3_CHECK
+        (context_range_id != 0 &&
+         DSL_FHE_Context_Range_Find
+             (composite_profile_id, composite_relu_value.id,
+              pu_identity.id, 0, &context_range) &&
+         DSL_FHE_Approx_Profile_Image_Validate(stderr),
+         "root composite ReLU context range");
+
     DSL_FHE_Plan_Image_Get_Header(&header);
     FHE_SYNC3_CHECK
-        (header.disposition_count == 2 && header.approximation_count == 1 &&
-         header.ckks_value_state_count == 2 && header.bn_fold_count == 1 &&
+        (header.disposition_count == 3 && header.approximation_count == 1 &&
+         header.ckks_value_state_count == 3 && header.bn_fold_count == 1 &&
          DSL_FHE_Plan_Image_Has_Records() &&
          DSL_FHE_Plan_Image_Validate(stderr),
          "complete planning image validates");
+    DSL_FHE_Approx_Profile_Image_Get_Header(&profile_header);
+    FHE_SYNC3_CHECK
+        (profile_header.profile_count == 2 &&
+         profile_header.stage_count == 6 &&
+         profile_header.association_count == 1 &&
+         profile_header.context_range_count == 1,
+         "composite approximation image counts");
     FHE_SYNC3_CHECK
         (DSL_FHE_Plan_Find_Conversion_Disposition
              (conv_value.producer_node_id, &disposition) &&
@@ -6151,6 +6354,116 @@ Check_FHE_SYNC3_Plan_Image(void)
     FHE_SYNC3_CHECK
         (DSL_FHE_Plan_Add_CKKS_Value_State(&ckks_state) == 0,
          "unknown CKKS pending action rejected");
+
+    UINT64 profile_image_size = DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE +
+        (UINT64)profile_header.profile_count *
+            DSL_FHE_COMPOSITE_PROFILE_RECORD_SIZE +
+        (UINT64)profile_header.stage_count *
+            DSL_FHE_APPROX_STAGE_RECORD_SIZE +
+        (UINT64)profile_header.association_count *
+            DSL_FHE_APPROX_ASSOCIATION_RECORD_SIZE +
+        (UINT64)profile_header.context_range_count *
+            DSL_FHE_CONTEXT_RANGE_RECORD_SIZE;
+    unsigned char *profile_image_bytes =
+        new unsigned char[profile_image_size];
+    unsigned char *profile_cursor = profile_image_bytes;
+    memcpy(profile_cursor, &profile_header, sizeof(profile_header));
+    profile_cursor += sizeof(profile_header);
+    for (UINT32 i = 1; i <= profile_header.profile_count; ++i) {
+        DSL_FHE_Approx_Profile_Get(i, &composite_profile);
+        memcpy(profile_cursor, &composite_profile,
+               sizeof(composite_profile));
+        profile_cursor += sizeof(composite_profile);
+    }
+    for (UINT32 i = 1; i <= profile_header.stage_count; ++i) {
+        DSL_FHE_Approx_Stage_Get(i, &composite_stages[0]);
+        memcpy(profile_cursor, &composite_stages[0],
+               sizeof(composite_stages[0]));
+        profile_cursor += sizeof(composite_stages[0]);
+    }
+    for (UINT32 i = 1; i <= profile_header.association_count; ++i) {
+        DSL_FHE_Approx_Association_Get(i, &composite_association);
+        memcpy(profile_cursor, &composite_association,
+               sizeof(composite_association));
+        profile_cursor += sizeof(composite_association);
+    }
+    for (UINT32 i = 1; i <= profile_header.context_range_count; ++i) {
+        DSL_FHE_Context_Range_Get(i, &context_range);
+        memcpy(profile_cursor, &context_range, sizeof(context_range));
+        profile_cursor += sizeof(context_range);
+    }
+    FHE_SYNC3_CHECK
+        (!DSL_FHE_Approx_Profile_Image_Load_Mapped
+             (profile_image_bytes, profile_image_size - 1, NULL) &&
+         !DSL_FHE_Approx_Profile_Image_Load_Mapped
+             (profile_image_bytes, profile_image_size + 1, NULL),
+         "composite profile truncated and trailing images rejected");
+    DSL_FHE_COMPOSITE_PROFILE_RECORD *mapped_profile =
+        (DSL_FHE_COMPOSITE_PROFILE_RECORD *)
+            (profile_image_bytes + DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE);
+    UINT32 saved_total_depth = mapped_profile->total_multiplicative_depth;
+    mapped_profile->total_multiplicative_depth = saved_total_depth + 1;
+    FHE_SYNC3_CHECK
+        (!DSL_FHE_Approx_Profile_Image_Load_Mapped
+             (profile_image_bytes, profile_image_size, NULL),
+         "composite profile and stage depth mismatch rejected");
+    mapped_profile->total_multiplicative_depth = saved_total_depth;
+    DSL_FHE_APPROX_STAGE_RECORD *mapped_stage =
+        (DSL_FHE_APPROX_STAGE_RECORD *)
+            (profile_image_bytes + DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE +
+             profile_header.profile_count *
+                 DSL_FHE_COMPOSITE_PROFILE_RECORD_SIZE);
+    UINT32 saved_degree = mapped_stage->degree;
+    mapped_stage->degree = saved_degree - 1;
+    FHE_SYNC3_CHECK
+        (!DSL_FHE_Approx_Profile_Image_Load_Mapped
+             (profile_image_bytes, profile_image_size, NULL),
+         "stage coefficient count and degree mismatch rejected");
+    mapped_stage->degree = saved_degree;
+    UINT32 saved_stage_ordinal = mapped_stage->stage_ordinal;
+    mapped_stage->stage_ordinal = 1;
+    FHE_SYNC3_CHECK
+        (!DSL_FHE_Approx_Profile_Image_Load_Mapped
+             (profile_image_bytes, profile_image_size, NULL),
+         "non-dense stage ordinal rejected");
+    mapped_stage->stage_ordinal = saved_stage_ordinal;
+    UINT32 saved_evaluation_scheme = mapped_stage->evaluation_scheme;
+    mapped_stage->evaluation_scheme = DSL_FHE_APPROX_EVAL_UNKNOWN;
+    FHE_SYNC3_CHECK
+        (!DSL_FHE_Approx_Profile_Image_Load_Mapped
+             (profile_image_bytes, profile_image_size, NULL),
+         "unresolved stage evaluator rejected");
+    mapped_stage->evaluation_scheme = saved_evaluation_scheme;
+    UINT32 saved_input_scale_policy = mapped_stage->input_scale_policy;
+    mapped_stage->input_scale_policy = DSL_FHE_APPROX_SCALE_EXPLICIT;
+    FHE_SYNC3_CHECK
+        (!DSL_FHE_Approx_Profile_Image_Load_Mapped
+             (profile_image_bytes, profile_image_size, NULL),
+         "unresolved explicit stage scale rejected");
+    mapped_stage->input_scale_policy = saved_input_scale_policy;
+    DSL_FHE_CONTEXT_RANGE_RECORD *mapped_context =
+        (DSL_FHE_CONTEXT_RANGE_RECORD *)
+            (profile_image_bytes + DSL_FHE_APPROX_PROFILE_IMAGE_HEADER_SIZE +
+             profile_header.profile_count *
+                 DSL_FHE_COMPOSITE_PROFILE_RECORD_SIZE +
+             profile_header.stage_count * DSL_FHE_APPROX_STAGE_RECORD_SIZE +
+             profile_header.association_count *
+                 DSL_FHE_APPROX_ASSOCIATION_RECORD_SIZE);
+    DSL_CALLSITE_METADATA_ID saved_context_callsite =
+        mapped_context->context_callsite_id;
+    mapped_context->context_callsite_id = DSL_Call_Image_Callsite_Count() + 1;
+    FHE_SYNC3_CHECK
+        (!DSL_FHE_Approx_Profile_Image_Load_Mapped
+             (profile_image_bytes, profile_image_size, NULL),
+         "invalid non-root context callsite rejected");
+    mapped_context->context_callsite_id = saved_context_callsite;
+    FHE_SYNC3_CHECK
+        (DSL_FHE_Approx_Profile_Count() == 2 &&
+         DSL_FHE_Approx_Stage_Count() == 6 &&
+         DSL_FHE_Approx_Association_Count() == 1 &&
+         DSL_FHE_Context_Range_Count() == 1 &&
+         DSL_FHE_Approx_Profile_Image_Validate(NULL),
+         "rejected mapped profiles leave managed tables unchanged");
 
     UINT64 image_size = DSL_FHE_PLAN_IMAGE_HEADER_SIZE +
         (UINT64)header.disposition_count *
@@ -6209,12 +6522,22 @@ Check_FHE_SYNC3_Plan_Image(void)
     mapped_disposition->result_value_id = saved_result_value_id;
     FHE_SYNC3_CHECK
         (DSL_FHE_Plan_Image_Load_Mapped(image_bytes, image_size, stderr) &&
-         DSL_FHE_Plan_Conversion_Disposition_Count() == 2 &&
+         DSL_FHE_Plan_Conversion_Disposition_Count() == 3 &&
          DSL_FHE_Plan_Approximation_Contract_Count() == 1 &&
-         DSL_FHE_Plan_CKKS_Value_State_Count() == 2 &&
+         DSL_FHE_Plan_CKKS_Value_State_Count() == 3 &&
          DSL_FHE_Plan_BN_Fold_Provenance_Count() == 1,
          "mapped planning image copied into managed tables");
     delete [] image_bytes;
+    FHE_SYNC3_CHECK
+        (DSL_FHE_Approx_Profile_Image_Load_Mapped
+             (profile_image_bytes, profile_image_size, stderr) &&
+         DSL_FHE_Approx_Profile_Count() == 2 &&
+         DSL_FHE_Approx_Stage_Count() == 6 &&
+         DSL_FHE_Approx_Association_Count() == 1 &&
+         DSL_FHE_Context_Range_Count() == 1 &&
+         DSL_FHE_Plan_Image_Validate(stderr),
+         "mapped composite profile copied and cross-validated");
+    delete [] profile_image_bytes;
 
     char diagnostic[4096];
     memset(&verify, 0, sizeof(verify));
@@ -6235,6 +6558,7 @@ Check_FHE_SYNC3_Plan_Image(void)
     DSL_FHE_Plan_Image_Reset();
     FHE_SYNC3_CHECK
         (!DSL_FHE_Plan_Image_Has_Records() &&
+         !DSL_FHE_Approx_Profile_Image_Has_Records() &&
          DSL_FHE_Plan_Conversion_Disposition_Count() == 0 &&
          DSL_FHE_Plan_Image_Validate(NULL),
          "planning image reset");

--- a/osprey/common/com/tests/dsl_fhe_sync3_plan_image_test.sh
+++ b/osprey/common/com/tests/dsl_fhe_sync3_plan_image_test.sh
@@ -50,6 +50,17 @@ for evidence in \
   'disposition=require_approximation' \
   'FHE Approximation Contract Table:' \
   'polynomial=relu_minimax_degree3.v1' \
+  'disposition=require_composite_approximation' \
+  'composite_profile=1' \
+  'FHE Composite Approximation Profile Image: version=1 capabilities=0x0000000f' \
+  'profile=ace.chebyshev.sign.7x15x13.depth11.v1' \
+  'FHE Ordered Approximation Stage Table:' \
+  'ordinal=0 family=chebyshev basis=chebyshev degree=7' \
+  'ordinal=1 family=chebyshev basis=chebyshev degree=15' \
+  'ordinal=2 family=chebyshev basis=chebyshev degree=13' \
+  'FHE Composite Approximation Association Table:' \
+  'FHE ReLU Context Range Table:' \
+  'out_of_range=reject provenance=fhe.sync-c.root-range.v1' \
   'FHE CKKS Value State Table:' \
   'level=<pending>' \
   'bootstrap_reason=pre_relu_refresh' \

--- a/osprey/include/sys/elf_whirl.h
+++ b/osprey/include/sys/elf_whirl.h
@@ -87,6 +87,7 @@
 #define WT_DSL_FHE_PLAN 0x24
 #define WT_DSL_CALL_ABI_IMAGE 0x25
 #define WT_DSL_PU_INTERFACE_IMAGE 0x26
+#define WT_DSL_FHE_APPROX_PROFILE 0x27
 
 /*
  * Special WHIRL section names.
@@ -107,6 +108,7 @@
 #define MIPS_WHIRL_DSL_FHE_PLAN ".WHIRL.dsl_fhe_plan"
 #define MIPS_WHIRL_DSL_CALL_ABI_IMAGE ".WHIRL.dsl_call_abi"
 #define MIPS_WHIRL_DSL_PU_INTERFACE_IMAGE ".WHIRL.dsl_pu_interface"
+#define MIPS_WHIRL_DSL_FHE_APPROX_PROFILE ".WHIRL.dsl_fhe_approx_profile"
 #if defined(TARG_SL)
 #define MIPS_WHIRL_CALLGRAPH    ".WHIRL.callgraph"
 #endif


### PR DESCRIPTION
## Summary

- add the optional `.WHIRL.dsl_fhe_approx_profile` mapped-image section for composite FHE approximation profiles
- preserve ordered polynomial stages, symbolic evaluator/state policy, tagged disposition associations, and exact ReLU context-range evidence
- add append-only composite disposition value `6` while preserving the existing single-polynomial v1 contract
- wire mapped-image validation, binary reader/writer support, and stable `ir_b2a -st -src` inspection
- document the SYNC-C compatibility and staging contract

## Compatibility

- existing FHE plan rows, WN layout, opcode encoding, TY encoding, and binary WHIRL revision are unchanged
- absence of the optional section preserves legacy behavior
- immediately previous readers reject disposition `6` rather than misinterpreting a composite profile as a v1 polynomial
- profile identity is `(config_id, profile_name, profile_version)`

## Validation

- rebuilt `dsl_builder_contract_test` and `ir_b2a` in Linux/amd64 Docker
- mixed legacy degree-3 and composite 7x15x13 mapped-image roundtrip passed
- malformed image tests cover truncation, trailing bytes, depth mismatch, coefficient-count mismatch, stage ordinal/evaluator/scale errors, invalid context callsites, and rejected-load table preservation
- neighboring SYNC-1, native rewrite, external tensor materialization, and value retirement tests passed
- previous `ir_b2a` reader failed closed at the new disposition
- FHE consumer review accepted the final contract with no blocker

## Staging Boundary

This PR does not encode ACE coefficient values, approve measured ranges, insert bootstrap operations, create concrete per-stage CKKS states, or lower the composite profile to OpenFHE. Those remain fail-closed behind later certification gates.
