### PR TITLE
Add authenticated FHE calibration manifest options

### DIFF
--- a/doc/FHE-SYNC3-NATIVE-PLAN-CONTRACT.md
+++ b/doc/FHE-SYNC3-NATIVE-PLAN-CONTRACT.md
@@ -648,6 +648,19 @@ surface is:
 - `-FHE:dump_after=on|off`;
 - `-FHE:checkpoint=<path>`, which selects conversion-only certification and
   names the binary WHIRL output.
+- `-FHE:calibration_manifest=<path>` and
+  `-FHE:calibration_sha256=<digest>`, which must be supplied together when an
+  approved external calibration manifest is selected. The digest is exactly
+  64 lowercase hexadecimal characters. The backend transports this
+  authenticated reference to every PU conversion; the registered FHE pass
+  owns reading the manifest, verifying its bytes against the digest, and
+  validating its identity-bound range policy.
+
+The calibration options are runtime phase inputs. They do not enter WHIRL,
+the mapped image, or tensor type identity. An FHE-bearing conversion rejects
+an incomplete or malformed pair before invoking the semantic gatekeeper.
+Ordinary WHIRL remains a no-op even when unrelated FHE options are propagated
+through the phase pipeline.
 
 `VHO_FHE_Convert_Program_Unit()` performs the structural DSL/FHE/FHE-plan
 gate, invokes the registered semantic gatekeeper, invokes the registered

--- a/doc/WHIRL-DSL-INFRASTRUCTURE.md
+++ b/doc/WHIRL-DSL-INFRASTRUCTURE.md
@@ -1779,8 +1779,10 @@ full-sequence causal prompt evaluation with no KV cache.
    not let it reach into WN, ST, TY, or mapped-image internals.
 
    Stage 3 implements `config_fhe.{h,cxx}` with `convert`, `strict_o0`,
-   `dump_before`, and `dump_after` controls in the independent `-FHE:` option
-   group. Conversion defaults on but is an exact no-op for artifacts without
+   `dump_before`, `dump_after`, authenticated `calibration_manifest` plus
+   `calibration_sha256`, and conversion `checkpoint` controls in the
+   independent `-FHE:` option group. Conversion defaults on but is an exact
+   no-op for artifacts without
    FHE image or FHE-plan records. An FHE-bearing artifact requires a
    registered semantic gatekeeper and conversion pass; absence is diagnosed
    as `CFHE-CONVERT-001` rather than allowing generic DSL lowering to erase

--- a/osprey/be/vho/fhe_convert.cxx
+++ b/osprey/be/vho/fhe_convert.cxx
@@ -138,6 +138,38 @@ VHO_FHE_Convert_Report
 }
 
 static BOOL
+VHO_FHE_Convert_Calibration_Options_Valid
+        (FILE *diagnostic, VHO_FHE_CONVERT_RESULT *result)
+{
+    const char *path = VHO_FHE_Calibration_Manifest_Path;
+    const char *sha256 = VHO_FHE_Calibration_Manifest_SHA256;
+    BOOL has_path = path != NULL && path[0] != '\0';
+    BOOL has_sha256 = sha256 != NULL && sha256[0] != '\0';
+
+    if (has_path != has_sha256)
+        return VHO_FHE_Convert_Report
+                   (diagnostic, result,
+                    "calibration manifest and SHA-256 must be specified "
+                    "together");
+    if (!has_path)
+        return TRUE;
+    if (strlen(sha256) != 64)
+        return VHO_FHE_Convert_Report
+                   (diagnostic, result,
+                    "calibration manifest SHA-256 must contain exactly 64 "
+                    "lowercase hexadecimal characters");
+    for (UINT32 i = 0; i < 64; ++i) {
+        if (!((sha256[i] >= '0' && sha256[i] <= '9') ||
+              (sha256[i] >= 'a' && sha256[i] <= 'f')))
+            return VHO_FHE_Convert_Report
+                       (diagnostic, result,
+                        "calibration manifest SHA-256 must contain exactly "
+                        "64 lowercase hexadecimal characters");
+    }
+    return TRUE;
+}
+
+static BOOL
 VHO_FHE_Convert_Structural_Gatekeeper
         (struct pu_info *pu_info,
          FILE *diagnostic,
@@ -423,6 +455,10 @@ VHO_FHE_Convert_Program_Unit
     VHO_FHE_CONVERT_OPTIONS options;
     memset(&local_result, 0, sizeof(local_result));
     options.strict_o0 = VHO_FHE_Strict_O0;
+    options.calibration_manifest_path =
+        VHO_FHE_Calibration_Manifest_Path;
+    options.calibration_manifest_sha256 =
+        VHO_FHE_Calibration_Manifest_SHA256;
 
     if (pu_info == NULL || tree == NULL || *tree == NULL) {
         VHO_FHE_Convert_Report
@@ -439,6 +475,13 @@ VHO_FHE_Convert_Program_Unit
         if (result != NULL)
             *result = local_result;
         return TRUE;
+    }
+
+    if (!VHO_FHE_Convert_Calibration_Options_Valid
+             (diagnostic, &local_result)) {
+        if (result != NULL)
+            *result = local_result;
+        return FALSE;
     }
 
     if (!VHO_FHE_Convert_Structural_Gatekeeper

--- a/osprey/be/vho/fhe_convert.h
+++ b/osprey/be/vho/fhe_convert.h
@@ -14,6 +14,8 @@ struct pu_info;
 
 typedef struct {
     BOOL strict_o0;
+    const char *calibration_manifest_path;
+    const char *calibration_manifest_sha256;
 } VHO_FHE_CONVERT_OPTIONS;
 
 typedef struct {

--- a/osprey/be/vho/tests/fhe_convert_contract_test.cxx
+++ b/osprey/be/vho/tests/fhe_convert_contract_test.cxx
@@ -47,6 +47,8 @@ Host_Format_Parm(INT kind, MEM_PTR parm)
 static char observed_order[8];
 static UINT32 observed_count;
 static BOOL observed_strict_o0;
+static const char *observed_calibration_manifest_path;
+static const char *observed_calibration_manifest_sha256;
 static char checkpoint_temporary[2][256];
 static char checkpoint_final[2][256];
 static char checkpoint_alias[2][256];
@@ -67,6 +69,10 @@ Observe_Semantic_Gatekeeper
     (void)diagnostic;
     observed_order[observed_count++] = 'G';
     observed_strict_o0 = options->strict_o0;
+    observed_calibration_manifest_path =
+        options->calibration_manifest_path;
+    observed_calibration_manifest_sha256 =
+        options->calibration_manifest_sha256;
     return pu_info != NULL && tree != NULL;
 }
 
@@ -81,6 +87,10 @@ Observe_Conversion
     (void)diagnostic;
     observed_order[observed_count++] = 'C';
     observed_strict_o0 = options->strict_o0;
+    observed_calibration_manifest_path =
+        options->calibration_manifest_path;
+    observed_calibration_manifest_sha256 =
+        options->calibration_manifest_sha256;
     result->source_disposition_count = 1;
     result->converted_disposition_count = 1;
     return pu_info != NULL && tree != NULL && *tree != NULL;
@@ -372,7 +382,14 @@ main(void)
 
     observed_count = 0;
     observed_strict_o0 = FALSE;
+    observed_calibration_manifest_path = NULL;
+    observed_calibration_manifest_sha256 = NULL;
     VHO_FHE_Strict_O0 = TRUE;
+    VHO_FHE_Calibration_Manifest_Path =
+        (char *)"/tmp/open64-fhe-calibration.json";
+    VHO_FHE_Calibration_Manifest_SHA256 =
+        (char *)"0123456789abcdef0123456789abcdef"
+                "0123456789abcdef0123456789abcdef";
     if (!VHO_FHE_Convert_Program_Unit(pu, &tree, stderr, &result) ||
         result.semantic_gatekeeper_count != 2 ||
         result.conversion_pass_count != 1 || result.error_count != 0 ||
@@ -380,14 +397,51 @@ main(void)
         result.converted_disposition_count != 1 ||
         observed_count != 3 || observed_order[0] != 'G' ||
         observed_order[1] != 'C' || observed_order[2] != 'G' ||
-        !observed_strict_o0) {
+        !observed_strict_o0 ||
+        observed_calibration_manifest_path !=
+            VHO_FHE_Calibration_Manifest_Path ||
+        observed_calibration_manifest_sha256 !=
+            VHO_FHE_Calibration_Manifest_SHA256) {
         fprintf(stderr, "FHE gatekeeper/conversion ordering changed\n");
         return 1;
     }
+    VHO_FHE_CONVERT_RESULT valid_result = result;
+
+    VHO_FHE_Calibration_Manifest_SHA256 = NULL;
+    if (VHO_FHE_Convert_Program_Unit(pu, &tree, NULL, &result) ||
+        result.error_count != 1) {
+        fprintf(stderr, "unauthenticated FHE calibration was not rejected\n");
+        return 1;
+    }
+    VHO_FHE_Calibration_Manifest_SHA256 =
+        (char *)"abc";
+    if (VHO_FHE_Convert_Program_Unit(pu, &tree, NULL, &result) ||
+        result.error_count != 1) {
+        fprintf(stderr, "short FHE calibration digest was not rejected\n");
+        return 1;
+    }
+    VHO_FHE_Calibration_Manifest_SHA256 =
+        (char *)"ABCDEF0123456789ABCDEF0123456789"
+                "ABCDEF0123456789ABCDEF0123456789";
+    if (VHO_FHE_Convert_Program_Unit(pu, &tree, NULL, &result) ||
+        result.error_count != 1) {
+        fprintf(stderr, "uppercase FHE calibration digest was not rejected\n");
+        return 1;
+    }
+    VHO_FHE_Calibration_Manifest_SHA256 =
+        (char *)"0123456789abcdef0123456789abcdef"
+                "0123456789abcdef0123456789abcdeg";
+    if (VHO_FHE_Convert_Program_Unit(pu, &tree, NULL, &result) ||
+        result.error_count != 1) {
+        fprintf(stderr, "non-hex FHE calibration digest was not rejected\n");
+        return 1;
+    }
+    VHO_FHE_Calibration_Manifest_Path = NULL;
+    VHO_FHE_Calibration_Manifest_SHA256 = NULL;
 
     VHO_FHE_CONVERT_RESULT aggregate;
     VHO_FHE_Convert_Result_Init(&aggregate);
-    VHO_FHE_Convert_Result_Accumulate(&aggregate, &result);
+    VHO_FHE_Convert_Result_Accumulate(&aggregate, &valid_result);
     if (aggregate.semantic_gatekeeper_count != 2 ||
         aggregate.conversion_pass_count != 1 ||
         aggregate.source_disposition_count != 1 ||

--- a/osprey/common/com/config_fhe.cxx
+++ b/osprey/common/com/config_fhe.cxx
@@ -16,6 +16,8 @@ BOOL VHO_FHE_Dump_Before_Conversion_Set = FALSE;
 BOOL VHO_FHE_Dump_After_Conversion = FALSE;
 BOOL VHO_FHE_Dump_After_Conversion_Set = FALSE;
 char *VHO_FHE_Conversion_Checkpoint_Output = NULL;
+char *VHO_FHE_Calibration_Manifest_Path = NULL;
+char *VHO_FHE_Calibration_Manifest_SHA256 = NULL;
 
 static OPTION_DESC Options_FHE[] = {
   { OVK_BOOL, OV_VISIBLE, TRUE, "convert", "convert",
@@ -32,5 +34,11 @@ static OPTION_DESC Options_FHE[] = {
     &VHO_FHE_Dump_After_Conversion_Set },
   { OVK_NAME, OV_VISIBLE, FALSE, "checkpoint", "checkpoint",
     0, 0, 0, &VHO_FHE_Conversion_Checkpoint_Output, NULL },
+  { OVK_NAME, OV_VISIBLE, FALSE, "calibration_manifest",
+    "calibration_manifest",
+    0, 0, 0, &VHO_FHE_Calibration_Manifest_Path, NULL },
+  { OVK_NAME, OV_VISIBLE, FALSE, "calibration_sha256",
+    "calibration_sha256",
+    0, 0, 0, &VHO_FHE_Calibration_Manifest_SHA256, NULL },
   { OVK_COUNT }
 };

--- a/osprey/common/com/config_fhe.h
+++ b/osprey/common/com/config_fhe.h
@@ -14,5 +14,7 @@ extern BOOL VHO_FHE_Dump_Before_Conversion_Set;
 extern BOOL VHO_FHE_Dump_After_Conversion;
 extern BOOL VHO_FHE_Dump_After_Conversion_Set;
 extern char *VHO_FHE_Conversion_Checkpoint_Output;
+extern char *VHO_FHE_Calibration_Manifest_Path;
+extern char *VHO_FHE_Calibration_Manifest_SHA256;
 
 #endif /* config_fhe_INCLUDED */

--- a/osprey/common/com/tests/dsl_fhe_sync3_vho_driver_test.sh
+++ b/osprey/common/com/tests/dsl_fhe_sync3_vho_driver_test.sh
@@ -73,6 +73,12 @@ if ! grep -Fq '"checkpoint", "checkpoint"' "$config_source"; then
   echo "missing -FHE:checkpoint option in $config_source" >&2
   exit 1
 fi
+for option in calibration_manifest calibration_sha256; do
+  if ! grep -Fq "\"$option\"" "$config_source"; then
+    echo "missing -FHE:$option option in $config_source" >&2
+    exit 1
+  fi
+done
 
 echo "FHE SYNC-3 VHO conversion phase fixture passed"
 echo "review trace: $trace"


### PR DESCRIPTION
## Summary

Adds an authenticated runtime transport for an approved FHE ReLU calibration
manifest. The backend now passes a manifest path and expected SHA-256 to every
FHE semantic gatekeeper and conversion callback.

## Contract

- Adds `-FHE:calibration_manifest=<path>`.
- Adds `-FHE:calibration_sha256=<digest>`.
- Requires both options together for FHE-bearing conversion.
- Requires exactly 64 lowercase hexadecimal SHA-256 characters.
- Rejects incomplete or malformed authentication before the semantic gate.
- Keeps ordinary non-FHE WHIRL behavior unchanged.
- Leaves manifest reading, exact-byte hashing, canonical-content validation,
  19-context coverage, and range binding under the registered FHE pass.

This is runtime phase state only. It changes no WHIRL table, ELF section,
opcode, type identity, or mapped-image contract.

## Validation

- Focused linked `fhe_convert_contract_test` passed.
- Missing, short, uppercase, and non-hex digest negatives passed.
- Retained FHE VHO phase fixture passed.
- Full DSL native syntax test passed.
- x86-64, MIPS, MIPS-SL, KEY, Loongson, and baseline layout checks passed.
- FHE consumer review accepted the pointer lifetime and all-PU finalizer model.
- `git diff --check` and the no-tab scan passed.

## Coordination

This PR supplies the transport required by the FHE collector commit
`baf8df71`. The collector remains separate and should rebase after this
infrastructure PR merges.
