### PR TITLE
Expose bundled RapidJSON to backend FHE builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,25 @@ only when the current task needs detail.
    identity. Continue using WOPT's existing `CODEREP` instantiation of
    `wn_simp_code.h`; do not add a parallel WOPT simplifier.
 
+## Backend Shared-Library Dependencies
+
+1. Do not add a new library dependency to `be.so` without explicit design and
+   build approval. This includes direct linkage and source-level references
+   that create new defined or undefined symbols in the shared library.
+2. Before approving a dependency, identify every consumer of `be.so`, including
+   `lw_inline`, backend plugins, and standalone tools, and prove that each
+   consumer remains link-closed on every supported build configuration.
+3. Prefer an existing Open64 service or an already compatible header-only
+   facility when structured parsing or another utility is needed in a backend
+   pass. Do not introduce ad hoc parsing to avoid the dependency review.
+4. Validation for an approved dependency change must rebuild `be.so` and its
+   shared consumers, inspect their defined and undefined symbols, and document
+   platform, static/shared, licensing, version, and binary-distribution impact.
+5. Frontend-only libraries and interfaces, including `DSL_Builder_*`, must not
+   leak into `be.so`. For example, an FHE backend may parse an authenticated
+   JSON manifest with the repository's compatible header-only RapidJSON
+   facility, but must not add JsonCpp linkage to `be.so` without approval.
+
 ## Coding Guidelines
 
 1. Do not introduce tab characters in any file touched in this Open64 project.

--- a/osprey/be/be/Makefile.gbase
+++ b/osprey/be/be/Makefile.gbase
@@ -254,6 +254,7 @@ HEADER_DIRS += $(TARGDIR)/include/libelf
 endif
 
 HEADER_DIRS += $(BUILD_TOT)/include/gnu
+HEADER_DIRS += $(BUILD_TOT)
 
 #----------------------------------------------------------------------
 # Build derived files

--- a/osprey/common/com/tests/dsl_native_syntax_test.sh
+++ b/osprey/common/com/tests/dsl_native_syntax_test.sh
@@ -37,6 +37,7 @@ cxxflags=(
   -I"$repo_root/osprey/common/util"
   -I"$repo_root/osprey/include"
   -I"$repo_root/osprey/libdwarf/libdwarf"
+  -I"$repo_root/osprey"
   -I"$repo_root/osprey/torch2whirl/python/native"
 )
 

--- a/osprey/ir_tools/Makefile.gbase
+++ b/osprey/ir_tools/Makefile.gbase
@@ -166,6 +166,7 @@ LDIRT += opt_dsl_wopt_test.o opt_dsl_semantic_wopt_test.o
 LCINCS = -I$(BUILD_BASE) -I$(COMMON_COM_DIR) -I$(COMMON_COM_TARG_DIR) \
 	-I$(COMMON_UTIL_DIR) -I$(BE_COM_DIR) -I$(BE_VHO_DIR) -I$(BE_OPT_DIR) $(XINC)  \
         -I$(BUILD_TOT)/include
+LCINCS += -I$(BUILD_TOT)
 ifeq ($(BUILD_OS), LINUX)
 LCINCS += -I$(BUILD_AREA)/include/libelf -I$(BUILD_TOT)/libjson/include
 endif


### PR DESCRIPTION
## Summary

Exposes Open64's bundled header-only RapidJSON tree to the targets that compile
the FHE semantic conversion pass. This closes the authenticated calibration
manifest parser's build boundary without adding JsonCpp or any other linked
library to `be.so`.

The change also records the general backend shared-library dependency rule in
`AGENTS.md`.

## Changes

- Add `$(BUILD_TOT)` to the `ir_tools` include search path.
- Add `$(BUILD_TOT)` to the `be`/`be.so` header directories.
- Add the equivalent repository path to the DSL native syntax fixture.
- Require explicit review before introducing new `be.so` dependencies and
  require validation of `lw_inline`, plugins, tools, and symbol closure.

## Validation

- Linked `fhe_semantic_convert_test` rebuilt and passed.
- `ir_b2a` rebuilt successfully.
- `be.so` and `be` rebuilt successfully.
- Forced `lw_inline` rebuild and link passed.
- `be.so` and `lw_inline` contain zero `Json::` and zero `DSL_Builder_*`
  defined or undefined symbols.
- Full DSL native syntax test passed.
- x86-64, MIPS, MIPS-SL, KEY, Loongson, and baseline layout matrix passed.
- `git diff --check` and no-tab checks passed.

## Compatibility

No linked library, runtime dependency, WHIRL image, opcode, type, or ELF
contract changes.
